### PR TITLE
ci: fix ambiguous 'master' tag creation by using 'nightly' for rolling releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,7 +204,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref == 'refs/heads/master' && 'nightly' || github.ref_name }}
+          prerelease: ${{ github.ref == 'refs/heads/master' }}
           files: artifacts/app-*/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 🐛 Problem
The current CI workflow triggers a release on every push to the `master` branch and uses `${{ github.ref_name }}` as the tag name. Since `ref_name` resolves to `"master"`, this creates a git tag named `master` on the repository.

This causes a naming conflict for developers during local git operations (like rebase or checkout), resulting in persistent warnings:
```bash
warning: refname 'master' is ambiguous.
```

### 🛠️ Solution
* Updated the release job in .github/workflows/main.yml.
* Condition changed: When the release is triggered from the master branch, the tag used is now forced to nightly instead of the branch name.
* Prerelease: explicitly marked as prerelease: true for these nightly builds.

Regular version tags (e.g., v1.0) are unaffected and will continue to use their respective tag names.