### PR TITLE
Sentinel: [Enhancement] Add compiler hardening flags to CMake

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Texture loading and upload functions did not validate dimensions against a safe limit, allowing massive allocations or buffer over-reads via crafted images or API misuse.
 **Learning:** GL driver limits are not a security feature. `glTexStorage2D` might succeed for large values that crash `glTexSubImage2D` if source buffer is too small, or simply exhaust VRAM.
 **Prevention:** Define explicit application-level limits (e.g., `MAX_TEXTURE_DIMENSION`) and enforce them before passing data to OpenGL or allocators.
+
+## 2026-02-03 - [Enhancement] Missing Compiler Hardening Flags
+**Vulnerability:** The build configuration lacked standard security hardening flags (Stack Protector, Fortify Source, RELRO), making the binary easier to exploit if memory corruption vulnerabilities were present.
+**Learning:** Default CMake configurations often optimize for compatibility/speed rather than security. Defensive coding in source (e.g., `safe_snprintf`) is good but should be backed by compiler-level protections (Defense in Depth).
+**Prevention:** Explicitly enable hardening flags (`-fstack-protector-strong`, `-D_FORTIFY_SOURCE=2`, `-Wl,-z,relro,-z,now`) in `CMakeLists.txt` for all production targets.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,29 @@ target_compile_definitions(app PRIVATE GLFW_INCLUDE_NONE)
 if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
     target_compile_options(app PRIVATE -Wall -Wextra)
 
+    # Sentinel: Security Hardening Flags
+    # -fstack-protector-strong: Protects against stack buffer overflows
+    # -Wformat -Wformat-security: Warns about unsafe format string usage
+    target_compile_options(app PRIVATE
+        -fstack-protector-strong
+        -Wformat
+        -Wformat-security
+    )
+
+    # _FORTIFY_SOURCE=2: Enables compile-time and runtime checks for buffer overflows
+    # (Requires optimization level -O1 or higher)
+    target_compile_definitions(app PRIVATE _FORTIFY_SOURCE=2)
+
+    # Linker Hardening:
+    # -Wl,-z,relro: Read-only Relocations (protects GOT)
+    # -Wl,-z,now: Immediate Binding (protects PLT)
+    # -Wl,-z,noexecstack: Prevents code execution on the stack
+    target_link_options(app PRIVATE
+        -Wl,-z,relro
+        -Wl,-z,now
+        -Wl,-z,noexecstack
+    )
+
     # -fno-omit-frame-pointer est CRUCIAL pour que les profilers (perf, gprof, callgrind)
     # puissent reconstruire la pile d'appel (stack trace) correctement.
     if(CMAKE_BUILD_TYPE STREQUAL "Profiling" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")

--- a/docs/build.md
+++ b/docs/build.md
@@ -78,7 +78,15 @@ Dependencies are automatically managed via CMake's `FetchContent` module. No man
 - **Source**: [DaveGamble/cJSON](https://github.com/DaveGamble/cJSON)
 - **Automation**: Fetched at configuration time.
 
-## Folder Structure
+## Security Hardening
+
+The project enforces strict security flags during compilation to mitigate memory corruption vulnerabilities:
+
+- **Stack Protection**: `-fstack-protector-strong` adds stack canaries to detect buffer overflows.
+- **Format Security**: `-Wformat -Wformat-security` prevents format string attacks.
+- **Fortify Source**: `_FORTIFY_SOURCE=2` adds runtime checks for common string/memory functions.
+- **Linker Hardening**: RELRO, NOW, and NoExecStack are enabled to protect the GOT and prevent stack execution.
+
 
 ## Fast Parallel Builds
 


### PR DESCRIPTION
Sentinel: [Enhancement] Add compiler hardening flags to CMake

**Vulnerability:** The build configuration lacked standard security hardening flags (Stack Protector, Fortify Source, RELRO), making the binary easier to exploit if memory corruption vulnerabilities were present.
**Fix:** Added `-fstack-protector-strong`, `-Wformat`, `-Wformat-security`, `_FORTIFY_SOURCE=2`, and linker hardening flags (`relro`, `now`, `noexecstack`) to `CMakeLists.txt` for the `app` target.
**Verification:** Built the application successfully and ran the test suite (`ctest`) with 28/28 tests passing. Verified that `_FORTIFY_SOURCE` is defined.

---
*PR created automatically by Jules for task [6040850282138540844](https://jules.google.com/task/6040850282138540844) started by @yoyonel*