### PR TITLE
Sync FXAA implementation with PostProcess UBO

### DIFF
--- a/docs/postprocess_ubo_architecture.md
+++ b/docs/postprocess_ubo_architecture.md
@@ -76,7 +76,13 @@ typedef struct {
     float vignette_roundness;
     float _pad1;             // 4 bytes
 
-    // ... subsequent effects
+    // ... (Grain, Exposure, etc.)
+
+    /* FXAA (16 bytes) */
+    float fxaa_quality_subpix;
+    float fxaa_quality_edge_threshold;
+    float fxaa_quality_edge_threshold_min;
+    float _pad10;
 } PostProcessUBO;
 ```
 
@@ -98,7 +104,13 @@ layout(std140, binding = 0) uniform PostProcessBlock {
     float v_roundness;
     float _pad1;
 
-    // ... subsequent effects
+    // ... (Grain, Exposure, etc.)
+
+    /* FXAA */
+    float fxaaQualitySubpix;
+    float fxaaQualityEdgeThreshold;
+    float fxaaQualityEdgeThresholdMin;
+    float _pad10;
 };
 ```
 

--- a/docs/postprocess_ubo_architecture.md
+++ b/docs/postprocess_ubo_architecture.md
@@ -5,7 +5,7 @@ This document details the implementation of the **Uniform Buffer Object (UBO)** 
 
 ## 1. Overview
 
-Instead of sending dozens of uniforms (floats, integers) one by one every frame, we bundle all configuration data (Vignette, Bloom, Exposure, etc.) into a single contiguous memory structure.
+Instead of sending dozens of uniforms (floats, integers) one by one every frame, we bundle all configuration data (Vignette, Bloom, Exposure, FXAA, etc.) into a single contiguous memory structure.
 
 -   **C Side**: `struct PostProcessUBO` (file `include/postprocess.h`)
 -   **GPU Side**: `program Block` with `std140` layout (file `shaders/postprocess/ubo.glsl`)

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -35,6 +35,11 @@
 #define DEFAULT_BLOOM_SOFT_THRESHOLD 0.5F
 #define DEFAULT_BLOOM_RADIUS 1.0F
 
+/* FXAA Defaults */
+#define DEFAULT_FXAA_SUBPIX 0.75F
+#define DEFAULT_FXAA_EDGE_THRESHOLD 0.125F
+#define DEFAULT_FXAA_EDGE_THRESHOLD_MIN 0.063F
+
 /* DoF defaults */
 #define DEFAULT_DOF_FOCAL_DISTANCE 20.0F
 #define DEFAULT_DOF_FOCAL_RANGE 5.0F
@@ -154,6 +159,16 @@ typedef struct {
 	float white_clip; /**< Absolute white cutoff. */
 } TonemapParams;
 
+/**
+ * @struct FXAAParams
+ * @brief Parameters for Fast Approximate Anti-Aliasing.
+ */
+typedef struct {
+	float subpix;             /**< Sub-pixel quality (0.0 - 1.0). */
+	float edge_threshold;     /**< Edge detection threshold (0.063 - 0.333). */
+	float edge_threshold_min; /**< Minimum edge threshold (0.0312 - 0.0833). */
+} FXAAParams;
+
 #define BLOOM_MIP_LEVELS 5
 
 /**
@@ -228,6 +243,12 @@ typedef struct {
 	float mb_max_velocity;
 	int32_t mb_samples;
 	float _pad9;
+
+	/* FXAA */
+	float fxaa_quality_subpix;
+	float fxaa_quality_edge_threshold;
+	float fxaa_quality_edge_threshold_min;
+	float _pad10;
 } PostProcessUBO;
 
 /**
@@ -276,6 +297,7 @@ typedef struct PostProcess {
 	DoFParams dof;
 	AutoExposureParams auto_exposure;
 	MotionBlurParams motion_blur;
+	FXAAParams fxaa;
 
 	float time;             /**< Accumulated time for noise/animation. */
 	float delta_time;       /**< Last frame delta. */
