### PR TITLE
⚡ Fix uncached shader recompilation due to dirty flags

### DIFF
--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -908,15 +908,26 @@ static void update_current_shader(PostProcess* post_processing,
 void postprocess_compile_optimized(PostProcess* post_processing,
                                    unsigned int static_flags)
 {
-	/* Check cache first */
-	Shader* cached = find_shader_in_cache(post_processing, static_flags);
+	/* Sanitization: Filter out unused bits from the flags to ensure cache hits
+	 */
+	unsigned int valid_mask = 0;
+	for (size_t i = 0; i < EFFECT_COUNT; i++) {
+		valid_mask |= (unsigned int)ALL_EFFECTS[i].flag;
+	}
+	unsigned int clean_flags = static_flags & valid_mask;
+
+	/* Check cache first using clean flags */
+	Shader* cached = find_shader_in_cache(post_processing, clean_flags);
 	if (cached) {
 		if (post_processing->postprocess_shader != cached) {
 			update_current_shader(post_processing, cached, true);
 			LOG_INFO("suckless-ogl.postprocess",
-			         "Using CACHED shader for flags 0x%08X",
-			         static_flags);
+			         "Using CACHED shader for flags 0x%08X (Clean: "
+			         "0x%08X)",
+			         static_flags, clean_flags);
 		}
+		/* Store ORIGINAL flags to satisfy state change checks in
+		 * postprocess_on_state_change */
 		post_processing->compiled_flags = static_flags;
 		return;
 	}
@@ -929,7 +940,7 @@ void postprocess_compile_optimized(PostProcess* post_processing,
 		if (!safe_snprintf(
 		        buffer[count], sizeof(buffer[count]), "%s %d",
 		        ALL_EFFECTS[i].define_name,
-		        ((static_flags & (unsigned int)ALL_EFFECTS[i].flag) !=
+		        ((clean_flags & (unsigned int)ALL_EFFECTS[i].flag) !=
 		         0))) {
 			LOG_ERROR("suckless-ogl.postprocess",
 			          "Failed to format shader define");
@@ -969,10 +980,10 @@ void postprocess_compile_optimized(PostProcess* post_processing,
 			}
 		}
 
-		post_processing->shader_cache[0].flags = static_flags;
+		post_processing->shader_cache[0].flags = clean_flags;
 		post_processing->shader_cache[0].shader = new_shader;
 
-		log_optimized_effects(static_flags);
+		log_optimized_effects(clean_flags);
 	} else {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to compile optimized shader");

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -908,7 +908,8 @@ static void update_current_shader(PostProcess* post_processing,
 void postprocess_compile_optimized(PostProcess* post_processing,
                                    unsigned int static_flags)
 {
-	/* Sanitization: Filter out unused bits from the flags to ensure cache hits
+	/* Sanitization: Filter out unused bits from the flags to ensure cache
+	 * hits
 	 */
 	unsigned int valid_mask = 0;
 	for (size_t i = 0; i < EFFECT_COUNT; i++) {


### PR DESCRIPTION
Sanitize flags in postprocess shader cache to prevent redundant recompilation

Before this change, if `active_effects` contained unused bits (e.g., from
an incomplete mask or dirty state), the shader cache lookup would fail
even if the effective shader configuration (based on valid effects) was
identical to a cached entry. This caused redundant shader recompilation.

This fix:
1. Calculates a `valid_mask` of all supported effects in `postprocess_compile_optimized`.
2. Applies this mask to `static_flags` to derive `clean_flags`.
3. Uses `clean_flags` for cache lookup and storage.
4. Maintains the original `static_flags` in `compiled_flags` to correctly
   satisfy the `active_effects == compiled_flags` check in the state loop.

Verified with a reproduction test case that previously caused redundant recompilation.
Regression tests passed.

---
*PR created automatically by Jules for task [4542142602343695429](https://jules.google.com/task/4542142602343695429) started by @yoyonel*