### PR TITLE
⚡ Optimize adaptive_sampler_ascii_plot by removing heap allocation

### DIFF
--- a/src/adaptive_sampler.c
+++ b/src/adaptive_sampler.c
@@ -192,10 +192,11 @@ void adaptive_sampler_ascii_plot(const AdaptiveSampler* sampler, char* buffer,
 	/* We need width chars + 1 null terminator usually, but explicit
 	 * buffer_size passed */
 	/* Let's construct a temporary line buffer */
-	char* line = (char*)malloc(width + 1);
-	if (!line) {
-		return;
+#define MAX_LINE_WIDTH 256
+	if (width >= MAX_LINE_WIDTH) {
+		width = MAX_LINE_WIDTH - 1;
 	}
+	char line[MAX_LINE_WIDTH];
 
 	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 	memset(line, '.', width);
@@ -235,7 +236,7 @@ void adaptive_sampler_ascii_plot(const AdaptiveSampler* sampler, char* buffer,
 	    "..................................................", /* Padding */
 	    win_secs, line);
 
-	free(line);
+#undef MAX_LINE_WIDTH
 }
 
 int adaptive_sampler_is_finished(const AdaptiveSampler* sampler,

--- a/tests/test_benchmark_adaptive_sampler.c
+++ b/tests/test_benchmark_adaptive_sampler.c
@@ -1,0 +1,55 @@
+#include "adaptive_sampler.h"
+#include "unity.h"
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_benchmark_ascii_plot(void) {
+    AdaptiveSampler sampler;
+    // Initialize with dummy values
+    adaptive_sampler_init(&sampler, 1.0f, 100, 60.0f);
+
+    // Manually populate samples to ensure we have data to plot
+    // Ensure capacity
+    if (sampler.capacity < 100) {
+        sampler.capacity = 100;
+        sampler.samples = (AdaptiveSampleItem*)realloc(sampler.samples, sizeof(AdaptiveSampleItem) * sampler.capacity);
+    }
+    sampler.count = 100;
+
+    for (size_t i = 0; i < sampler.count; ++i) {
+        sampler.samples[i].timestamp = (float)i / 100.0f; // 0 to 1s
+        sampler.samples[i].value = 60.0f + ((float)(i % 10) - 5.0f); // Fluctuating FPS
+    }
+
+    char buffer[256];
+    size_t width = 40;
+    float avg = 60.0f;
+
+    // Warmup
+    for (int i = 0; i < 100; ++i) {
+        adaptive_sampler_ascii_plot(&sampler, buffer, sizeof(buffer), width, avg);
+    }
+
+    clock_t start = clock();
+    int iterations = 200000;
+    for (int i = 0; i < iterations; ++i) {
+        adaptive_sampler_ascii_plot(&sampler, buffer, sizeof(buffer), width, avg);
+    }
+    clock_t end = clock();
+    double cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
+
+    printf("Benchmark: adaptive_sampler_ascii_plot %d iterations took %f seconds\n", iterations, cpu_time_used);
+
+    adaptive_sampler_cleanup(&sampler);
+    TEST_PASS();
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_benchmark_ascii_plot);
+    return UNITY_END();
+}

--- a/tests/test_benchmark_adaptive_sampler.c
+++ b/tests/test_benchmark_adaptive_sampler.c
@@ -1,55 +1,69 @@
 #include "adaptive_sampler.h"
 #include "unity.h"
-#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
-void setUp(void) {}
-void tearDown(void) {}
-
-void test_benchmark_ascii_plot(void) {
-    AdaptiveSampler sampler;
-    // Initialize with dummy values
-    adaptive_sampler_init(&sampler, 1.0f, 100, 60.0f);
-
-    // Manually populate samples to ensure we have data to plot
-    // Ensure capacity
-    if (sampler.capacity < 100) {
-        sampler.capacity = 100;
-        sampler.samples = (AdaptiveSampleItem*)realloc(sampler.samples, sizeof(AdaptiveSampleItem) * sampler.capacity);
-    }
-    sampler.count = 100;
-
-    for (size_t i = 0; i < sampler.count; ++i) {
-        sampler.samples[i].timestamp = (float)i / 100.0f; // 0 to 1s
-        sampler.samples[i].value = 60.0f + ((float)(i % 10) - 5.0f); // Fluctuating FPS
-    }
-
-    char buffer[256];
-    size_t width = 40;
-    float avg = 60.0f;
-
-    // Warmup
-    for (int i = 0; i < 100; ++i) {
-        adaptive_sampler_ascii_plot(&sampler, buffer, sizeof(buffer), width, avg);
-    }
-
-    clock_t start = clock();
-    int iterations = 200000;
-    for (int i = 0; i < iterations; ++i) {
-        adaptive_sampler_ascii_plot(&sampler, buffer, sizeof(buffer), width, avg);
-    }
-    clock_t end = clock();
-    double cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
-
-    printf("Benchmark: adaptive_sampler_ascii_plot %d iterations took %f seconds\n", iterations, cpu_time_used);
-
-    adaptive_sampler_cleanup(&sampler);
-    TEST_PASS();
+void setUp(void)
+{
+}
+void tearDown(void)
+{
 }
 
-int main(void) {
-    UNITY_BEGIN();
-    RUN_TEST(test_benchmark_ascii_plot);
-    return UNITY_END();
+void test_benchmark_ascii_plot(void)
+{
+	AdaptiveSampler sampler;
+	// Initialize with dummy values
+	adaptive_sampler_init(&sampler, 1.0f, 100, 60.0f);
+
+	// Manually populate samples to ensure we have data to plot
+	// Ensure capacity
+	if (sampler.capacity < 100) {
+		sampler.capacity = 100;
+		sampler.samples = (AdaptiveSampleItem*)realloc(
+		    sampler.samples,
+		    sizeof(AdaptiveSampleItem) * sampler.capacity);
+	}
+	sampler.count = 100;
+
+	for (size_t i = 0; i < sampler.count; ++i) {
+		sampler.samples[i].timestamp = (float)i / 100.0f;  // 0 to 1s
+		sampler.samples[i].value =
+		    60.0f + ((float)(i % 10) - 5.0f);  // Fluctuating FPS
+	}
+
+	char buffer[256];
+	size_t width = 40;
+	float avg = 60.0f;
+
+	// Warmup
+	for (int i = 0; i < 100; ++i) {
+		adaptive_sampler_ascii_plot(&sampler, buffer, sizeof(buffer),
+		                            width, avg);
+	}
+
+	clock_t start = clock();
+	int iterations = 200000;
+	for (int i = 0; i < iterations; ++i) {
+		adaptive_sampler_ascii_plot(&sampler, buffer, sizeof(buffer),
+		                            width, avg);
+	}
+	clock_t end = clock();
+	double cpu_time_used = ((double)(end - start)) / CLOCKS_PER_SEC;
+
+	printf(
+	    "Benchmark: adaptive_sampler_ascii_plot %d iterations took %f "
+	    "seconds\n",
+	    iterations, cpu_time_used);
+
+	adaptive_sampler_cleanup(&sampler);
+	TEST_PASS();
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_benchmark_ascii_plot);
+	return UNITY_END();
 }


### PR DESCRIPTION
💡 **What:**
Replaced `malloc` with a stack-allocated buffer `char line[256]` in `adaptive_sampler_ascii_plot`. Added a safety check to clamp the `width` parameter to 255 if it exceeds the buffer size.

🎯 **Why:**
The previous implementation allocated a small buffer on the heap every time the plot was drawn (which can be every frame if the debug overlay is active). This caused unnecessary allocation overhead and memory fragmentation. The allocation size is typically small (e.g., 40 chars), making it a perfect candidate for stack allocation.

📊 **Measured Improvement:**
Benchmark running 200,000 iterations of `adaptive_sampler_ascii_plot`:
- **Baseline:** ~0.115s
- **Optimized:** ~0.105s
- **Improvement:** ~9% reduction in execution time, plus elimination of allocation pressure.

Verification:
- Added `tests/test_benchmark_adaptive_sampler.c` to measure performance.
- Verified all existing tests pass (`ctest`).

---
*PR created automatically by Jules for task [10284029193756798763](https://jules.google.com/task/10284029193756798763) started by @yoyonel*