@@ -366,6 +388,8 @@ void postprocess_set_auto_exposure(PostProcess* post_processing,
                                    float min_luminance, float max_luminance,
                                    float speed_up, float speed_down,
                                    float key_value);
+void postprocess_set_fxaa(PostProcess* post_processing, float subpix,
+                          float edge_threshold, float edge_threshold_min);
 
 /**
  * @brief Updates view-projection matrices for effects requiring
@@ -390,6 +414,7 @@ typedef struct {
 	TonemapParams tonemapper;
 	BloomParams bloom;
 	DoFParams dof;
+	FXAAParams fxaa;
 } PostProcessPreset;
 
 /**

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -164,9 +164,10 @@ typedef struct {
  * @brief Parameters for Fast Approximate Anti-Aliasing.
  */
 typedef struct {
-	float subpix;             /**< Sub-pixel quality (0.0 - 1.0). */
-	float edge_threshold;     /**< Edge detection threshold (0.063 - 0.333). */
-	float edge_threshold_min; /**< Minimum edge threshold (0.0312 - 0.0833). */
+	float subpix;         /**< Sub-pixel quality (0.0 - 1.0). */
+	float edge_threshold; /**< Edge detection threshold (0.063 - 0.333). */
+	float edge_threshold_min; /**< Minimum edge threshold (0.0312 - 0.0833).
+	                           */
 } FXAAParams;
 
 #define BLOOM_MIP_LEVELS 5

--- a/include/postprocess_presets.h
+++ b/include/postprocess_presets.h
@@ -43,7 +43,10 @@ static const PostProcessPreset PRESET_DEFAULT = {
               .radius = 1.0F},
     .dof = {.focal_distance = DEFAULT_DOF_FOCAL_DISTANCE,
             .focal_range = DEFAULT_DOF_FOCAL_RANGE,
-            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE}};
+            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE},
+    .fxaa = {.subpix = DEFAULT_FXAA_SUBPIX,
+             .edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD,
+             .edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN}};
 
 /** @brief Subtle adjustments for a polished but realistic look. */
 static const PostProcessPreset PRESET_SUBTLE = {
@@ -77,7 +80,10 @@ static const PostProcessPreset PRESET_SUBTLE = {
               .radius = 1.0F},
     .dof = {.focal_distance = DEFAULT_DOF_FOCAL_DISTANCE,
             .focal_range = DEFAULT_DOF_FOCAL_RANGE,
-            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE}};
+            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE},
+    .fxaa = {.subpix = DEFAULT_FXAA_SUBPIX,
+             .edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD,
+             .edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN}};
 
 /** @brief Rich, high-contrast look with auto-exposure and bloom. */
 static const PostProcessPreset PRESET_CINEMATIC = {
@@ -112,7 +118,10 @@ static const PostProcessPreset PRESET_CINEMATIC = {
               .radius = 1.0F},
     .dof = {.focal_distance = DEFAULT_DOF_FOCAL_DISTANCE,
             .focal_range = DEFAULT_DOF_FOCAL_RANGE,
-            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE}};
+            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE},
+    .fxaa = {.subpix = DEFAULT_FXAA_SUBPIX,
+             .edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD,
+             .edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN}};
 
 /** @brief Warm, grainy look with strong vignette and chromatic aberration. */
 static const PostProcessPreset PRESET_VINTAGE = {
@@ -147,7 +156,10 @@ static const PostProcessPreset PRESET_VINTAGE = {
               .radius = 1.0F},
     .dof = {.focal_distance = DEFAULT_DOF_FOCAL_DISTANCE,
             .focal_range = DEFAULT_DOF_FOCAL_RANGE,
-            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE}};
+            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE},
+    .fxaa = {.subpix = DEFAULT_FXAA_SUBPIX,
+             .edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD,
+             .edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN}};
 
 /** @brief Cool, green-tinted high contrast look. */
 static const PostProcessPreset PRESET_MATRIX = {
@@ -182,7 +194,10 @@ static const PostProcessPreset PRESET_MATRIX = {
               .radius = 1.0F},
     .dof = {.focal_distance = DEFAULT_DOF_FOCAL_DISTANCE,
             .focal_range = DEFAULT_DOF_FOCAL_RANGE,
-            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE}};
+            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE},
+    .fxaa = {.subpix = DEFAULT_FXAA_SUBPIX,
+             .edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD,
+             .edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN}};
 
 /** @brief Desaturated, high-contrast black and white look. */
 static const PostProcessPreset PRESET_BW_CONTRAST = {
@@ -216,6 +231,9 @@ static const PostProcessPreset PRESET_BW_CONTRAST = {
               .radius = 1.0F},
     .dof = {.focal_distance = DEFAULT_DOF_FOCAL_DISTANCE,
             .focal_range = DEFAULT_DOF_FOCAL_RANGE,
-            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE}};
+            .bokeh_scale = DEFAULT_DOF_BOKEH_SCALE},
+    .fxaa = {.subpix = DEFAULT_FXAA_SUBPIX,
+             .edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD,
+             .edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN}};
 
 #endif /* POSTPROCESS_PRESETS_H */

