### PR TITLE
⚡ Optimize postprocess shader recompilation by caching source

### DIFF
--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -358,6 +358,9 @@ typedef struct PostProcess {
 	unsigned int
 	    compiled_flags; /**< Flags used for the current optimized shader. */
 
+	char* cached_vert_src; /**< Pre-resolved vertex shader source. */
+	char* cached_frag_src; /**< Pre-resolved fragment shader source. */
+
 	ShaderCacheEntry shader_cache[SHADER_CACHE_SIZE];
 	int shader_cache_count;
 } PostProcess;

--- a/include/shader.h
+++ b/include/shader.h
@@ -49,7 +49,8 @@ char* shader_read_resolved_source(const char* path);
  * @param count Number of macros.
  * @return Heap-allocated string with injected defines. Result must be freed.
  */
-char* shader_inject_defines(const char* source, const char** defines, int count);
+char* shader_inject_defines(const char* source, const char** defines,
+                            int count);
 
 /**
  * @brief Helper to load a classic Vertex+Fragment program from disk.
@@ -106,7 +107,8 @@ Shader* shader_load(const char* vertex_path, const char* fragment_path);
  * @param name Descriptive name for the shader.
  * @return Pointer to the Shader object.
  */
-Shader* shader_create_from_source(const char* vert_src, const char* frag_src, const char* name);
+Shader* shader_create_from_source(const char* vert_src, const char* frag_src,
+                                  const char* name);
 
 /**
  * @brief Loads a compute program and caches its uniforms.

--- a/include/shader.h
+++ b/include/shader.h
@@ -20,11 +20,36 @@
 GLuint shader_compile(const char* path, GLenum type);
 
 /**
+ * @brief Compiles a single shader stage from a source string.
+ * @param source Null-terminated shader source code.
+ * @param type GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, or GL_COMPUTE_SHADER.
+ * @return GLuint handle of the compiled shader stage.
+ */
+GLuint shader_compile_from_source(const char* source, GLenum type);
+
+/**
  * @brief Reads a shader file into RAM, processing all includes.
  * @param path Absolute or relative path.
  * @return Heap-allocated null-terminated string. Result must be freed.
  */
 char* shader_read_file(const char* path);
+
+/**
+ * @brief Reads a shader file into RAM, processing all includes.
+ * @note This is an alias for shader_read_file but explicit about resolution.
+ * @param path Absolute or relative path.
+ * @return Heap-allocated null-terminated string. Result must be freed.
+ */
+char* shader_read_resolved_source(const char* path);
+
+/**
+ * @brief Injects `#define` directives into shader source.
+ * @param source Original source code.
+ * @param defines Array of macro strings (e.g. "BLOOM_ENABLED").
+ * @param count Number of macros.
+ * @return Heap-allocated string with injected defines. Result must be freed.
+ */
+char* shader_inject_defines(const char* source, const char** defines, int count);
 
 /**
  * @brief Helper to load a classic Vertex+Fragment program from disk.
@@ -73,6 +98,15 @@ typedef struct {
  * @return Pointer to the Shader object.
  */
 Shader* shader_load(const char* vertex_path, const char* fragment_path);
+
+/**
+ * @brief Creates a shader object from source strings.
+ * @param vert_src Vertex shader source.
+ * @param frag_src Fragment shader source.
+ * @param name Descriptive name for the shader.
+ * @return Pointer to the Shader object.
+ */
+Shader* shader_create_from_source(const char* vert_src, const char* frag_src, const char* name);
 
 /**
  * @brief Loads a compute program and caches its uniforms.

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -1,5 +1,6 @@
 #include "postprocess.h"
 
+#include "app_settings.h"
 #include "effects/fx_auto_exposure.h"
 #include "effects/fx_bloom.h"
 #include "effects/fx_dof.h"
@@ -146,6 +147,22 @@ int postprocess_init(PostProcess* post_processing, int width, int height)
 		return 0;
 	}
 
+	/* Cache shader sources to avoid repeated I/O during recompilation */
+	post_processing->cached_vert_src =
+	    shader_read_resolved_source("shaders/postprocess.vert");
+	post_processing->cached_frag_src =
+	    shader_read_resolved_source("shaders/postprocess.frag");
+
+	if (!post_processing->cached_vert_src ||
+	    !post_processing->cached_frag_src) {
+		LOG_ERROR("suckless-ogl.postprocess",
+		          "Failed to load postprocess shader sources");
+		destroy_framebuffer(post_processing);
+		fx_bloom_cleanup(post_processing);
+		destroy_screen_quad(post_processing);
+		return 0;
+	}
+
 	/* Charger le shader de post-processing (Optimized Mode) */
 	postprocess_compile_optimized(post_processing,
 	                              post_processing->active_effects);
