### PR TITLE
⚡ Enable optimized shader compilation by default

### DIFF
--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -146,11 +146,9 @@ int postprocess_init(PostProcess* post_processing, int width, int height)
 		return 0;
 	}
 
-#ifndef ENABLE_SHADER_OPTIMIZATION
-	/* Charger le shader de post-processing (Debug mode uniquement) */
-	post_processing->postprocess_shader =
-	    shader_load("shaders/postprocess.vert", "shaders/postprocess.frag");
-#endif
+	/* Charger le shader de post-processing (Optimized Mode) */
+	postprocess_compile_optimized(post_processing,
+	                              post_processing->active_effects);
 
 	/* Initialize UBO */
 	glGenBuffers(1, &post_processing->settings_ubo);

--- a/tests/test_postprocess.c
+++ b/tests/test_postprocess.c
@@ -197,23 +197,20 @@ void test_postprocess_optimization_switch(void)
 	PostProcess post_proc = {0};
 	postprocess_init(&post_proc, SmallTestWidth, SmallTestHeight);
 
-	// Default should be dynamic
-	TEST_ASSERT_FALSE(post_proc.is_optimized);
+	// Default should be OPTIMIZED
+	TEST_ASSERT_TRUE(post_proc.is_optimized);
 	GLuint original_program = post_proc.postprocess_shader->program;
 
-	// Switch to optimized
-	unsigned int opt_flags = (unsigned int)(POSTFX_VIGNETTE | POSTFX_GRAIN);
-	postprocess_compile_optimized(&post_proc, opt_flags);
-	TEST_ASSERT_TRUE(post_proc.is_optimized);
+	// Switch to dynamic
+	postprocess_use_dynamic(&post_proc);
+	TEST_ASSERT_FALSE(post_proc.is_optimized);
 	TEST_ASSERT_NOT_EQUAL(original_program,
 	                      post_proc.postprocess_shader->program);
 
-	// Switch back to dynamic
-	GLuint optimized_program = post_proc.postprocess_shader->program;
-	postprocess_use_dynamic(&post_proc);
-	TEST_ASSERT_FALSE(post_proc.is_optimized);
-	TEST_ASSERT_NOT_EQUAL(optimized_program,
-	                      post_proc.postprocess_shader->program);
+	// Switch back to optimized
+	unsigned int opt_flags = (unsigned int)(POSTFX_VIGNETTE | POSTFX_GRAIN);
+	postprocess_compile_optimized(&post_proc, opt_flags);
+	TEST_ASSERT_TRUE(post_proc.is_optimized);
 
 	postprocess_cleanup(&post_proc);
 }


### PR DESCRIPTION
Enables optimized shader compilation by default in `src/postprocess.c`, utilizing the existing shader cache to improve performance.

1.  Modified `postprocess_init` in `src/postprocess.c` to call `postprocess_compile_optimized` instead of `shader_load`.
2.  Updated `tests/test_postprocess.c` to assert that the post-processor starts in optimized mode.

This change ensures that specialized shaders (with static defines) are used, reducing branch divergence on the GPU, while the existing cache mechanism prevents redundant recompilations.

---
*PR created automatically by Jules for task [12865019447356002165](https://jules.google.com/task/12865019447356002165) started by @yoyonel*