--- a/shaders/postprocess/fxaa.glsl
+++ b/shaders/postprocess/fxaa.glsl
@@ -70,7 +70,8 @@ vec3 applyFXAA(vec3 colorInput, vec2 texCoords)
 
 	// Early Exit: Contrast too low?
 	// 0.063 = EdgeThresholdMin, 0.125 = EdgeThreshold
-	if (range < max(fxaaQualityEdgeThresholdMin, rangeMax * fxaaQualityEdgeThreshold)) {
+	if (range < max(fxaaQualityEdgeThresholdMin,
+	                rangeMax * fxaaQualityEdgeThreshold)) {
 		return colorInput;
 	}
 
@@ -117,8 +118,8 @@ vec3 applyFXAA(vec3 colorInput, vec2 texCoords)
 	float subPixelOffset2 = (-2.0 * subPixelOffset1) + 3.0;
 	float subPixelOffsetFinal =
 	    subPixelOffset1 * subPixelOffset1 * subPixelOffset2;
-	subPixelOffsetFinal =
-	    subPixelOffsetFinal * subPixelOffsetFinal * fxaaQualitySubpix;  // Subpix Quality
+	subPixelOffsetFinal = subPixelOffsetFinal * subPixelOffsetFinal *
+	                      fxaaQualitySubpix;  // Subpix Quality
 
 	// ------------------------------------------------------------------------
 	// 4. Edge Search (Mode Dependent)

--- a/shaders/postprocess/fxaa.glsl
+++ b/shaders/postprocess/fxaa.glsl
@@ -70,7 +70,7 @@ vec3 applyFXAA(vec3 colorInput, vec2 texCoords)
 
 	// Early Exit: Contrast too low?
 	// 0.063 = EdgeThresholdMin, 0.125 = EdgeThreshold
-	if (range < max(0.063, rangeMax * 0.125)) {
+	if (range < max(fxaaQualityEdgeThresholdMin, rangeMax * fxaaQualityEdgeThreshold)) {
 		return colorInput;
 	}
 
@@ -118,7 +118,7 @@ vec3 applyFXAA(vec3 colorInput, vec2 texCoords)
 	float subPixelOffsetFinal =
 	    subPixelOffset1 * subPixelOffset1 * subPixelOffset2;
 	subPixelOffsetFinal =
-	    subPixelOffsetFinal * subPixelOffsetFinal * 0.75;  // Subpix Quality
+	    subPixelOffsetFinal * subPixelOffsetFinal * fxaaQualitySubpix;  // Subpix Quality
 
 	// ------------------------------------------------------------------------
 	// 4. Edge Search (Mode Dependent)

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -96,6 +96,11 @@ int postprocess_init(PostProcess* post_processing, int width, int height)
 		/* On continue quand même */
 	}
 
+	/* Initialisation FXAA */
+	post_processing->fxaa.subpix = DEFAULT_FXAA_SUBPIX;
+	post_processing->fxaa.edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD;
+	post_processing->fxaa.edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN;
+
 	/* Effets par défaut définis dans postprocess.h */
 	post_processing->active_effects = DEFAULT_ACTIVE_EFFECTS;
 
@@ -356,6 +361,14 @@ void postprocess_set_auto_exposure(PostProcess* post_processing,
 	post_processing->auto_exposure.key_value = key_value;
 }
 
+void postprocess_set_fxaa(PostProcess* post_processing, float subpix,
+                          float edge_threshold, float edge_threshold_min)
+{
+	post_processing->fxaa.subpix = subpix;
+	post_processing->fxaa.edge_threshold = edge_threshold;
+	post_processing->fxaa.edge_threshold_min = edge_threshold_min;
+}
+
 void postprocess_set_grading_ue_default(PostProcess* post_processing)
 {
 	/* * Valeurs par défaut d'Unreal Engine (Section "Global").
@@ -387,6 +400,7 @@ void postprocess_apply_preset(PostProcess* post_processing,
 	post_processing->tonemapper = preset->tonemapper;
 	post_processing->bloom = preset->bloom;
 	post_processing->dof = preset->dof;
+	post_processing->fxaa = preset->fxaa;
 
 	postprocess_on_state_change(post_processing);
 }
@@ -562,6 +576,11 @@ void postprocess_end(PostProcess* post_processing)
 	ubo.mb_intensity = post_processing->motion_blur.intensity;
 	ubo.mb_max_velocity = post_processing->motion_blur.max_velocity;
 	ubo.mb_samples = post_processing->motion_blur.samples;
+
+	ubo.fxaa_quality_subpix = post_processing->fxaa.subpix;
+	ubo.fxaa_quality_edge_threshold = post_processing->fxaa.edge_threshold;
+	ubo.fxaa_quality_edge_threshold_min =
+	    post_processing->fxaa.edge_threshold_min;
 
 	glBindBuffer(GL_UNIFORM_BUFFER, post_processing->settings_ubo);
 	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(PostProcessUBO), &ubo);

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -99,7 +99,8 @@ int postprocess_init(PostProcess* post_processing, int width, int height)
 	/* Initialisation FXAA */
 	post_processing->fxaa.subpix = DEFAULT_FXAA_SUBPIX;
 	post_processing->fxaa.edge_threshold = DEFAULT_FXAA_EDGE_THRESHOLD;
-	post_processing->fxaa.edge_threshold_min = DEFAULT_FXAA_EDGE_THRESHOLD_MIN;
+	post_processing->fxaa.edge_threshold_min =
+	    DEFAULT_FXAA_EDGE_THRESHOLD_MIN;
 
 	/* Effets par défaut définis dans postprocess.h */
 	post_processing->active_effects = DEFAULT_ACTIVE_EFFECTS;


### PR DESCRIPTION
This PR synchronizes the FXAA implementation across the codebase. 
Previously, the `PostProcessUBO` in C code was missing FXAA parameters that were present in `ubo.glsl`, leading to a potential `std140` layout mismatch.
Also, `fxaa.glsl` was using hardcoded values.

Changes:
- Added FXAA parameters to `PostProcessUBO` in `include/postprocess.h`.
- Added `FXAAParams` struct and defaults.
- Implemented `postprocess_set_fxaa` and initialization logic in `src/postprocess.c`.
- Updated `shaders/postprocess/fxaa.glsl` to use UBO uniforms.
- Updated documentation.

---
*PR created automatically by Jules for task [3373475836824452198](https://jules.google.com/task/3373475836824452198) started by @yoyonel*