@@ -221,6 +238,16 @@ void postprocess_cleanup(PostProcess* post_processing)
 		}
 		post_processing->postprocess_shader = NULL;
 	}
+
+	if (post_processing->cached_vert_src) {
+		free(post_processing->cached_vert_src);
+		post_processing->cached_vert_src = NULL;
+	}
+	if (post_processing->cached_frag_src) {
+		free(post_processing->cached_frag_src);
+		post_processing->cached_frag_src = NULL;
+	}
+
 	fx_bloom_cleanup(post_processing);
 	fx_dof_cleanup(post_processing);
 	fx_auto_exposure_cleanup(post_processing);
@@ -939,9 +966,23 @@ void postprocess_compile_optimized(PostProcess* post_processing,
 		count++;
 	}
 
-	Shader* new_shader = shader_load_with_defines(
-	    "shaders/postprocess.vert", "shaders/postprocess.frag", defines,
-	    count);
+#ifdef USE_TRANSPARENT_BILLBOARDS
+	if (count < MAX_SHADER_DEFINES) {
+		defines[count++] = "USE_TRANSPARENT_BILLBOARDS";
+	}
+#endif
+
+	/* Use cached source strings to avoid I/O */
+	char* vert_src = shader_inject_defines(post_processing->cached_vert_src,
+	                                       defines, count);
+	char* frag_src = shader_inject_defines(post_processing->cached_frag_src,
+	                                       defines, count);
+
+	Shader* new_shader = shader_create_from_source(
+	    vert_src, frag_src, "shaders/postprocess.vert + shaders/postprocess.frag");
+
+	free(vert_src);
+	free(frag_src);
 
 	if (new_shader) {
 		update_current_shader(post_processing, new_shader, true);

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -979,7 +979,8 @@ void postprocess_compile_optimized(PostProcess* post_processing,
 	                                       defines, count);
 
 	Shader* new_shader = shader_create_from_source(
-	    vert_src, frag_src, "shaders/postprocess.vert + shaders/postprocess.frag");
+	    vert_src, frag_src,
+	    "shaders/postprocess.vert + shaders/postprocess.frag");
 
 	free(vert_src);
 	free(frag_src);

--- a/src/shader.c
+++ b/src/shader.c
@@ -726,14 +726,17 @@ Shader* shader_load(const char* vertex_path, const char* fragment_path)
 	return shader_load_with_defines(vertex_path, fragment_path, NULL, 0);
 }
 
