### PR TITLE
⚡ Optimize post-processing shader cache with flag masking

### DIFF
--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -18,6 +18,7 @@ static int create_framebuffer(PostProcess* post_processing);
 static void destroy_framebuffer(PostProcess* post_processing);
 static void destroy_screen_quad(PostProcess* post_processing);
 static bool is_shader_in_cache(PostProcess* post_processing, Shader* shader);
+static unsigned int get_valid_flags_mask(void);
 
 /* Texture Units */
 enum {
@@ -273,15 +274,17 @@ void postprocess_resize(PostProcess* post_processing, int width, int height)
 static void postprocess_on_state_change(PostProcess* post_processing)
 {
 	if (post_processing->is_optimized) {
-		if (post_processing->active_effects ==
-		    post_processing->compiled_flags) {
+		unsigned int valid_mask = get_valid_flags_mask();
+		unsigned int clean_active =
+		    post_processing->active_effects & valid_mask;
+
+		if (clean_active == post_processing->compiled_flags) {
 			return;
 		}
 		LOG_INFO(
 		    "suckless-ogl.postprocess",
 		    "State changed in optimized mode - recompiling shader...");
-		postprocess_compile_optimized(post_processing,
-		                              post_processing->active_effects);
+		postprocess_compile_optimized(post_processing, clean_active);
 	}
 }
 
@@ -849,6 +852,15 @@ static const EffectMetadata ALL_EFFECTS[] = {
 
 #define EFFECT_COUNT (sizeof(ALL_EFFECTS) / sizeof(ALL_EFFECTS[0]))
 
+static unsigned int get_valid_flags_mask(void)
+{
+	unsigned int mask = 0;
+	for (size_t i = 0; i < EFFECT_COUNT; i++) {
+		mask |= (unsigned int)ALL_EFFECTS[i].flag;
+	}
+	return mask;
+}
+
 static void log_optimized_effects(unsigned int flags)
 {
 	LOG_INFO("suckless-ogl.postprocess",
@@ -908,6 +920,9 @@ static void update_current_shader(PostProcess* post_processing,
 void postprocess_compile_optimized(PostProcess* post_processing,
                                    unsigned int static_flags)
 {
+	unsigned int valid_mask = get_valid_flags_mask();
+	static_flags &= valid_mask;
+
 	/* Check cache first */
 	Shader* cached = find_shader_in_cache(post_processing, static_flags);
 	if (cached) {

--- a/tests/test_postprocess.c
+++ b/tests/test_postprocess.c
@@ -322,6 +322,31 @@ void test_postprocess_large_working_set(void)
 	postprocess_cleanup(&post_proc);
 }
 
+void test_postprocess_garbage_flags_cache_hit(void)
+{
+	PostProcess post_proc = {0};
+	postprocess_init(&post_proc, SmallTestWidth, SmallTestHeight);
+
+	unsigned int flags = (unsigned int)(POSTFX_VIGNETTE | POSTFX_GRAIN);
+	// Garbage bit: 1 << 31
+	unsigned int garbage_flags = flags | (1U << 31);
+
+	// Compile initial shader
+	postprocess_compile_optimized(&post_proc, flags);
+	GLuint original_program = post_proc.postprocess_shader->program;
+
+	// Compile with garbage flags
+	// Currently, this should cause a MISS because the cache key is garbage_flags
+	// But the generated shader should be identical.
+	// We want this to be a HIT.
+
+	postprocess_compile_optimized(&post_proc, garbage_flags);
+
+	TEST_ASSERT_EQUAL(original_program, post_proc.postprocess_shader->program);
+
+	postprocess_cleanup(&post_proc);
+}
+
 int main(void)
 {
 	UNITY_BEGIN();
@@ -335,6 +360,7 @@ int main(void)
 	RUN_TEST(test_postprocess_recompilation_benchmark);
 	RUN_TEST(test_postprocess_cache_overflow_benchmark);
 	RUN_TEST(test_postprocess_large_working_set);
+	RUN_TEST(test_postprocess_garbage_flags_cache_hit);
 	RUN_TEST(test_postprocess_cleanup);
 	return UNITY_END();
 }

--- a/tests/test_postprocess.c
+++ b/tests/test_postprocess.c
@@ -336,13 +336,14 @@ void test_postprocess_garbage_flags_cache_hit(void)
 	GLuint original_program = post_proc.postprocess_shader->program;
 
 	// Compile with garbage flags
-	// Currently, this should cause a MISS because the cache key is garbage_flags
-	// But the generated shader should be identical.
-	// We want this to be a HIT.
+	// Currently, this should cause a MISS because the cache key is
+	// garbage_flags But the generated shader should be identical. We want
+	// this to be a HIT.
 
 	postprocess_compile_optimized(&post_proc, garbage_flags);
 
-	TEST_ASSERT_EQUAL(original_program, post_proc.postprocess_shader->program);
+	TEST_ASSERT_EQUAL(original_program,
+	                  post_proc.postprocess_shader->program);
 
 	postprocess_cleanup(&post_proc);
 }


### PR DESCRIPTION
Implemented an optimization to sanitize `active_effects` flags before using them for shader cache lookups or compilation. This prevents redundant operations when garbage bits are present in the flags, ensuring robust cache hits and avoiding unnecessary shader linking. Verified with a new regression test.

---
*PR created automatically by Jules for task [15922991949533043074](https://jules.google.com/task/15922991949533043074) started by @yoyonel*