### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in shader loading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-01 - [DoS] Unbounded File Read in Shader Loading
+**Vulnerability:** `load_file_into_ram` in `src/shader.c` did not enforce `MAX_SHADER_SOURCE_SIZE` (16MB), allowing arbitrary allocation size based on file size, leading to potential DoS via OOM.
+**Learning:** Even when limits are defined (`MAX_SHADER_SOURCE_SIZE` existed as an enum), they must be explicitly enforced in the code. The constant was previously unused.
+**Prevention:** Always validate input sizes against defined limits before allocation. Ensure defined constants are actually used in logic.

--- a/src/shader.c
+++ b/src/shader.c
@@ -96,6 +96,15 @@ static char* load_file_into_ram(const char* path)
 		return NULL;
 	}
 
+	/* Check against MAX_SHADER_SOURCE_SIZE to prevent DoS */
+	if (len > MAX_SHADER_SOURCE_SIZE) {
+		LOG_ERROR("suckless-ogl.shader",
+		          "File too large: %s (%ld > %d)", path, len,
+		          MAX_SHADER_SOURCE_SIZE);
+		RAII_SATISFY_FILE(file_ptr);
+		return NULL;
+	}
+
 	size_t size = (size_t)len;
 	CLEANUP_FREE char* buf = safe_calloc(size + 1, 1);
 	if (!buf) {

--- a/tests/test_shader_security.c
+++ b/tests/test_shader_security.c
@@ -1,0 +1,60 @@
+#include "shader.h"
+#include "unity.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* MAX_SHADER_SOURCE_SIZE is defined as 16 * 1024 * 1024 in src/shader.c */
+#define MAX_SIZE (16 * 1024 * 1024)
+
+static void create_large_file(const char* filename, size_t size) {
+    FILE* f = fopen(filename, "wb");
+    if (!f) {
+        TEST_FAIL_MESSAGE("Failed to create test file");
+    }
+
+    /* Write one byte at the end to set size */
+    if (fseek(f, (long)(size - 1), SEEK_SET) != 0) {
+        fclose(f);
+        TEST_FAIL_MESSAGE("Failed to seek in test file");
+    }
+    if (fputc('A', f) == EOF) {
+        fclose(f);
+        TEST_FAIL_MESSAGE("Failed to write to test file");
+    }
+    fclose(f);
+}
+
+void test_shader_read_too_large(void) {
+    const char* filename = "too_large.glsl";
+    create_large_file(filename, MAX_SIZE + 1);
+
+    char* result = shader_read_file(filename);
+    /* Expect NULL because we want to enforce the limit */
+    TEST_ASSERT_NULL_MESSAGE(result, "Should fail for files larger than MAX_SHADER_SOURCE_SIZE");
+
+    remove(filename);
+    if (result) free(result);
+}
+
+void test_shader_read_limit(void) {
+    const char* filename = "limit.glsl";
+    create_large_file(filename, MAX_SIZE);
+
+    char* result = shader_read_file(filename);
+    /* Expect non-NULL because it's within limit */
+    TEST_ASSERT_NOT_NULL_MESSAGE(result, "Should succeed for files equal to MAX_SHADER_SOURCE_SIZE");
+
+    remove(filename);
+    free(result);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_shader_read_too_large);
+    RUN_TEST(test_shader_read_limit);
+    return UNITY_END();
+}

--- a/tests/test_shader_security.c
+++ b/tests/test_shader_security.c
@@ -4,57 +4,68 @@
 #include <stdlib.h>
 #include <string.h>
 
-void setUp(void) {}
-void tearDown(void) {}
+void setUp(void)
+{
+}
+void tearDown(void)
+{
+}
 
 /* MAX_SHADER_SOURCE_SIZE is defined as 16 * 1024 * 1024 in src/shader.c */
 #define MAX_SIZE (16 * 1024 * 1024)
 
