### PR TITLE
chore: standardize developer environment and support host IDEs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgl1-mesa-dev libglew-dev libglfw3-dev cmake clang-tidy gamemode-dev
+          sudo apt-get install -y libgl1-mesa-dev libglew-dev libglfw3-dev cmake clang-tidy gamemode-dev libxinerama-dev libxcursor-dev libxi-dev libxrandr-dev
       - name: Run Format & Lint
         run: |
           clang-format --version
@@ -66,7 +66,7 @@ jobs:
             build-essential cmake clang llvm \
             libgl1-mesa-dev libglew-dev libglfw3-dev \
             xorg-dev xvfb libgl1-mesa-dri mesa-vulkan-drivers \
-            imagemagick gamemode-dev
+            imagemagick gamemode-dev libxinerama-dev libxcursor-dev libxi-dev libxrandr-dev
 
       - name: Make test wrapper executable
         run: chmod +x tests/run_test_with_xvfb.sh
@@ -260,7 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Deps
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake libgl1-mesa-dev libglew-dev libglfw3-dev gamemode-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake libgl1-mesa-dev libglew-dev libglfw3-dev gamemode-dev libxinerama-dev libxcursor-dev libxi-dev libxrandr-dev
       - name: Build
         run: |
           FLAGS=""

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "llvm-vs-code-extensions.vscode-clangd",
+    "vadimcn.vscode-lldb"
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,28 +187,21 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(stb)
 
-# 4. GLFW (System Package or FetchContent)
-find_package(PkgConfig QUIET)
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(GLFW3 QUIET glfw3)
-endif()
-
-if(NOT GLFW3_FOUND)
-    message(STATUS "GLFW3 not found via pkg-config, fetching via FetchContent...")
-    FetchContent_Declare(
-        glfw
-        GIT_REPOSITORY https://github.com/glfw/glfw.git
-        GIT_TAG        3.3.8
-    )
-    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-    set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-    set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
-    set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(glfw)
-    set(GLFW3_LIBRARIES glfw)
-else()
-    message(STATUS "GLFW3 found via pkg-config")
-endif()
+# 4. GLFW (Force FetchContent for Host IDE Support)
+# We deliberately skip pkg-config to ensure headers are available in build/_deps
+# This allows clangd on the host to index them even if they are not installed on the host system.
+message(STATUS "Forcing GLFW3 FetchContent for IDE compatibility...")
+FetchContent_Declare(
+    glfw
+    GIT_REPOSITORY https://github.com/glfw/glfw.git
+    GIT_TAG        3.3.8
+)
+set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(glfw)
+set(GLFW3_LIBRARIES glfw)
 
 # 5. cJSON (Static Build - CONFIGURATION AMÉLIORÉE)
 message(STATUS "Fetching cJSON...")

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -5,4 +5,6 @@
 -g
 -Isrc
 -Ideps
-`pkg-config --cflags glfw3`
+-Ideps/cglm/include
+-Ideps/stb
+-Ideps/cjson

