### PR TITLE
🛡️ Sentinel: Fix Path Traversal in Shader Includes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The build configuration lacked standard security hardening flags (Stack Protector, Fortify Source, RELRO), making the binary easier to exploit if memory corruption vulnerabilities were present.
 **Learning:** Default CMake configurations often optimize for compatibility/speed rather than security. Defensive coding in source (e.g., `safe_snprintf`) is good but should be backed by compiler-level protections (Defense in Depth).
 **Prevention:** Explicitly enable hardening flags (`-fstack-protector-strong`, `-D_FORTIFY_SOURCE=2`, `-Wl,-z,relro,-z,now`) in `CMakeLists.txt` for all production targets.
+
+## 2026-02-04 - [Path Traversal] Shader Include Path Traversal
+**Vulnerability:** The `@header` directive in shaders allowed including files via relative paths containing `..`, enabling reading of arbitrary files (limited by process permissions) into the shader source.
+**Learning:** File inclusion mechanisms (like `@header`) must always sanitize input paths to prevent directory traversal. Concatenating paths is not enough; one must check for `..` or use path canonicalization.
+**Prevention:** Implemented `is_safe_path` to reject `..`, absolute paths, and drive letters in included paths.

--- a/src/shader.c
+++ b/src/shader.c
@@ -193,6 +193,23 @@ static void get_dir_from_path(const char* path, char* out_dir, size_t size)
 	}
 }
 
+static bool is_safe_path(const char* path)
+{
+	if (strstr(path, "..")) {
+		return false;
+	}
+	if (path[0] == '/') {
+		return false;
+	}
+	if (strchr(path, '\\')) {
+		return false;
+	}
+	if (strstr(path, ":")) {
+		return false;
+	}
+	return true;
+}
+
 /*
  * Helper to resolve and parse an included file.
  * Returns true on success, false on error.
@@ -202,6 +219,14 @@ static bool resolve_and_parse_include(IncludeContext* ctx,
                                       const char* path_term,
                                       const char* current_file_path)
 {
+	if (!is_safe_path(path_term)) {
+		LOG_ERROR("suckless-ogl.shader",
+		          "Security Violation: Unsafe include path detected: "
+		          "%s (in %s)",
+		          path_term, current_file_path);
+		return false;
+	}
+
 	/* Resolve relative path */
 	char current_dir[PATH_BUFFER_SIZE];
 	get_dir_from_path(current_file_path, current_dir, sizeof(current_dir));

--- a/tests/test_path_traversal.c
+++ b/tests/test_path_traversal.c
@@ -1,0 +1,67 @@
+#include "shader.h"
+#include "unity.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+void setUp(void)
+{
+}
+void tearDown(void)
+{
+}
+
+void test_shader_path_traversal(void)
+{
+	// 1. Create a secret file outside the expected shader dir
+	FILE *f = fopen("secret_data.txt", "w");
+	if (f) {
+		fprintf(f, "THIS_IS_SECRET");
+		fclose(f);
+	} else {
+		TEST_FAIL_MESSAGE("Could not create secret file");
+	}
+
+	// 2. Create a shader file in a subdir that tries to access the secret
+	// We'll use a subdir "traversal_test"
+	mkdir("traversal_test", 0777);
+	const char *shader_path = "traversal_test/malicious.glsl";
+	f = fopen(shader_path, "w");
+	if (f) {
+		// @header "../secret_data.txt"
+		fprintf(f, "@header \"../secret_data.txt\"\n");
+		fprintf(f, "void main() {}\n");
+		fclose(f);
+	} else {
+		TEST_FAIL_MESSAGE("Could not create malicious shader file");
+	}
+
+	// 3. Try to load the shader
+	// We expect NULL now because of the security check
+	char *source = shader_read_file(shader_path);
+
+	if (source != NULL) {
+		free(source);
+		// Cleanup before failing
+		remove(shader_path);
+		rmdir("traversal_test");
+		remove("secret_data.txt");
+		TEST_FAIL_MESSAGE(
+		    "Security check failed: Shader with traversal path was "
+		    "loaded!");
+	}
+
+	// Cleanup
+	remove(shader_path);
+	rmdir("traversal_test");
+	remove("secret_data.txt");
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_shader_path_traversal);
+	return UNITY_END();
+}


### PR DESCRIPTION
**Vulnerability Fix: Shader Path Traversal**

Identified and fixed a security vulnerability where shader `@header` includes could reference files outside the intended directory using `..` (path traversal).

**Changes:**
- Modified `src/shader.c`: Added `is_safe_path` validation in `resolve_and_parse_include`.
- Rejects paths with `..`, starting with `/` (absolute), `\` (backslash), or containing `:` (drive/protocol).
- Added regression test `tests/test_path_traversal.c` which attempts to exploit the vulnerability and asserts failure (safe behavior).
- Updated security journal.

**Verification:**
- Ran `tests/test_path_traversal.c` which confirmed the fix (access denied).
- Ran full test suite (`ctest`) with 29 passing tests.
- Linting checks passed.

---
*PR created automatically by Jules for task [1857894685908617233](https://jules.google.com/task/1857894685908617233) started by @yoyonel*