### PR TITLE
⚡ Optimize post-processing state changes to avoid redundant cache lookups

### DIFF
--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -355,7 +355,8 @@ typedef struct PostProcess {
 	bool is_optimized; /**< true if Uber-shader uses static preprocessor
 	                      flags. */
 
-	unsigned int compiled_flags; /**< Flags used for the current optimized shader. */
+	unsigned int
+	    compiled_flags; /**< Flags used for the current optimized shader. */
 
 	ShaderCacheEntry shader_cache[SHADER_CACHE_SIZE];
 	int shader_cache_count;

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -355,6 +355,8 @@ typedef struct PostProcess {
 	bool is_optimized; /**< true if Uber-shader uses static preprocessor
 	                      flags. */
 
+	unsigned int compiled_flags; /**< Flags used for the current optimized shader. */
+
 	ShaderCacheEntry shader_cache[SHADER_CACHE_SIZE];
 	int shader_cache_count;
 } PostProcess;

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -44,6 +44,7 @@ int postprocess_init(PostProcess* post_processing, int width, int height)
 	post_processing->height = height;
 	post_processing->time = 0.0F;
 	post_processing->is_optimized = false;
+	post_processing->compiled_flags = ~0U;
 
 	post_processing->shader_cache_count = 0;
 
@@ -274,6 +275,10 @@ void postprocess_resize(PostProcess* post_processing, int width, int height)
 static void postprocess_on_state_change(PostProcess* post_processing)
 {
 	if (post_processing->is_optimized) {
+		if (post_processing->active_effects ==
+		    post_processing->compiled_flags) {
+			return;
+		}
 		LOG_INFO(
 		    "suckless-ogl.postprocess",
 		    "State changed in optimized mode - recompiling shader...");
@@ -914,6 +919,7 @@ void postprocess_compile_optimized(PostProcess* post_processing,
 			         "Using CACHED shader for flags 0x%08X",
 			         static_flags);
 		}
+		post_processing->compiled_flags = static_flags;
 		return;
 	}
 
@@ -941,6 +947,7 @@ void postprocess_compile_optimized(PostProcess* post_processing,
 
 	if (new_shader) {
 		update_current_shader(post_processing, new_shader, true);
+		post_processing->compiled_flags = static_flags;
 		new_shader->silent_warnings = true;
 
 		/* Add to cache */


### PR DESCRIPTION
This PR implements a performance optimization for the post-processing pipeline.

**Changes:**
- Added `unsigned int compiled_flags` to `struct PostProcess` in `include/postprocess.h`.
- Initialized `compiled_flags` to `~0U` in `postprocess_init`.
- Updated `compiled_flags` whenever a shader is successfully loaded in `postprocess_compile_optimized`.
- Added a check in `postprocess_on_state_change` to return early if `active_effects` matches `compiled_flags`.

**Why:**
Previously, `postprocess_on_state_change` would always call `postprocess_compile_optimized`, which performs a linear search through the shader cache. Even though the cache is fast (32 items), avoiding this lookup when the state hasn't actually changed reduces CPU overhead, especially if state changes are triggered frequently by UI or logic updates.

**Verification:**
- Ran `tests/test_postprocess` benchmarks.
- Confirmed that functionality is preserved (all tests passed).
- Confirmed that the optimization logic is safe (initialization to `~0U` prevents false positives).

---
*PR created automatically by Jules for task [17659946969817625220](https://jules.google.com/task/17659946969817625220) started by @yoyonel*