--- a/docs/ide_setup.md
+++ b/docs/ide_setup.md
@@ -1,0 +1,88 @@
+# IDE & Environment Setup Guide
+
+This guide explains how to set up a robust development environment for **Suckless OGL**, focusing on modern C tooling (clangd, CMake) and compatibility with containerized workflows like **Distrobox**.
+
+## 1. Prerequisites
+
+### Essential Tools
+-   **CMake** (3.14+)
+-   **Clang / GCC** (C11 support)
+-   **Make** or **Ninja**
+-   **clangd** (Language Server)
+
+### Recommended Editor
+**VS Code** is highly recommended for its excellent `clangd` integration.
+-   Install the **clangd** extension (`llvm-vs-code-extensions.vscode-clangd`).
+-   *Optional*: **CodeLLDB** for debugging (`vadimcn.vscode-lldb`).
+
+---
+
+## 2. The Setup Architecture
+
+This project uses a **hybrid build approach** to ensure headers are visible to both the build system (inside Distrobox/Docker) and your IDE (on the Host).
+
+### Key Components
+1.  **CMake FetchContent**: We force `FetchContent` for third-party libraries (like GLFW) instead of using system packages (`pkg-config`).
+    -   *Why?* This downloads sources into `build/_deps/`, ensuring headers are physically present in the project folder.
+2.  **Compilation Database**: We generate `compile_commands.json` which tells `clangd` exactly where to look for headers.
+
+---
+
+## 3. Configuration Steps
+
+### Step 1: Generate Compilation Database
+Run this command once (or whenever you add new CMake targets). It works inside Distrobox or on a native Debian/Linux system.
+
+```bash
+# Clean build (optional but recommended for fresh setup)
+rm -rf build/
+
+# Configure and generate compile_commands.json
+# Note: We configure in 'build/' but link the JSON to root for clangd
+cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+# Create symlink for clangd
+ln -sf build/compile_commands.json compile_commands.json
+```
+
+**What this does:**
+-   Downloads GLFW, cglm, stb, etc. into `build/_deps/`.
+-   Generates `build/compile_commands.json` with absolute paths to those headers.
+-   Links it to the root so your editor finds it.
+
+### Step 2: VS Code Configuration
+If you haven't already, accept the workspace recommendation to install `clangd`.
+
+1.  Open the project in VS Code.
+2.  If prompted, **Disable IntelliSense** for the Microsoft C/C++ extension (to allow `clangd` to take over).
+3.  Open `src/main.c`. You should be able to Ctrl+Click on functions like `glfwInit` or `app_run`.
+
+---
+
+## 4. Troubleshooting
+
+### Headers not found (red squiggles)
+If `clangd` reports missing headers despite the build working:
+
+1.  **Check for `compile_commands.json`**: Ensure the symlink exists in the project root.
+2.  **Verify Include Paths**: Open `compile_commands.json` and search for `-I.../build/_deps/glfw-src/include`. If it's missing, re-run `cmake -B build`.
+3.  **Reload Window**: VS Code sometimes caches old paths. run `Ctrl+Shift+P` -> `Developer: Reload Window`.
+4.  **Rebuild**:
+    ```bash
+    # Sometimes generating the headers (glad) requires a build
+    make
+    ```
+
+### Distrobox vs Host Paths
+If you build inside a container but edit on the host:
+-   **The Fix**: Our `CMakeLists.txt` forces local dependency builds (`FetchContent`). This avoids the issue where `pkg-config` points to `/usr/include` inside the container (which doesn't exist on the host).
+-   **Validation**: Ensure you **DO NOT** use system-installed GLFW dev packages for the *build configuration* if you want IDE completions to work perfectly on the host.
+
+---
+
+## 5. Debian / Native Linux Compatibility
+This setup is fully compatible with Debian 13 or any other distro without Distrobox.
+-   **Requirement**: You need X11 development headers installed system-wide, as GLFW compiles from source.
+    ```bash
+    sudo apt install libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
     - Performance Mode & Notifs: perf_and_notifications.md
   - Guides:
     - Build Guide: build.md
+    - IDE & Env Setup: ide_setup.md
     - Docker Guide: docker.md
     - Profiling: profiling_guide.md
     - Perf Troubleshooting: perf_profiling.md


### PR DESCRIPTION
## Description
This PR standardizes the developer environment to support modern C tooling (Clangd, VS Code, CMake) across both native and containerized (Distrobox) workflows.

## Changes
- **CMake**: Enforced `FetchContent` for `glfw` to ensure headers are physically present in `build/_deps/`, making them visible to host-side IDEs even when building inside a container.
- **Documentation**: Added `docs/ide_setup.md` detailing the robust IDE setup (compilation database generation, extension recommendations).
- **VS Code**: Added `.vscode/extensions.json` to recommend `clangd` and `lldb` for a seamless "Open Folder" experience.
- **Fix**: Removed invalid shell commands from `compile_flags.txt` and superseded it with `compile_commands.json` generation instructions.

## Verification
- Validated that "Go to Definition" works for `glfw` and `glad` symbols on the host while building inside Distrobox.
- Verified compilation succeeds with the vendored libraries.