-Shader* shader_create_from_source(const char* vert_src, const char* frag_src, const char* name)
+Shader* shader_create_from_source(const char* vert_src, const char* frag_src,
+                                  const char* name)
 {
-	GLuint vertex_shader = shader_compile_from_source(vert_src, GL_VERTEX_SHADER);
+	GLuint vertex_shader =
+	    shader_compile_from_source(vert_src, GL_VERTEX_SHADER);
 	if (vertex_shader == 0) {
 		return NULL;
 	}
 
-	GLuint fragment_shader = shader_compile_from_source(frag_src, GL_FRAGMENT_SHADER);
+	GLuint fragment_shader =
+	    shader_compile_from_source(frag_src, GL_FRAGMENT_SHADER);
 	if (fragment_shader == 0) {
 		glDeleteShader(vertex_shader);
 		return NULL;
@@ -749,8 +752,8 @@ Shader* shader_create_from_source(const char* vert_src, const char* frag_src, co
 	if (success == 0) {
 		char log[INFO_LOG_SIZE];
 		glGetProgramInfoLog(program, INFO_LOG_SIZE, NULL, log);
-		LOG_ERROR("suckless-ogl.shader", "Shader linking error (from source):\n%s",
-		          log);
+		LOG_ERROR("suckless-ogl.shader",
+		          "Shader linking error (from source):\n%s", log);
 		glDeleteProgram(program);
 		program = 0;
 	}

--- a/src/shader.c
+++ b/src/shader.c
@@ -68,6 +68,9 @@ enum { HEADER_TAG_LEN = 7 };
 static bool process_source(IncludeContext* ctx, const char* current_file_src,
                            const char* current_file_path);
 
+char* shader_read_file_with_defines(const char* path, const char** defines,
+                                    int count);
+
 /*
  * Reads an entire file into a null-terminated string.
  * This is the only place doing raw I/O and malloc for file content.
@@ -361,9 +364,10 @@ static bool process_source(IncludeContext* ctx, const char* current_file_src,
  * Handles insertion after #version directive if present.
  * Returns a newly allocated string that must be freed by caller.
  */
-static char* inject_defines_into_source(const char* buffer, size_t file_size,
-                                        const char** defines, int count)
+char* shader_inject_defines(const char* buffer, const char** defines, int count)
 {
+	size_t file_size = strlen(buffer);
+
 	if (count <= 0 || !defines) {
 		char* copy = safe_calloc(file_size + 1, 1);
 		safe_memcpy(copy, file_size + 1, buffer, file_size);
@@ -425,12 +429,58 @@ static char* inject_defines_into_source(const char* buffer, size_t file_size,
 
 enum { MAX_DEFINES = 32 };
 
-char* shader_read_file_with_defines(const char* path, const char** defines,
-                                    int count)
+char* shader_read_resolved_source(const char* path)
 {
 	/* 1. Load root file */
 	CLEANUP_FREE char* root_src = load_file_into_ram(path);
 	if (!root_src) {
+		return NULL;
+	}
+
+	/* 2. Setup Context */
+	CLEANUP_CTX IncludeContext ctx = {0};
+	ctx_add_buffer(&ctx, TRANSFER_OWNERSHIP(root_src));
+
+	/* 3. Recursively parse and build chunk list */
+	if (!process_source(&ctx, ctx.buffers_head->data, path)) {
+		return NULL;
+	}
+
+	/* 4. Single Allocation for final result */
+	CLEANUP_FREE char* final_src = safe_calloc(ctx.total_size + 1, 1);
+	if (!final_src) {
+		LOG_ERROR("suckless-ogl.shader",
+		          "Final allocation failed (%lu bytes)",
+		          ctx.total_size);
+		return NULL;
+	}
+
+	/* 5. Assemble */
+	char* wptr = final_src;
+	Chunk* node = ctx.chunks_head;
+	while (node) {
+		safe_memcpy(wptr,
+		            ctx.total_size + 1 - (size_t)(wptr - final_src),
+		            node->ptr, node->len);
+		wptr += node->len;
+		node = node->next;
+	}
+	*wptr = '\0'; /* Null terminate */
+
+	return TRANSFER_OWNERSHIP(final_src);
+}
+
+char* shader_read_file(const char* path)
+{
+	return shader_read_file_with_defines(path, NULL, 0);
+}
+
+char* shader_read_file_with_defines(const char* path, const char** defines,
+                                    int count)
+{
+	/* 1. Read resolved source (recurse headers) */
+	CLEANUP_FREE char* resolved_src = shader_read_resolved_source(path);
+	if (!resolved_src) {
 		return NULL;
 	}
 
@@ -451,53 +501,39 @@ char* shader_read_file_with_defines(const char* path, const char** defines,
 	}
 
 	if (total_defines > 0) {
-		char* modified_root = inject_defines_into_source(
-		    root_src, strlen(root_src), all_defines, total_defines);
-		if (!modified_root) {
-			return NULL; /* raii frees root_src */
-		}
-		/* Swap */
-		free(TRANSFER_OWNERSHIP(
-		    root_src)); /* Free original raw buffer */
-		root_src = modified_root;
+		return shader_inject_defines(resolved_src, all_defines,
+		                             total_defines);
 	}
 
-	/* 3. Setup Context */
-	CLEANUP_CTX IncludeContext ctx = {0};
-	ctx_add_buffer(&ctx, TRANSFER_OWNERSHIP(root_src));
-
-	/* 4. Recursively parse and build chunk list */
-	if (!process_source(&ctx, ctx.buffers_head->data, path)) {
-		return NULL;
-	}
-
-	/* 5. Single Allocation for final result */
-	CLEANUP_FREE char* final_src = safe_calloc(ctx.total_size + 1, 1);
-	if (!final_src) {
-		LOG_ERROR("suckless-ogl.shader",
-		          "Final allocation failed (%lu bytes)",
-		          ctx.total_size);
-		return NULL;
-	}
-
-	/* 6. Assemble */
-	char* wptr = final_src;
-	Chunk* node = ctx.chunks_head;
-	while (node) {
-		safe_memcpy(wptr,
-		            ctx.total_size + 1 - (size_t)(wptr - final_src),
-		            node->ptr, node->len);
-		wptr += node->len;
-		node = node->next;
-	}
-	*wptr = '\0'; /* Null terminate */
-
-	return TRANSFER_OWNERSHIP(final_src);
+	/* Return copy of resolved src if no defines */
+	size_t len = strlen(resolved_src);
+	char* copy = safe_calloc(len + 1, 1);
+	safe_memcpy(copy, len + 1, resolved_src, len);
+	return copy;
 }
 
-char* shader_read_file(const char* path)
+GLuint shader_compile_from_source(const char* source, GLenum type)
 {
-	return shader_read_file_with_defines(path, NULL, 0);
+	if (!source) {
+		return 0;
+	}
+
+	GLuint shader = glCreateShader(type);
+	glShaderSource(shader, 1, &source, NULL);
+	glCompileShader(shader);
+
+	int success = 0;
+	glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+	if (success == 0) {
+		char log[INFO_LOG_SIZE];
+		glGetShaderInfoLog(shader, INFO_LOG_SIZE, NULL, log);
+		LOG_ERROR("suckless-ogl.shader",
+		          "Shader compilation error (from source):\n%s", log);
+		glDeleteShader(shader);
+		return 0;
+	}
+
+	return shader;
 }
 
 GLuint shader_compile_with_defines(const char* path, GLenum type,
@@ -510,20 +546,11 @@ GLuint shader_compile_with_defines(const char* path, GLenum type,
 		return 0;
 	}
 
-	GLuint shader = glCreateShader(type);
-	glShaderSource(shader, 1, (const char**)&src, NULL);
-	glCompileShader(shader);
+	GLuint shader = shader_compile_from_source(src, type);
 	free(src);
 
-	int success = 0;
-	glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
-	if (success == 0) {
-		char log[INFO_LOG_SIZE];
-		glGetShaderInfoLog(shader, INFO_LOG_SIZE, NULL, log);
-		LOG_ERROR("suckless-ogl.shader",
-		          "Shader compilation error (%s):\n%s", path, log);
-		glDeleteShader(shader);
-		return 0;
+	if (shader == 0) {
+		LOG_ERROR("suckless-ogl.shader", "Failed to compile %s", path);
 	}
 
 	return shader;
@@ -697,6 +724,45 @@ static Shader* shader_create_from_program(GLuint program, const char* name)
 Shader* shader_load(const char* vertex_path, const char* fragment_path)
 {
 	return shader_load_with_defines(vertex_path, fragment_path, NULL, 0);
+}
+
+Shader* shader_create_from_source(const char* vert_src, const char* frag_src, const char* name)
+{
+	GLuint vertex_shader = shader_compile_from_source(vert_src, GL_VERTEX_SHADER);
+	if (vertex_shader == 0) {
+		return NULL;
+	}
+
+	GLuint fragment_shader = shader_compile_from_source(frag_src, GL_FRAGMENT_SHADER);
+	if (fragment_shader == 0) {
+		glDeleteShader(vertex_shader);
+		return NULL;
+	}
+
+	GLuint program = glCreateProgram();
+	glAttachShader(program, vertex_shader);
+	glAttachShader(program, fragment_shader);
+	glLinkProgram(program);
+
+	int success = 0;
+	glGetProgramiv(program, GL_LINK_STATUS, &success);
+	if (success == 0) {
+		char log[INFO_LOG_SIZE];
+		glGetProgramInfoLog(program, INFO_LOG_SIZE, NULL, log);
+		LOG_ERROR("suckless-ogl.shader", "Shader linking error (from source):\n%s",
+		          log);
+		glDeleteProgram(program);
+		program = 0;
+	}
+
+	glDeleteShader(vertex_shader);
+	glDeleteShader(fragment_shader);
+
+	if (program == 0) {
+		return NULL;
+	}
+
+	return shader_create_from_program(program, name);
 }
 
 Shader* shader_load_with_defines(const char* vertex_path,

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,705 @@
+2026-02-04 22:53:39,913 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:39,914 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:39,915 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:39,920 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:39,920 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:39,920 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:39,920 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:39,920 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:39,920 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:39,922 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:39,922 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (640x480)
+2026-02-04 22:53:39,923 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:328:test_postprocess_init_creates_resources:PASS
+2026-02-04 22:53:40,067 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,068 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,069 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,073 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,073 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,073 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,073 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,073 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,073 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,074 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,075 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,075 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:329:test_postprocess_defaults:PASS
+2026-02-04 22:53:40,197 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,197 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,198 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,202 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,202 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,202 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,202 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,202 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,202 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,203 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,203 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,203 [8290:8290] - suckless-ogl.postprocess - INFO     - State changed in optimized mode - recompiling shader...
+2026-02-04 22:53:40,208 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 24). Binary size: 30573 bytes
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001025)
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     - State changed in optimized mode - recompiling shader...
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00001024
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     - State changed in optimized mode - recompiling shader...
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00001025
+2026-02-04 22:53:40,208 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:330:test_postprocess_toggle_effects:PASS
+2026-02-04 22:53:40,328 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,329 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,330 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,333 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,333 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,333 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,333 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,333 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,333 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,335 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,335 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,335 [8290:8290] - suckless-ogl.postprocess - INFO     - State changed in optimized mode - recompiling shader...
+2026-02-04 22:53:40,337 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 24). Binary size: 25469 bytes
+2026-02-04 22:53:40,337 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,337 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,337 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,337 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,337 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:40,337 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,337 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000002F)
+2026-02-04 22:53:40,338 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:331:test_postprocess_apply_preset:PASS
+2026-02-04 22:53:40,457 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,458 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,458 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,462 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,462 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,462 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,462 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,462 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,462 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,463 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,464 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,465 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,465 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,466 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,466 [8290:8290] - suckless-ogl.postprocess - INFO     - Resized to 200x200
+2026-02-04 22:53:40,466 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:332:test_postprocess_resize:PASS
+2026-02-04 22:53:40,584 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,585 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,585 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,589 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,589 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,589 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,589 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,589 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,589 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,590 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,590 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,597 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 24). Binary size: 46165 bytes
+2026-02-04 22:53:40,597 [8290:8290] - suckless-ogl.postprocess - INFO     - Switched to DYNAMIC shader
+2026-02-04 22:53:40,599 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 27). Binary size: 23317 bytes
+2026-02-04 22:53:40,600 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,600 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,600 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,600 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000003)
+2026-02-04 22:53:40,600 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:333:test_postprocess_optimization_switch:PASS
+2026-02-04 22:53:40,719 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,720 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,720 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,724 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,724 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,724 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,724 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,724 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,724 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,725 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,726 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,726 [8290:8290] - suckless-ogl.postprocess - INFO     - State changed in optimized mode - recompiling shader...
+2026-02-04 22:53:40,728 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 24). Binary size: 28973 bytes
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Depth of Field
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Auto-Exposure
+2026-02-04 22:53:40,728 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Motion Blur
+2026-02-04 22:53:40,729 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000573)
+2026-02-04 22:53:40,729 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:334:test_postprocess_optimized_preset_switch:PASS
+2026-02-04 22:53:40,847 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,848 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,849 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,852 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,852 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,852 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,852 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,852 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,852 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,854 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,854 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,855 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 24). Binary size: 23317 bytes
+2026-02-04 22:53:40,855 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,856 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,856 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,856 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000003)
+2026-02-04 22:53:40,857 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 27). Binary size: 23621 bytes
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000013)
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:40,857 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+Benchmark Time: 0.003265 seconds
+2026-02-04 22:53:40,858 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:335:test_postprocess_recompilation_benchmark:PASS
+2026-02-04 22:53:40,977 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:40,977 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:40,978 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:40,981 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:40,982 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,982 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,982 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:40,982 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:40,982 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:40,983 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:40,983 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:40,984 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 24). Binary size: 21493 bytes
+2026-02-04 22:53:40,984 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,984 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000000)
+2026-02-04 22:53:40,985 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 27). Binary size: 22157 bytes
+2026-02-04 22:53:40,985 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,985 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,986 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000001)
+2026-02-04 22:53:40,987 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 30). Binary size: 22669 bytes
+2026-02-04 22:53:40,987 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,987 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,987 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000002)
+2026-02-04 22:53:40,989 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 33). Binary size: 23317 bytes
+2026-02-04 22:53:40,989 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,989 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,989 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,989 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000003)
+2026-02-04 22:53:40,990 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 36). Binary size: 21565 bytes
+2026-02-04 22:53:40,990 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,990 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,990 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000004)
+2026-02-04 22:53:40,992 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 39). Binary size: 22229 bytes
+2026-02-04 22:53:40,992 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,992 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,992 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,992 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000005)
+2026-02-04 22:53:40,994 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 42). Binary size: 22741 bytes
+2026-02-04 22:53:40,994 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,994 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,994 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,994 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000006)
+2026-02-04 22:53:40,996 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 45). Binary size: 23389 bytes
+2026-02-04 22:53:40,996 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,996 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,996 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:40,996 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:40,996 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000007)
+2026-02-04 22:53:40,997 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 48). Binary size: 22157 bytes
+2026-02-04 22:53:40,997 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,997 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:40,997 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000008)
+2026-02-04 22:53:40,999 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 51). Binary size: 22813 bytes
+2026-02-04 22:53:40,999 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:40,999 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:40,999 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:40,999 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000009)
+2026-02-04 22:53:41,001 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 54). Binary size: 23333 bytes
+2026-02-04 22:53:41,001 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,001 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,001 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,001 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000A)
+2026-02-04 22:53:41,003 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 57). Binary size: 23981 bytes
+2026-02-04 22:53:41,003 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,003 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,003 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,003 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,003 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000B)
+2026-02-04 22:53:41,004 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 60). Binary size: 22253 bytes
+2026-02-04 22:53:41,004 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,004 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,004 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,004 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000C)
+2026-02-04 22:53:41,006 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 63). Binary size: 22909 bytes
+2026-02-04 22:53:41,006 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,006 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,006 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,006 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,006 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000D)
+2026-02-04 22:53:41,008 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 66). Binary size: 23429 bytes
+2026-02-04 22:53:41,008 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,008 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,008 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,008 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,008 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000E)
+2026-02-04 22:53:41,010 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 69). Binary size: 24077 bytes
+2026-02-04 22:53:41,010 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,010 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,010 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,010 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,010 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,010 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000F)
+2026-02-04 22:53:41,012 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 72). Binary size: 21797 bytes
+2026-02-04 22:53:41,012 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,012 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,012 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000010)
+2026-02-04 22:53:41,013 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 75). Binary size: 22461 bytes
+2026-02-04 22:53:41,013 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,013 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,013 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,013 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000011)
+2026-02-04 22:53:41,015 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 78). Binary size: 22973 bytes
+2026-02-04 22:53:41,015 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,015 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,015 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,015 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000012)
+2026-02-04 22:53:41,017 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 81). Binary size: 23621 bytes
+2026-02-04 22:53:41,017 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,017 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,017 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,017 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,017 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000013)
+2026-02-04 22:53:41,019 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 84). Binary size: 21893 bytes
+2026-02-04 22:53:41,019 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,019 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,019 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,019 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000014)
+2026-02-04 22:53:41,020 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 87). Binary size: 22557 bytes
+2026-02-04 22:53:41,020 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,020 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,020 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,020 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,020 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000015)
+2026-02-04 22:53:41,022 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 90). Binary size: 23069 bytes
+2026-02-04 22:53:41,022 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,022 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,022 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,022 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,022 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000016)
+2026-02-04 22:53:41,024 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 93). Binary size: 23717 bytes
+2026-02-04 22:53:41,024 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,024 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,024 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,024 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,024 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,024 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000017)
+2026-02-04 22:53:41,026 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 96). Binary size: 22477 bytes
+2026-02-04 22:53:41,026 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,026 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,026 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,026 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000018)
+2026-02-04 22:53:41,028 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 99). Binary size: 23141 bytes
+2026-02-04 22:53:41,028 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,028 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,028 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,028 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,028 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000019)
+2026-02-04 22:53:41,030 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 102). Binary size: 23653 bytes
+2026-02-04 22:53:41,030 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,030 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,030 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,030 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,030 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001A)
+2026-02-04 22:53:41,032 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 105). Binary size: 24301 bytes
+2026-02-04 22:53:41,032 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,032 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,032 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,032 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,032 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,032 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001B)
+2026-02-04 22:53:41,033 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 108). Binary size: 22573 bytes
+2026-02-04 22:53:41,033 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,033 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,033 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,033 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,033 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001C)
+2026-02-04 22:53:41,035 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 111). Binary size: 23237 bytes
+2026-02-04 22:53:41,035 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,035 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,035 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,035 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,035 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,035 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001D)
+2026-02-04 22:53:41,037 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 114). Binary size: 23749 bytes
+2026-02-04 22:53:41,037 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,037 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,037 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,037 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,037 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,037 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001E)
+2026-02-04 22:53:41,039 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 117). Binary size: 24397 bytes
+2026-02-04 22:53:41,039 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,039 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,039 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,039 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,039 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,039 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,039 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001F)
+2026-02-04 22:53:41,041 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 120). Binary size: 22909 bytes
+2026-02-04 22:53:41,041 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,041 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,041 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000020)
+2026-02-04 22:53:41,043 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 123). Binary size: 23565 bytes
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000021)
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,043 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+Overflow Benchmark Time: 0.004053 seconds
+2026-02-04 22:53:41,047 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:336:test_postprocess_cache_overflow_benchmark:PASS
+2026-02-04 22:53:41,165 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:41,165 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:41,166 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:41,170 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:41,170 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,170 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,170 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,170 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:41,170 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:41,171 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:41,172 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:41,173 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 24). Binary size: 21493 bytes
+2026-02-04 22:53:41,173 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,173 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000000)
+2026-02-04 22:53:41,174 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 27). Binary size: 22157 bytes
+2026-02-04 22:53:41,175 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,175 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,175 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000001)
+2026-02-04 22:53:41,176 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 30). Binary size: 22669 bytes
+2026-02-04 22:53:41,176 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,176 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,176 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000002)
+2026-02-04 22:53:41,178 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 33). Binary size: 23317 bytes
+2026-02-04 22:53:41,178 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,178 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,178 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,178 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000003)
+2026-02-04 22:53:41,179 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 36). Binary size: 21565 bytes
+2026-02-04 22:53:41,179 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,179 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,179 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000004)
+2026-02-04 22:53:41,181 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 39). Binary size: 22229 bytes
+2026-02-04 22:53:41,181 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,181 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,181 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,181 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000005)
+2026-02-04 22:53:41,182 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 42). Binary size: 22741 bytes
+2026-02-04 22:53:41,182 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,182 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,182 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,182 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000006)
+2026-02-04 22:53:41,183 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 45). Binary size: 23389 bytes
+2026-02-04 22:53:41,184 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,184 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,184 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,184 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,184 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000007)
+2026-02-04 22:53:41,185 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 48). Binary size: 22157 bytes
+2026-02-04 22:53:41,185 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,185 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,185 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000008)
+2026-02-04 22:53:41,186 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 51). Binary size: 22813 bytes
+2026-02-04 22:53:41,186 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,186 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,186 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,186 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000009)
+2026-02-04 22:53:41,187 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 54). Binary size: 23333 bytes
+2026-02-04 22:53:41,187 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,187 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,187 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,187 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000A)
+2026-02-04 22:53:41,189 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 57). Binary size: 23981 bytes
+2026-02-04 22:53:41,189 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,189 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,189 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,189 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,189 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000B)
+2026-02-04 22:53:41,190 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 60). Binary size: 22253 bytes
+2026-02-04 22:53:41,190 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,190 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,190 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,190 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000C)
+2026-02-04 22:53:41,191 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 63). Binary size: 22909 bytes
+2026-02-04 22:53:41,192 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,192 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,192 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,192 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,192 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000D)
+2026-02-04 22:53:41,193 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 66). Binary size: 23429 bytes
+2026-02-04 22:53:41,193 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,193 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,193 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,193 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,193 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000E)
+2026-02-04 22:53:41,195 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 69). Binary size: 24077 bytes
+2026-02-04 22:53:41,195 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,195 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,195 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,195 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,195 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,195 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000000F)
+2026-02-04 22:53:41,196 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 72). Binary size: 21797 bytes
+2026-02-04 22:53:41,196 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,196 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,196 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000010)
+2026-02-04 22:53:41,197 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 75). Binary size: 22461 bytes
+2026-02-04 22:53:41,197 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,197 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,197 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,197 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000011)
+2026-02-04 22:53:41,199 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 78). Binary size: 22973 bytes
+2026-02-04 22:53:41,199 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,199 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,199 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,199 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000012)
+2026-02-04 22:53:41,201 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 81). Binary size: 23621 bytes
+2026-02-04 22:53:41,201 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,201 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,201 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,201 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,201 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000013)
+2026-02-04 22:53:41,202 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 84). Binary size: 21893 bytes
+2026-02-04 22:53:41,202 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,202 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,202 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,202 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000014)
+2026-02-04 22:53:41,204 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 87). Binary size: 22557 bytes
+2026-02-04 22:53:41,204 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,204 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,204 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,204 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,204 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000015)
+2026-02-04 22:53:41,205 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 90). Binary size: 23069 bytes
+2026-02-04 22:53:41,205 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,205 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,205 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,205 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,205 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000016)
+2026-02-04 22:53:41,207 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 93). Binary size: 23717 bytes
+2026-02-04 22:53:41,207 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,207 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,207 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,207 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,207 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,207 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000017)
+2026-02-04 22:53:41,208 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 96). Binary size: 22477 bytes
+2026-02-04 22:53:41,208 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,208 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,208 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,208 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000018)
+2026-02-04 22:53:41,210 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 99). Binary size: 23141 bytes
+2026-02-04 22:53:41,210 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,210 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,210 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,210 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,210 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000019)
+2026-02-04 22:53:41,211 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 102). Binary size: 23653 bytes
+2026-02-04 22:53:41,212 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,212 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,212 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,212 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,212 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001A)
+2026-02-04 22:53:41,213 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 105). Binary size: 24301 bytes
+2026-02-04 22:53:41,213 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,213 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,213 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,213 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,213 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,213 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001B)
+2026-02-04 22:53:41,215 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 108). Binary size: 22573 bytes
+2026-02-04 22:53:41,215 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,215 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,215 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,215 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,215 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001C)
+2026-02-04 22:53:41,216 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 111). Binary size: 23237 bytes
+2026-02-04 22:53:41,216 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,216 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,216 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,216 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,216 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,216 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001D)
+2026-02-04 22:53:41,218 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 114). Binary size: 23749 bytes
+2026-02-04 22:53:41,218 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,218 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,218 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,218 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,218 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,218 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001E)
+2026-02-04 22:53:41,220 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 117). Binary size: 24397 bytes
+2026-02-04 22:53:41,220 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,220 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,220 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,220 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,220 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Chromatic Aberration
+2026-02-04 22:53:41,220 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Bloom
+2026-02-04 22:53:41,220 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x0000001F)
+2026-02-04 22:53:41,222 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 120). Binary size: 22909 bytes
+2026-02-04 22:53:41,222 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,222 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,222 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000020)
+2026-02-04 22:53:41,224 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 123). Binary size: 23565 bytes
+2026-02-04 22:53:41,224 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,224 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,224 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,224 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000021)
+2026-02-04 22:53:41,226 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 126). Binary size: 24085 bytes
+2026-02-04 22:53:41,226 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,226 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,226 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,226 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000022)
+2026-02-04 22:53:41,228 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 129). Binary size: 24725 bytes
+2026-02-04 22:53:41,228 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,228 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,228 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,228 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,228 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000023)
+2026-02-04 22:53:41,230 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 132). Binary size: 22965 bytes
+2026-02-04 22:53:41,230 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,230 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,230 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,230 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000024)
+2026-02-04 22:53:41,237 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 135). Binary size: 23621 bytes
+2026-02-04 22:53:41,237 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,237 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,237 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,237 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,237 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000025)
+2026-02-04 22:53:41,242 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 138). Binary size: 24141 bytes
+2026-02-04 22:53:41,242 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,242 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,242 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,242 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,242 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000026)
+2026-02-04 22:53:41,245 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 141). Binary size: 24789 bytes
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Vignette
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Film Grain
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00000027)
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000000
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000001
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000002
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000003
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000004
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000005
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000006
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000007
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000008
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000009
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000000A
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000000B
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000000C
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000000D
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000000E
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000000F
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000010
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000011
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000012
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000013
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000014
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000015
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000016
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000017
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000018
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000019
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000001A
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000001B
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000001C
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000001D
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000001E
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x0000001F
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000020
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000021
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000022
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000023
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000024
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000025
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000026
+2026-02-04 22:53:41,245 [8290:8290] - suckless-ogl.postprocess - INFO     - Using CACHED shader for flags 0x00000027
+Large Working Set Time: 0.000335 seconds
+2026-02-04 22:53:41,249 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:337:test_postprocess_large_working_set:PASS
+2026-02-04 22:53:41,369 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 7). Binary size: 5293 bytes
+2026-02-04 22:53:41,370 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 10). Binary size: 6369 bytes
+2026-02-04 22:53:41,370 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 13). Binary size: 5685 bytes
+2026-02-04 22:53:41,374 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 16). Binary size: 29925 bytes
+2026-02-04 22:53:41,374 [8290:8290] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
+2026-02-04 22:53:41,374 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Manual Exposure
+2026-02-04 22:53:41,374 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ Color Grading
+2026-02-04 22:53:41,374 [8290:8290] - suckless-ogl.postprocess - INFO     -   ✓ FXAA
+2026-02-04 22:53:41,374 [8290:8290] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
+2026-02-04 22:53:41,375 [8290:8290] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 19). Binary size: 8289 bytes
+2026-02-04 22:53:41,375 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing initialized (100x100)
+2026-02-04 22:53:41,376 [8290:8290] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
+/app/tests/test_postprocess.c:338:test_postprocess_cleanup:PASS
+
+-----------------------
+11 Tests 0 Failures 0 Ignored
+OK


### PR DESCRIPTION
- Refactored `src/shader.c` to expose `shader_read_resolved_source`, `shader_inject_defines`, and `shader_create_from_source`.
- Optimized `src/postprocess.c` to cache resolved shader source strings in memory.
- `postprocess_compile_optimized` now uses cached source + in-memory define injection instead of reloading files from disk.
- Ensures `USE_TRANSPARENT_BILLBOARDS` is correctly handled in manual compilation path to avoid visual regression.
- Performance: Eliminates file I/O and recursive include parsing during shader variant recompilation.
- Verification: `test_postprocess` benchmarks passed, `test_shader` passed, `test_app` passed.

---
*PR created automatically by Jules for task [6367929974988798736](https://jules.google.com/task/6367929974988798736) started by @yoyonel*