### PR TITLE
🛡️ Sentinel: [Enhancement] Enforce path length limits in loaders

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `@header` directive in shaders allowed including files via relative paths containing `..`, enabling reading of arbitrary files (limited by process permissions) into the shader source.
 **Learning:** File inclusion mechanisms (like `@header`) must always sanitize input paths to prevent directory traversal. Concatenating paths is not enough; one must check for `..` or use path canonicalization.
 **Prevention:** Implemented `is_safe_path` to reject `..`, absolute paths, and drive letters in included paths.
+
+## 2026-02-05 - [Enhancement] Enforce Path Length Limits
+**Vulnerability:** Ignored return values of `safe_snprintf` in `async_loader.c` and `app_env.c` could lead to silent path truncation and potential logic errors or loading of incorrect files.
+**Learning:** Safe wrappers like `safe_snprintf` are only safe if their return values (indicating success/failure/truncation) are actually checked.
+**Prevention:** Always check the return value of string manipulation functions. If a path is truncated, treat it as a hard error/failure rather than proceeding.

--- a/src/app_env.c
+++ b/src/app_env.c
@@ -66,8 +66,12 @@ int app_load_env_map(App* app, const char* filename)
 	char path
 	    [256]; /* NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 	            */
-	(void)safe_snprintf(path, sizeof(path), "assets/textures/hdr/%s",
-	                    filename);
+	if (!safe_snprintf(path, sizeof(path), "assets/textures/hdr/%s",
+	                   filename)) {
+		LOG_ERROR("suckless-ogl.app", "Filename too long: %s",
+		          filename);
+		return 0;
+	}
 
 	LOG_INFO("suckless-ogl.app", "Queuing async load for: %s", path);
 	if (async_loader_request(path)) {

--- a/src/async_loader.c
+++ b/src/async_loader.c
@@ -157,12 +157,17 @@ bool async_loader_request(const char* path)
 			current_request.data = NULL;
 		}
 
-		(void)safe_snprintf(current_request.path,
-		                    sizeof(current_request.path), "%s", path);
-		current_request.state = ASYNC_PENDING;
-		has_pending_work = true;
-		pthread_cond_signal(&request_cond);
-		accepted = true;
+		if (!safe_snprintf(current_request.path,
+		                   sizeof(current_request.path), "%s", path)) {
+			LOG_ERROR("suckless-ogl.async", "Path too long: %s",
+			          path);
+			current_request.state = ASYNC_IDLE;
+		} else {
+			current_request.state = ASYNC_PENDING;
+			has_pending_work = true;
+			pthread_cond_signal(&request_cond);
+			accepted = true;
+		}
 	}
 
 	pthread_mutex_unlock(&request_mutex);

--- a/src/shader.c
+++ b/src/shader.c
@@ -232,8 +232,13 @@ static bool resolve_and_parse_include(IncludeContext* ctx,
 	get_dir_from_path(current_file_path, current_dir, sizeof(current_dir));
 
 	char resolved_path[RESOLVED_PATH_BUFFER_SIZE];
-	safe_snprintf(resolved_path, sizeof(resolved_path), "%s%s", current_dir,
-	              path_term);
+	if (!safe_snprintf(resolved_path, sizeof(resolved_path), "%s%s",
+	                   current_dir, path_term)) {
+		LOG_ERROR("suckless-ogl.shader",
+		          "Include path too long: %s (dir) + %s (term)",
+		          current_dir, path_term);
+		return false;
+	}
 
 	/* Load the included file */
 	char* inc_src = load_file_into_ram(resolved_path);


### PR DESCRIPTION
🛡️ Sentinel: [Enhancement] Enforce path length limits in loaders

**Severity:** MEDIUM (Defense in Depth / Error Handling)
**Vulnerability:** Ignored return values from `safe_snprintf` could allow silently truncated file paths to be processed. This typically leads to failed loads (e.g. `assets/text...` instead of `assets/textures/...`) but could theoretically point to valid but unintended files in edge cases or cause confusing application behavior.
**Fix:** Explicitly check the boolean return value of `safe_snprintf` (which returns `false` on truncation or error). If truncation occurs, log an error and abort the operation (return false/0/failure) instead of proceeding with the corrupted path.
**Verification:**
- Verified that `safe_snprintf` correctly returns `false` on truncation via a temporary test script.
- Verified that the codebase compiles and all existing tests pass with `ctest`.
- Verified that valid paths still work (no regression).

---
*PR created automatically by Jules for task [16197833427556306634](https://jules.google.com/task/16197833427556306634) started by @yoyonel*