-static void create_large_file(const char* filename, size_t size) {
-    FILE* f = fopen(filename, "wb");
-    if (!f) {
-        TEST_FAIL_MESSAGE("Failed to create test file");
-    }
+static void create_large_file(const char* filename, size_t size)
+{
+	FILE* f = fopen(filename, "wb");
+	if (!f) {
+		TEST_FAIL_MESSAGE("Failed to create test file");
+	}
 
-    /* Write one byte at the end to set size */
-    if (fseek(f, (long)(size - 1), SEEK_SET) != 0) {
-        fclose(f);
-        TEST_FAIL_MESSAGE("Failed to seek in test file");
-    }
-    if (fputc('A', f) == EOF) {
-        fclose(f);
-        TEST_FAIL_MESSAGE("Failed to write to test file");
-    }
-    fclose(f);
+	/* Write one byte at the end to set size */
+	if (fseek(f, (long)(size - 1), SEEK_SET) != 0) {
+		fclose(f);
+		TEST_FAIL_MESSAGE("Failed to seek in test file");
+	}
+	if (fputc('A', f) == EOF) {
+		fclose(f);
+		TEST_FAIL_MESSAGE("Failed to write to test file");
+	}
+	fclose(f);
 }
 
-void test_shader_read_too_large(void) {
-    const char* filename = "too_large.glsl";
-    create_large_file(filename, MAX_SIZE + 1);
+void test_shader_read_too_large(void)
+{
+	const char* filename = "too_large.glsl";
+	create_large_file(filename, MAX_SIZE + 1);
 
-    char* result = shader_read_file(filename);
-    /* Expect NULL because we want to enforce the limit */
-    TEST_ASSERT_NULL_MESSAGE(result, "Should fail for files larger than MAX_SHADER_SOURCE_SIZE");
+	char* result = shader_read_file(filename);
+	/* Expect NULL because we want to enforce the limit */
+	TEST_ASSERT_NULL_MESSAGE(
+	    result, "Should fail for files larger than MAX_SHADER_SOURCE_SIZE");
 
-    remove(filename);
-    if (result) free(result);
+	remove(filename);
+	if (result)
+		free(result);
 }
 
-void test_shader_read_limit(void) {
-    const char* filename = "limit.glsl";
-    create_large_file(filename, MAX_SIZE);
+void test_shader_read_limit(void)
+{
+	const char* filename = "limit.glsl";
+	create_large_file(filename, MAX_SIZE);
 
-    char* result = shader_read_file(filename);
-    /* Expect non-NULL because it's within limit */
-    TEST_ASSERT_NOT_NULL_MESSAGE(result, "Should succeed for files equal to MAX_SHADER_SOURCE_SIZE");
+	char* result = shader_read_file(filename);
+	/* Expect non-NULL because it's within limit */
+	TEST_ASSERT_NOT_NULL_MESSAGE(
+	    result, "Should succeed for files equal to MAX_SHADER_SOURCE_SIZE");
 
-    remove(filename);
-    free(result);
+	remove(filename);
+	free(result);
 }
 
-int main(void) {
-    UNITY_BEGIN();
-    RUN_TEST(test_shader_read_too_large);
-    RUN_TEST(test_shader_read_limit);
-    return UNITY_END();
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_shader_read_too_large);
+	RUN_TEST(test_shader_read_limit);
+	return UNITY_END();
 }


### PR DESCRIPTION
This PR fixes a potential Denial of Service (DoS) vulnerability in the shader loading mechanism.

### Vulnerability Details
The `load_file_into_ram` function reads a file's size and allocates a buffer to hold its content. Previously, this size was not validated against the existing `MAX_SHADER_SOURCE_SIZE` constant (16MB). This meant that a sufficiently large file (provided maliciously or accidentally) could cause the application to attempt an excessive memory allocation, leading to a crash.

### Resolution
I have added a check to ensure `len <= MAX_SHADER_SOURCE_SIZE`. If the file is too large, an error is logged, the file is closed, and `NULL` is returned, preventing the dangerous allocation.

### Verification
A new test file `tests/test_shader_security.c` was added.
1. `test_shader_read_too_large`: Creates a 16MB+1byte file and asserts that `shader_read_file` returns `NULL`.
2. `test_shader_read_limit`: Creates a 16MB file and asserts that it loads successfully.

Ran `ctest` and confirmed all 24 tests passed.

---
*PR created automatically by Jules for task [9505068950064440160](https://jules.google.com/task/9505068950064440160) started by @yoyonel*