### PR TITLE
Refactor skybox detection to use stencil buffer

### DIFF
--- a/include/app_settings.h
+++ b/include/app_settings.h
@@ -41,6 +41,11 @@
 enum { DEFAULT_SAMPLES = 1 };
 
 /**
+ * @brief Value for all bits enabled in a stencil mask.
+ */
+static const unsigned int DEFAULT_STENCIL_MASK = 0xFF;
+
+/**
  * @brief Enable High Quality Transparent Sphere Rendering.
  *
  * **If Defined**:

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -236,7 +236,7 @@ typedef struct {
  */
 typedef struct PostProcess {
 	/* FBO principal et textures */
-	GLuint scene_fbo;       /**< Main HDR framebuffer. */
+	GLuint scene_fbo;          /**< Main HDR framebuffer. */
 	GLuint scene_color_tex;    /**< RGBA16F HDR texture. */
 	GLuint velocity_tex;       /**< RG16F Motion vector texture. */
 	GLuint scene_depth_tex;    /**< D32F Depth texture. */

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -237,9 +237,10 @@ typedef struct {
 typedef struct PostProcess {
 	/* FBO principal et textures */
 	GLuint scene_fbo;       /**< Main HDR framebuffer. */
-	GLuint scene_color_tex; /**< RGBA16F HDR texture. */
-	GLuint velocity_tex;    /**< RG16F Motion vector texture. */
-	GLuint scene_depth_tex; /**< D32F Depth texture. */
+	GLuint scene_color_tex;    /**< RGBA16F HDR texture. */
+	GLuint velocity_tex;       /**< RG16F Motion vector texture. */
+	GLuint scene_depth_tex;    /**< D32F Depth texture. */
+	GLuint scene_stencil_view; /**< Stencil view of depth texture. */
 
 	/* Module Resources */
 	BloomFX bloom_fx;                /**< Bloom subsystem. */

--- a/shaders/postprocess.frag
+++ b/shaders/postprocess.frag
@@ -6,6 +6,7 @@ in vec2 TexCoords;
 
 uniform sampler2D screenTexture;
 uniform sampler2D depthTexture;
+uniform usampler2D stencilTexture;
 
 /* Includes for Post-Process Effects */
 @header "postprocess/ubo.glsl";
@@ -37,9 +38,9 @@ void main()
 
 	vec3 color;
 
-	/* Skybox Hack: Depth ~ 1.0 */
-	float depth = texture(depthTexture, TexCoords).r;
-	bool isSkybox = depth >= 0.99999;
+	/* Stencil Check: 0 = Skybox/Background, 1 = Object */
+	uint stencil = texture(stencilTexture, TexCoords).r;
+	bool isSkybox = (stencil == 0u);
 
 	// --------------------------------------------------------------------------------
 	// FIXME: ça semble casser les performances de rajouter un if else pour

--- a/src/app.c
+++ b/src/app.c
@@ -385,6 +385,12 @@ void app_render(App* app)
 	}
 
 	glPolygonMode(GL_FRONT_AND_BACK, app->wireframe ? GL_LINE : GL_FILL);
+
+	glEnable(GL_STENCIL_TEST);
+	glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+	glStencilFunc(GL_ALWAYS, 1, 0xFF);
+	glStencilMask(0xFF);
+
 	if (app->billboard_mode) {
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -393,14 +399,26 @@ void app_render(App* app)
 	} else {
 		app_render_instanced(app, view, proj, camera_pos);
 	}
+
+	glDisable(GL_STENCIL_TEST);
+
 	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 #else
 	glPolygonMode(GL_FRONT_AND_BACK, app->wireframe ? GL_LINE : GL_FILL);
+
+	glEnable(GL_STENCIL_TEST);
+	glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+	glStencilFunc(GL_ALWAYS, 1, 0xFF);
+	glStencilMask(0xFF);
+
 	if (app->billboard_mode) {
 		app_render_billboards(app, view, proj, camera_pos);
 	} else {
 		app_render_instanced(app, view, proj, camera_pos);
 	}
+
+	glDisable(GL_STENCIL_TEST);
+
 	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
 	if (app->show_envmap) {

--- a/src/app.c
+++ b/src/app.c
@@ -388,8 +388,8 @@ void app_render(App* app)
 
 	glEnable(GL_STENCIL_TEST);
 	glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
-	glStencilFunc(GL_ALWAYS, 1, 0xFF);
-	glStencilMask(0xFF);
+	glStencilFunc(GL_ALWAYS, 1, DEFAULT_STENCIL_MASK);
+	glStencilMask(DEFAULT_STENCIL_MASK);
 
 	if (app->billboard_mode) {
 		glEnable(GL_BLEND);
@@ -408,8 +408,8 @@ void app_render(App* app)
 
 	glEnable(GL_STENCIL_TEST);
 	glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
-	glStencilFunc(GL_ALWAYS, 1, 0xFF);
-	glStencilMask(0xFF);
+	glStencilFunc(GL_ALWAYS, 1, DEFAULT_STENCIL_MASK);
+	glStencilMask(DEFAULT_STENCIL_MASK);
 
 	if (app->billboard_mode) {
 		app_render_billboards(app, view, proj, camera_pos);

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -24,7 +24,8 @@ enum {
 	POSTPROCESS_TEX_UNIT_EXPOSURE = 3,
 	POSTPROCESS_TEX_UNIT_VELOCITY = 4,
 	POSTPROCESS_TEX_UNIT_NEIGHBOR_MAX = 5,
-	POSTPROCESS_TEX_UNIT_DOF_BLUR = 6
+	POSTPROCESS_TEX_UNIT_DOF_BLUR = 6,
+	POSTPROCESS_TEX_UNIT_STENCIL = 7
 };
 
 /* Compute Shader Constants */
@@ -394,8 +395,10 @@ void postprocess_begin(PostProcess* post_processing)
 {
 	/* Rendre dans notre framebuffer */
 	glBindFramebuffer(GL_FRAMEBUFFER, post_processing->scene_fbo);
+	glClearStencil(0);
 	glClear((GLbitfield)GL_COLOR_BUFFER_BIT |
-	        (GLbitfield)GL_DEPTH_BUFFER_BIT);
+	        (GLbitfield)GL_DEPTH_BUFFER_BIT |
+	        (GLbitfield)GL_STENCIL_BUFFER_BIT);
 }
 
 void postprocess_end(PostProcess* post_processing)
@@ -503,6 +506,12 @@ void postprocess_end(PostProcess* post_processing)
 		shader_set_int(post_processing->postprocess_shader,
 		               "dofBlurTexture", POSTPROCESS_TEX_UNIT_DOF_BLUR);
 	}
+
+	/* Bind Stencil Texture View (Unit 7) */
+	glActiveTexture(GL_TEXTURE0 + POSTPROCESS_TEX_UNIT_STENCIL);
+	glBindTexture(GL_TEXTURE_2D, post_processing->scene_stencil_view);
+	shader_set_int(post_processing->postprocess_shader, "stencilTexture",
+	               POSTPROCESS_TEX_UNIT_STENCIL);
 
 	/* Upload settings via UBO */
 	PostProcessUBO ubo = {0};
@@ -626,22 +635,36 @@ static int create_framebuffer(PostProcess* post_processing)
 	GLenum drawBuffers[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
 	glDrawBuffers(2, drawBuffers);
 
-	/* Créer la texture de profondeur (D32F pour précision max) */
+	/* Créer la texture de profondeur (D32F_S8 pour précision max + stencil) */
 	glGenTextures(1, &post_processing->scene_depth_tex);
 	glBindTexture(GL_TEXTURE_2D, post_processing->scene_depth_tex);
 	glObjectLabel(GL_TEXTURE, post_processing->scene_depth_tex, -1,
-	              "Scene Depth (D32F)");
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32F,
-	             post_processing->width, post_processing->height, 0,
-	             GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+	              "Scene Depth (D32F_S8)");
+	/* glTextureView requires immutable storage */
+	glTexStorage2D(GL_TEXTURE_2D, 1, GL_DEPTH32F_STENCIL8,
+	               post_processing->width, post_processing->height);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
 	                       GL_TEXTURE_2D, post_processing->scene_depth_tex,
 	                       0);
+
+	/* Créer une vue Texture View pour accéder au Stencil uniquement */
+	glGenTextures(1, &post_processing->scene_stencil_view);
+	/* Utiliser le même format compatible (class 64-bit/32F_S8) mais changer le mode de lecture */
+	glTextureView(post_processing->scene_stencil_view, GL_TEXTURE_2D,
+	              post_processing->scene_depth_tex, GL_DEPTH32F_STENCIL8, 0, 1,
+	              0, 1);
+	glObjectLabel(GL_TEXTURE, post_processing->scene_stencil_view, -1,
+	              "Scene Stencil View");
+	glBindTexture(GL_TEXTURE_2D, post_processing->scene_stencil_view);
+	/* Mode Stencil Index: Permet de lire le canal Stencil (uint) via usampler2D */
+	glTexParameteri(GL_TEXTURE_2D, GL_DEPTH_STENCIL_TEXTURE_MODE, GL_STENCIL_INDEX);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
 	return render_utils_check_framebuffer("PostProcess Scene FBO");
 }
@@ -659,6 +682,10 @@ static void destroy_framebuffer(PostProcess* post_processing)
 	if (post_processing->scene_depth_tex) {
 		glDeleteTextures(1, &post_processing->scene_depth_tex);
 		post_processing->scene_depth_tex = 0;
+	}
+	if (post_processing->scene_stencil_view) {
+		glDeleteTextures(1, &post_processing->scene_stencil_view);
+		post_processing->scene_stencil_view = 0;
 	}
 	if (post_processing->velocity_tex) {
 		glDeleteTextures(1, &post_processing->velocity_tex);

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -635,7 +635,8 @@ static int create_framebuffer(PostProcess* post_processing)
 	GLenum drawBuffers[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
 	glDrawBuffers(2, drawBuffers);
 
-	/* Créer la texture de profondeur (D32F_S8 pour précision max + stencil) */
+	/* Créer la texture de profondeur (D32F_S8 pour précision max + stencil)
+	 */
 	glGenTextures(1, &post_processing->scene_depth_tex);
 	glBindTexture(GL_TEXTURE_2D, post_processing->scene_depth_tex);
 	glObjectLabel(GL_TEXTURE, post_processing->scene_depth_tex, -1,
@@ -654,15 +655,18 @@ static int create_framebuffer(PostProcess* post_processing)
 
 	/* Créer une vue Texture View pour accéder au Stencil uniquement */
 	glGenTextures(1, &post_processing->scene_stencil_view);
-	/* Utiliser le même format compatible (class 64-bit/32F_S8) mais changer le mode de lecture */
+	/* Utiliser le même format compatible (class 64-bit/32F_S8) mais changer
+	 * le mode de lecture */
 	glTextureView(post_processing->scene_stencil_view, GL_TEXTURE_2D,
-	              post_processing->scene_depth_tex, GL_DEPTH32F_STENCIL8, 0, 1,
-	              0, 1);
+	              post_processing->scene_depth_tex, GL_DEPTH32F_STENCIL8, 0,
+	              1, 0, 1);
 	glObjectLabel(GL_TEXTURE, post_processing->scene_stencil_view, -1,
 	              "Scene Stencil View");
 	glBindTexture(GL_TEXTURE_2D, post_processing->scene_stencil_view);
-	/* Mode Stencil Index: Permet de lire le canal Stencil (uint) via usampler2D */
-	glTexParameteri(GL_TEXTURE_2D, GL_DEPTH_STENCIL_TEXTURE_MODE, GL_STENCIL_INDEX);
+	/* Mode Stencil Index: Permet de lire le canal Stencil (uint) via
+	 * usampler2D */
+	glTexParameteri(GL_TEXTURE_2D, GL_DEPTH_STENCIL_TEXTURE_MODE,
+	                GL_STENCIL_INDEX);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 


### PR DESCRIPTION
Replaced the hacky depth-based skybox detection with a robust stencil buffer implementation.

1.  **Framebuffer Update**: Changed the scene depth texture format from `GL_DEPTH_COMPONENT32F` to `GL_DEPTH32F_STENCIL8`. This preserves the high-precision depth required by the engine while adding an 8-bit stencil channel.
2.  **Texture View**: Implemented `glTextureView` to create a view of the depth-stencil texture that allows sampling the stencil component as an unsigned integer (`usampler2D`). Crucially, switched to `glTexStorage2D` (immutable storage) for the depth texture creation, as required by `glTextureView`.
3.  **Rendering Logic**: Updated `app_render` in `src/app.c` to:
    *   Enable stencil testing and write `1` to the stencil buffer during the object rendering pass (instanced meshes and billboards).
    *   Leave the stencil buffer at `0` (the clear value) for pixels where no object is drawn (i.e., the skybox/background).
4.  **Shader Update**: Modified `shaders/postprocess.frag` to accept a `uniform usampler2D stencilTexture`. The `isSkybox` check now simply reads the stencil value: if it's `0`, it's the skybox.

This eliminates the brittle `depth >= 0.99999` check and provides a reliable mask for post-processing effects that need to distinguish between scene geometry and the background (e.g., chromatic aberration).

---
*PR created automatically by Jules for task [5818017055435589721](https://jules.google.com/task/5818017055435589721) started by @yoyonel*