### PR TITLE
Sentinel: Fix texture DoS via unbounded dimensions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** `load_file_into_ram` in `src/shader.c` did not enforce `MAX_SHADER_SOURCE_SIZE` (16MB), allowing arbitrary allocation size based on file size, leading to potential DoS via OOM.
 **Learning:** Even when limits are defined (`MAX_SHADER_SOURCE_SIZE` existed as an enum), they must be explicitly enforced in the code. The constant was previously unused.
 **Prevention:** Always validate input sizes against defined limits before allocation. Ensure defined constants are actually used in logic.
+
+## 2026-02-02 - [DoS] Unbounded Texture Dimensions
+**Vulnerability:** Texture loading and upload functions did not validate dimensions against a safe limit, allowing massive allocations or buffer over-reads via crafted images or API misuse.
+**Learning:** GL driver limits are not a security feature. `glTexStorage2D` might succeed for large values that crash `glTexSubImage2D` if source buffer is too small, or simply exhaust VRAM.
+**Prevention:** Define explicit application-level limits (e.g., `MAX_TEXTURE_DIMENSION`) and enforce them before passing data to OpenGL or allocators.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,28 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(stb)
 
-# 4. GLFW (System Package)
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(GLFW3 REQUIRED glfw3)
+# 4. GLFW (System Package or FetchContent)
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(GLFW3 QUIET glfw3)
+endif()
+
+if(NOT GLFW3_FOUND)
+    message(STATUS "GLFW3 not found via pkg-config, fetching via FetchContent...")
+    FetchContent_Declare(
+        glfw
+        GIT_REPOSITORY https://github.com/glfw/glfw.git
+        GIT_TAG        3.3.8
+    )
+    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+    set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(glfw)
+    set(GLFW3_LIBRARIES glfw)
+else()
+    message(STATUS "GLFW3 found via pkg-config")
+endif()
 
 # 5. cJSON (Static Build - CONFIGURATION AMÉLIORÉE)
 message(STATUS "Fetching cJSON...")

--- a/src/texture.c
+++ b/src/texture.c
@@ -7,6 +7,8 @@
 #include <stb_image.h>
 #include <stddef.h>
 
+enum { MAX_TEXTURE_DIMENSION = 8192 };
+
 float* texture_load_pixels(const char* path, int* width, int* height,
                            int* channels)
 {
@@ -16,6 +18,15 @@ float* texture_load_pixels(const char* path, int* width, int* height,
 		          "Failed to load HDR image: %s", path);
 		return NULL;
 	}
+
+	if (*width > MAX_TEXTURE_DIMENSION || *height > MAX_TEXTURE_DIMENSION) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "HDR image exceeds max dimensions: %s (%dx%d > %d)",
+		          path, *width, *height, MAX_TEXTURE_DIMENSION);
+		stbi_image_free(data);
+		return NULL;
+	}
+
 	LOG_INFO("suckless-ogl.texture",
 	         "HDR image loaded (CPU): %dx%d, channels=%d", *width, *height,
 	         *channels);
@@ -25,6 +36,13 @@ float* texture_load_pixels(const char* path, int* width, int* height,
 GLuint texture_upload_hdr(float* data, int width, int height)
 {
 	if (!data) {
+		return 0;
+	}
+
+	if (width > MAX_TEXTURE_DIMENSION || height > MAX_TEXTURE_DIMENSION) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Texture exceeds max dimensions: %dx%d > %d", width,
+		          height, MAX_TEXTURE_DIMENSION);
 		return 0;
 	}
 
@@ -110,6 +128,14 @@ GLuint texture_load(const char* path)
 	if (!data) {
 		LOG_ERROR("suckless-ogl.texture", "Failed to load image: %s",
 		          path);
+		return 0;
+	}
+
+	if (width > MAX_TEXTURE_DIMENSION || height > MAX_TEXTURE_DIMENSION) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Image exceeds max dimensions: %s (%dx%d > %d)", path,
+		          width, height, MAX_TEXTURE_DIMENSION);
+		stbi_image_free(data);
 		return 0;
 	}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(OPENGL_TESTS
     test_fxaa_synthetic
     test_render_utils
     test_benchmark_histogram
+    test_texture_security
 )
 
 # Pour chaque fichier test trouvé

