### PR TITLE
Build: Accelerate linting with clang-tidy caching (cltcache)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,17 @@ jobs:
           python-version: '3.x'
       - name: Install linting tools via pip
         run: |
-          pip install clang-format==19.1.7 ruff
+          pip install clang-format==19.1.7 ruff cltcache
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache Clang-Tidy Results
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/cltcache
+          key: ${{ runner.os }}-cltcache-${{ hashFiles('src/**/*.c', 'include/**/*.h') }}
+          restore-keys: |
+            ${{ runner.os }}-cltcache-
+
       - name: Install Build Dependencies
         run: |
           sudo apt-get update

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,40 @@
 cmake_minimum_required(VERSION 3.14)
 project(suckless-ogl C)
 
+# --- Clang-Tidy & Caching ---
+option(ENABLE_CLANG_TIDY "Enable clang-tidy linting during build" OFF)
+option(ENABLE_CLANG_TIDY_CACHE "Use caching for clang-tidy (requires ctcache)" ON)
+
+if(ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_BIN NAMES clang-tidy)
+    if(CLANG_TIDY_BIN)
+        set(CLANG_TIDY_CMD "${CLANG_TIDY_BIN}")
+
+        if(ENABLE_CLANG_TIDY_CACHE)
+            # Try to find cltcache (or cltcache.py)
+            find_program(CTCACHE_BIN NAMES cltcache cltcache.py)
+            if(NOT CTCACHE_BIN)
+                # Fallback: check standard user paths
+                find_program(CTCACHE_BIN NAMES cltcache cltcache.py PATHS "${CMAKE_SOURCE_DIR}/.venv/bin" "$ENV{HOME}/.local/bin")
+            endif()
+
+            if(CTCACHE_BIN)
+                message(STATUS "Clang-Tidy with Cache: ENABLED (using ${CTCACHE_BIN})")
+                set(CLANG_TIDY_CMD "${CTCACHE_BIN}" "${CLANG_TIDY_BIN}")
+            else()
+                 message(WARNING "cltcache not found even though ENABLE_CLANG_TIDY_CACHE is ON. Falling back to uncached clang-tidy.")
+            endif()
+        else()
+            message(STATUS "Clang-Tidy: ENABLED (Uncached)")
+        endif()
+
+        # Do NOT set CMAKE_C_CLANG_TIDY globally to avoid linting dependencies (cglm, glad, etc.)
+        # set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_CMD}")
+    else()
+        message(WARNING "clang-tidy not found, linting disabled")
+    endif()
+endif()
+
 # Option pour activer le rendu SSBO
 option(USE_SSBO_RENDERING "Use SSBO-based rendering instead of instanced rendering" OFF)
 
@@ -242,6 +276,11 @@ endif()
 
 # App target
 add_executable(app ${SOURCES})
+
+# Apply Clang-Tidy only to this target
+if(ENABLE_CLANG_TIDY AND CLANG_TIDY_CMD)
+    set_target_properties(app PROPERTIES C_CLANG_TIDY "${CLANG_TIDY_CMD}")
+endif()
 
 # Target properties and includes
 target_include_directories(app PRIVATE src include ${stb_SOURCE_DIR})

--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,11 @@ GLAD_INC := build/_deps/glad-build/include
 CJSON_INC := $(shell [ -d deps/cjson ] && echo deps/cjson || echo build/_deps/cjson-src)
 
 lint: $(BUILD_DIR)/Makefile
-	@echo "Ensuring dependencies are generated..."
-	@$(DISTROBOX) $(CMAKE) --build $(BUILD_DIR) --target glad
-	@echo "Linting C code..."
-	$(DISTROBOX) clang-tidy -header-filter="^$(CURDIR)/(src|include)/.*" $(shell find src -name "*.c" ! -name "stb_image_impl.c") -- -D_POSIX_C_SOURCE=200809L -Isrc -Iinclude -isystem $(CURDIR)/$(STB_INC) -isystem $(CURDIR)/$(GLAD_INC) -isystem $(CURDIR)/$(CGLM_INC) -isystem $(CURDIR)/$(CJSON_INC)
+	@echo "Linting C code (with caching if available)..."
+	@# Reconfigure with clang-tidy enabled
+	@$(DISTROBOX) $(CMAKE) -B $(BUILD_DIR) -DENABLE_CLANG_TIDY=ON
+	@# Build just the app target (parallelized) - this triggers the linting
+	@$(DISTROBOX) $(CMAKE) --build $(BUILD_DIR) --target app --parallel $(shell nproc)
 	@echo "Linting Python scripts..."
 	@$(TOOL_RUN) ruff check scripts/trace_analyze.py tests/test_trace_analyze.py || (echo "⚠️  Install ruff: $$CMD install ruff" && exit 1)
 	@echo "✓ All linting passed"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 
 # Linting and formatting
 ruff
+cltcache
 
 # Testing and coverage
 pytest


### PR DESCRIPTION
## 🚀 Summary
This PR significantly speeds up the linting process (both locally and in CI/CD) by implementing caching for `clang-tidy` results.
## 🛠️ Changes
### ⚡ Performance & Caching
- **Integrated `cltcache`**: Added `cltcache` (Python wrapper) to `requirements-dev.txt`. This tool hashes input files and caches `clang-tidy` output.
- **CMake Integration**: Updated `CMakeLists.txt` to automatically detect `cltcache` and wrap the `clang-tidy` command.
- **Targeted Linting**: Restricted `clang-tidy` analysis to the `app` target (user code) only. This avoids wasting time linting third-party dependencies like `cglm` and `glad`.
### 🔄 CI/CD Optimization (GitHub Actions)
- Updated `.github/workflows/main.yml` to install `cltcache`.
- Added `actions/cache` to persist the linting cache (`~/.cache/cltcache`) between runs, making subsequent pipeline runs much faster.
### 🧹 Build System
- **Simplified Makefile**: The `make lint` target now leverages the CMake integration instead of a complex manual command.
## 🧪 Verification
- **Local**: Run `make return` twice. The second run should be nearly instantaneous.
- **Offline**: Validated that the build gracefully degrades (prints a warning but succeeds) if `cltcache` is missing in an offline environment.