### PR TITLE
fix(ci): resolve nightly release issues & add automated schedule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ on:
     # Pour tout le reste, on passe par les PRs (master/main comme cibles)
     # Cela garantit un seul run par commit dans une PR
     branches: ["master", "main"]
+  schedule:
+    # Build nightly tous les jours à 01h00 UTC
+    - cron: '0 1 * * *'
 
 jobs:
   # --- JOB 1 : QUALITÉ ET LINT (RAPIDE) ---
@@ -281,17 +284,32 @@ jobs:
   # --- JOB 5 : RELEASE ---
   release:
     needs: build-production
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Nécessaire pour les tags
+
       - uses: actions/download-artifact@v4
         with: { path: artifacts }
+
+      - name: Update Nightly Tag
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # On supprime le tag localment et on le recrée sur le commit actuel
+          git tag -f nightly
+          git push origin nightly --force
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref == 'refs/heads/master' && 'nightly' || github.ref_name }}
-          prerelease: ${{ github.ref == 'refs/heads/master' }}
+          tag_name: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && 'nightly' || github.ref_name }}
+          name: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && 'Nightly Build' || github.ref_name }}
+          prerelease: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+          draft: false
           files: artifacts/app-*/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/cicd_pipeline.md
+++ b/docs/cicd_pipeline.md
@@ -1,0 +1,86 @@
+# CI/CD Pipeline & Release Process
+
+This document details the automated Continuous Integration and Continuous Deployment (CI/CD) pipeline for **Suckless-OGL**, managed via **GitHub Actions**.
+
+## Overview
+
+The pipeline is defined in `.github/workflows/main.yml`. It ensures code quality, runs tests, generates documentation, and handles automated releases.
+
+## Triggers
+
+The workflow is triggered automatically events:
+
+1.  **Push to `master` or `main`**:
+    - Triggers the full pipeline (Lint, Test, Docs, Build).
+    - Updates the **Nightly Release**.
+    - Deploys the latest documentation to GitHub Pages.
+2.  **Pull Requests**:
+    - Runs quality checks (Lint, Format).
+    - Runs unit tests and visual regression tests.
+    - Generates a documentation preview (deployed to Surge.sh).
+3.  **Tags (`v*`)**:
+    - Triggers a **Stable Release** build.
+    - Creates a GitHub Release with the corresponding version number.
+4.  **Schedule (Cron)**:
+    - Runs daily at **01:00 UTC**.
+    - Ensures a fresh **Nightly Build** is generated every day from the latest code.
+
+## Workflow Jobs
+
+### 1. `lint-and-format` (Quality)
+- **Goal**: Ensure code style and quality.
+- **Tools**: `clang-format`, `clang-tidy`, `ruff` (Python).
+- **Checks**:
+    - Fails if `make format` results in file changes (enforces code style).
+    - Runs `make lint` for static analysis.
+
+### 2. `test-and-coverage` (Validation)
+- **Goal**: Verify functionality and prevent regressions.
+- **Environment**: Runs under **Xvfb** (Virtual Framebuffer) to simulate a display server for OpenGL tests.
+- **Steps**:
+    - Runs Python tests (`pytest`).
+    - Runs C Unit Tests with Code Coverage (`llvm-cov`).
+    - **Visual Regression**: Captures rendered frames and compares them against reference images.
+    - Generates a visual diff report if changes are detected.
+
+### 3. `documentation` (Docs)
+- **Goal**: Generate and publish technical documentation.
+- **Tools**: Doxygen, Graphviz, MkDocs.
+- **Outputs**:
+    - Combines manual Markdown docs and auto-generated C API docs.
+    - **Pull Requests**: Deploys a preview link to [Surge.sh](https://surge.sh).
+    - **Master/Main**: Prepares artifacts for GitHub Pages deployment.
+
+### 4. `build-production` (Compilation)
+- **Goal**: Compile optimized binaries for users.
+- **Configurations**:
+    - **Release**: Standard optimized build (`-O2` / `-O3`).
+    - **Profiling**: Includes symbols and profiling markers.
+    - **UltraRelease**: Aggressive optimizations (`-DENABLE_UNITY_BUILD`, `-march=native`, `-ffast-math`).
+- **Artifacts**: Binaries are saved for the Release step.
+
+### 5. `deploy-pages` (Web)
+- **Goal**: Update the official documentation site.
+- **Trigger**: Only on `master` or `main` push.
+- **Action**: Deploys the content of the `documentation` job to GitHub Pages.
+
+### 6. `release` (Distribution)
+- **Goal**: Publish binaries and source code.
+- **Logic**:
+    - **Nightly**:
+        - Triggered by push to `master/main` OR daily schedule.
+        - Updates the `nightly` git tag to the current commit.
+        - Overwrites the "Nightly Build" release with new assets.
+        - **NOT a Draft**: Immediately available.
+    - **Stable (Tagged)**:
+        - Triggered by pushing a tag like `v1.0.0`.
+        - Creates a new standard release titled with the version name.
+
+## Release Artifacts
+
+Each release (Nightly or Stable) contains:
+
+- `app-Release`: The main executable.
+- `app-Profiling`: Version for performance analysis.
+- `app-UltraRelease`: Experimental high-performance build.
+- Source code archives (`zip`, `tar.gz`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,16 +48,18 @@ The build is configured with the following settings:
 
 ## 🤖 CI/CD Workflow (GitHub Actions)
 
-The pipeline is structured to optimize the build while guaranteeing maximum quality:
+## 🤖 CI/CD Workflow (GitHub Actions)
 
-1. **Test & Coverage**: Instrumented compilation and test execution under **Xvfb** (virtual X server). A coverage report is generated and saved as an artifact.
-2. **Lint & Format Check**:
-   - Verifies that the code is formatted. If `make format` modifies a file, the CI fails.
-   - Runs `make lint` to validate CERT compliance and security.
-3. **Build & Release**:
-   - Triggers on `master` or `v*` tags.
-   - Packages the `app` binary with `assets/` and `shaders/` directories.
-   - Compresses everything into a `.tar.gz` archive and creates an automatic **GitHub Release**.
+The pipeline is structured to optimize the build while guaranteeing maximum quality. It handles Testing, Quality Assurance, Documentation, and Automated Releases.
+
+**[> Read the full CI/CD Pipeline Documentation](cicd_pipeline.md)**
+
+### Quick Summary
+1. **Test & Coverage**: Instrumented compilation and test execution under **Xvfb**.
+2. **Lint & Format**: Enforces styling (`clang-format`) and static analysis (`clang-tidy`).
+3. **Automated Releases**:
+   - **Nightly**: Built every night at 01:00 UTC and on every push to master.
+   - **Stable**: Triggered by version tags (`v*`).
 
 ## 📁 Project Structure
 - `src/` & `include/`: Engine core (Log, App, Shader, Texture, Icosphere).


### PR DESCRIPTION
## 📝 Summary
This PR fixes the automated release workflow which was failing to correctly update the "Nightly" release. It also creates a dedicated documentation page for the CI/CD pipeline.

## 🛠️ Changes

### 🤖 CI/CD ([.github/workflows/main.yml](cci:7://file:///home/latty/Prog/__PERSO__/suckless-ogl/.github/workflows/main.yml:0:0-0:0))
- **Fix Nightly Tag**: The workflow now correctly forces the update of the `nightly` tag (`git tag -f`) to point to the latest commit.
- **Fix Release State**: Releases are no longer created as "Drafts" by default ensuring they are immediately available.
- **New Schedule**: Added a cron trigger to Build & Release a fresh **Nightly Build every day at 01:00 UTC**.
- **Main Branch Support**: Added explicit support for the `main` branch alongside `master`.

### 📚 Documentation
- **New Page**: Added [docs/cicd_pipeline.md](cci:7://file:///home/latty/Prog/__PERSO__/suckless-ogl/docs/cicd_pipeline.md:0:0-0:0) which details the entire pipeline (Triggers, Jobs, Release logic).
- **Update**: Updated [docs/index.md](cci:7://file:///home/latty/Prog/__PERSO__/suckless-ogl/docs/index.md:0:0-0:0) to link to this new documentation.

## 🧪 Verification
- [x] Push to branch triggers the workflow.
- [ ] Verify that the next run on `master` correctly moves the `nightly` tag and updates the release assets.