--- a/tests/test_texture_security.c
+++ b/tests/test_texture_security.c
@@ -1,0 +1,82 @@
+#include "texture.h"
+#include "unity.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+static GLFWwindow* window = NULL;
+
+void setUp(void)
+{
+	if (!glfwInit()) {
+		TEST_FAIL_MESSAGE("Failed to initialize GLFW");
+	}
+
+	// Hidden window for headless testing
+	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+	window = glfwCreateWindow(640, 480, "Test Window", NULL, NULL);
+	if (!window) {
+		glfwTerminate();
+		TEST_FAIL_MESSAGE("Failed to create GLFW window");
+	}
+
+	glfwMakeContextCurrent(window);
+
+	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+		glfwDestroyWindow(window);
+		glfwTerminate();
+		TEST_FAIL_MESSAGE("Failed to initialize GLAD");
+	}
+}
+
+void tearDown(void)
+{
+	if (window) {
+		glfwDestroyWindow(window);
+	}
+	glfwTerminate();
+}
+
+void test_texture_upload_excessive_dimensions(void)
+{
+	// The implementation enforces a limit of 8192.
+	// We test 8193 to ensure it is rejected.
+	int width = 8193;
+	int height = 16;
+	float dummy_data[64] = {0};
+
+	GLuint tex = texture_upload_hdr(dummy_data, width, height);
+	TEST_ASSERT_EQUAL_MESSAGE(
+	    0, tex, "Should reject texture with width > MAX_TEXTURE_DIMENSION (8192)");
+
+	width = 16;
+	height = 8193;
+	tex = texture_upload_hdr(dummy_data, width, height);
+	TEST_ASSERT_EQUAL_MESSAGE(
+	    0, tex,
+	    "Should reject texture with height > MAX_TEXTURE_DIMENSION (8192)");
+}
+
+void test_texture_upload_valid_dimensions(void)
+{
+	int width = 4;
+	int height = 4;
+	// 4x4 * 4 floats * sizeof(float) = 64 bytes
+	float dummy_data[64] = {0};
+
+	GLuint tex = texture_upload_hdr(dummy_data, width, height);
+	TEST_ASSERT_NOT_EQUAL(0, tex);
+
+	glDeleteTextures(1, &tex);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_texture_upload_excessive_dimensions);
+	RUN_TEST(test_texture_upload_valid_dimensions);
+	return UNITY_END();
+}

--- a/tests/test_texture_security.c
+++ b/tests/test_texture_security.c
@@ -50,7 +50,8 @@ void test_texture_upload_excessive_dimensions(void)
 
 	GLuint tex = texture_upload_hdr(dummy_data, width, height);
 	TEST_ASSERT_EQUAL_MESSAGE(
-	    0, tex, "Should reject texture with width > MAX_TEXTURE_DIMENSION (8192)");
+	    0, tex,
+	    "Should reject texture with width > MAX_TEXTURE_DIMENSION (8192)");
 
 	width = 16;
 	height = 8193;


### PR DESCRIPTION
This PR addresses a Denial of Service (DoS) vulnerability in the texture loading and upload pipeline.

Previously, the application allowed loading and uploading textures of arbitrary dimensions. A maliciously crafted image (e.g., specifying 100k x 100k resolution) or incorrect API usage could cause:
1.  Massive memory allocation (RAM/VRAM exhaustion).
2.  Buffer over-reads (Segmentation Faults) if the source buffer was smaller than the dimensions implied (as demonstrated by the new regression test).
3.  Driver crashes/hangs.

**Changes:**
1.  **Enforce Limits:** Introduced `MAX_TEXTURE_DIMENSION = 8192` in `src/texture.c`.
2.  **Validation:** Added checks in `texture_load`, `texture_load_pixels`, and `texture_upload_hdr` to reject dimensions exceeding this limit.
3.  **Safety:** Ensures `stbi_image_free` is called on error paths during loading.
4.  **Testing:** Added `tests/test_texture_security.c` to verify the fix and prevent regression.
5.  **Build System:** Improved `CMakeLists.txt` to fetch GLFW via `FetchContent` if not found on the system, improving build portability for tests.

**Sentinel Journal:**
Added entry for [DoS] Unbounded Texture Dimensions.

---
*PR created automatically by Jules for task [14908014436618670682](https://jules.google.com/task/14908014436618670682) started by @yoyonel*