### PR TITLE
Refactor: Cleanup leaks, dead code, and fix safety bugs

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -121,7 +121,6 @@ typedef struct App {
 	int show_exposure_debug;       /**< Enable auto-exposure histogram. */
 	int pbr_debug_mode;            /**< Swap to wireframe/normal/roughness
 	                                  visualization. */
-	int show_imgui_demo;           /**< Reserved for ImGui integration. */
 	int show_help;                 /**< Overlay help text. */
 	int show_info_overlay;         /**< Show FPS and stats. */
 	int text_overlay_mode;         /**< Verbosity level of text UI. */
@@ -133,9 +132,9 @@ typedef struct App {
 	int first_mouse;               /**< Input initialization flag. */
 	int camera_enabled;            /**< Pause camera movement. */
 	int billboard_mode;    /**< Toggle for billboard rendering path. */
-	int show_debug_tex;    /**< Reserved for texture debugging. */
 	int hdr_count;         /**< Number of available environment maps. */
 	int current_hdr_index; /**< Index of active HDR in file list. */
+	int banding_style_idx; /**< Cycle index for banding styles. */
 	int env_map_loading;   /**< Async lock for HDR loading. */
 	int perf_mode_active;  /**< Performance/GameMode optimization active. */
 	PerfModeContext perf_context; /**< Performance mode state context. */
@@ -168,7 +167,6 @@ typedef struct App {
 
 	/* --- Global Configuration Uniforms --- */
 	float env_lod;          /**< Skybox blurriness. */
-	float debug_lod;        /**< Reserved for texture debugging. */
 	float u_metallic;       /**< Override metallic for all objects. */
 	float u_roughness;      /**< Override roughness for all objects. */
 	float u_ao;             /**< Override AO for all objects. */

--- a/include/camera.h
+++ b/include/camera.h
@@ -69,6 +69,8 @@ typedef struct Camera {
 	float yaw_target;         /**< Target yaw to lerp towards. */
 	float pitch_target;       /**< Target pitch to lerp towards. */
 	float rotation_smoothing; /**< Interpolation factor for rotation. */
+	float smoothed_x;         /**< Input smoothing state X. */
+	float smoothed_y;         /**< Input smoothing state Y. */
 
 	/* Head bobbing */
 	float bobbing_time; /**< Accumulated time for the sine-wave oscillation.
@@ -101,13 +103,6 @@ void camera_init(Camera* cam, float distance, float yaw, float pitch);
  * @note Updates cam->front, cam->right, and cam->up.
  */
 void camera_update_vectors(Camera* cam);
-
-/**
- * @brief Legacy keyboard handling (variable timestep movement).
- * @param cam Pointer to the camera instance.
- * @param delta_time Time since last frame.
- */
-void camera_process_keyboard(Camera* cam, float delta_time);
 
 /**
  * @brief Processes mouse movement to update target orientation.

--- a/src/app.c
+++ b/src/app.c
@@ -260,6 +260,7 @@ void app_cleanup(App* app)
 	glDeleteBuffers(1, &app->wire_cube_vbo);
 	glDeleteBuffers(1, &app->wire_quad_vbo);
 	glDeleteBuffers(1, &app->quad_vbo);
+	glDeleteBuffers(2, app->lum_ssbo);
 
 	ui_destroy(&app->ui);
 	postprocess_cleanup(&app->postprocess);
@@ -367,19 +368,6 @@ void app_render(App* app)
 	postprocess_begin(&app->postprocess);
 	glClearColor(0.0F, 0.0F, 0.0F, 1.0F);
 
-	if (app->show_debug_tex) {
-		shader_use(app->debug_shader);
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, app->brdf_lut_tex);
-		shader_set_int(app->debug_shader, "tex", 0);
-		shader_set_float(app->debug_shader, "lod", app->debug_lod);
-		glBindVertexArray(app->empty_vao);
-		glDrawArrays(GL_TRIANGLES, 0, 3);
-		glBindVertexArray(0);
-		postprocess_end(&app->postprocess);
-		return;
-	}
-
 	mat4 view;
 	mat4 proj;
 	mat4 view_proj;
@@ -387,9 +375,13 @@ void app_render(App* app)
 	vec3 camera_pos = {app->camera.position[0], app->camera.position[1],
 	                   app->camera.position[2]};
 	camera_get_view_matrix(&app->camera, view);
-	glm_perspective(glm_rad(app->camera.zoom),
-	                (float)app->width / (float)app->height, NEAR_PLANE,
-	                FAR_PLANE, proj);
+	if (app->height > 0) {
+		glm_perspective(glm_rad(app->camera.zoom),
+		                (float)app->width / (float)app->height,
+		                NEAR_PLANE, FAR_PLANE, proj);
+	} else {
+		glm_mat4_identity(proj);
+	}
 	glm_mat4_mul(proj, view, view_proj);
 	glm_mat4_inv(view_proj, inv_view_proj);
 

--- a/src/app_env.c
+++ b/src/app_env.c
@@ -40,12 +40,19 @@ void app_scan_hdr_files(App* app)
 		while ((entry = readdir(dir_handle)) != NULL) {
 			char* dot = strrchr(entry->d_name, '.');
 			if (dot && strcmp(dot, ".hdr") == 0) {
-				app->hdr_count++;
-				app->hdr_files = realloc(
+				char** new_files = realloc(
 				    app->hdr_files,
-				    (size_t)app->hdr_count * sizeof(char*));
-				app->hdr_files[app->hdr_count - 1] =
-				    strdup(entry->d_name);
+				    (size_t)(app->hdr_count + 1) * sizeof(char*));
+				if (new_files) {
+					app->hdr_files = new_files;
+					app->hdr_count++;
+					app->hdr_files[app->hdr_count - 1] =
+					    strdup(entry->d_name);
+				} else {
+					LOG_ERROR("suckless-ogl.app",
+					          "Failed to realloc memory for "
+					          "HDR files");
+				}
 			}
 		}
 		closedir(dir_handle);

--- a/src/app_env.c
+++ b/src/app_env.c
@@ -40,18 +40,20 @@ void app_scan_hdr_files(App* app)
 		while ((entry = readdir(dir_handle)) != NULL) {
 			char* dot = strrchr(entry->d_name, '.');
 			if (dot && strcmp(dot, ".hdr") == 0) {
-				char** new_files = realloc(
-				    app->hdr_files,
-				    (size_t)(app->hdr_count + 1) * sizeof(char*));
+				char** new_files =
+				    realloc(app->hdr_files,
+				            (size_t)(app->hdr_count + 1) *
+				                sizeof(char*));
 				if (new_files) {
 					app->hdr_files = new_files;
 					app->hdr_count++;
 					app->hdr_files[app->hdr_count - 1] =
 					    strdup(entry->d_name);
 				} else {
-					LOG_ERROR("suckless-ogl.app",
-					          "Failed to realloc memory for "
-					          "HDR files");
+					LOG_ERROR(
+					    "suckless-ogl.app",
+					    "Failed to realloc memory for "
+					    "HDR files");
 				}
 			}
 		}

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -122,8 +122,9 @@ void handle_preset_input(App* app, int key)
 			         banding_names[app->banding_style_idx]);
 
 			char buf[NOTIF_BUF_SIZE];
-			(void)safe_snprintf(buf, sizeof(buf), "Banding: %s",
-			                    banding_names[app->banding_style_idx]);
+			(void)safe_snprintf(
+			    buf, sizeof(buf), "Banding: %s",
+			    banding_names[app->banding_style_idx]);
 			action_notifier_push(&app->notifier, buf,
 			                     NOTIF_DUR_LONG);
 			break;

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -89,7 +89,6 @@ void handle_preset_input(App* app, int key)
 			                     NOTIF_DUR_LONG);
 			break;
 		case GLFW_KEY_7: { /* Style Cycle: All Banding Styles */
-			static int banding_style_idx = 0;
 			const PostProcessPreset* banding_presets[] = {
 			    &PRESET_POSTERIZED,  /* 1. Posterization */
 			    &PRESET_RETRO,       /* 2. Dithered */
@@ -108,23 +107,23 @@ void handle_preset_input(App* app, int key)
 			   idx 0. Else cycle to next. */
 			if (!postprocess_is_enabled(&app->postprocess,
 			                            POSTFX_BANDING)) {
-				banding_style_idx = 0;
+				app->banding_style_idx = 0;
 			} else {
-				banding_style_idx =
-				    (banding_style_idx + 1) % num_styles;
+				app->banding_style_idx =
+				    (app->banding_style_idx + 1) % num_styles;
 			}
 
 			postprocess_apply_preset(
 			    &app->postprocess,
-			    banding_presets[banding_style_idx]);
+			    banding_presets[app->banding_style_idx]);
 			LOG_INFO("suckless-ogl.app",
 			         "Banding Style [%d/%d]: %s",
-			         banding_style_idx + 1, num_styles,
-			         banding_names[banding_style_idx]);
+			         app->banding_style_idx + 1, num_styles,
+			         banding_names[app->banding_style_idx]);
 
 			char buf[NOTIF_BUF_SIZE];
 			(void)safe_snprintf(buf, sizeof(buf), "Banding: %s",
-			                    banding_names[banding_style_idx]);
+			                    banding_names[app->banding_style_idx]);
 			action_notifier_push(&app->notifier, buf,
 			                     NOTIF_DUR_LONG);
 			break;

--- a/src/camera.c
+++ b/src/camera.c
@@ -30,6 +30,8 @@ void camera_init(Camera* cam, float distance, float yaw, float pitch)
 	cam->yaw_target = yaw;
 	cam->pitch_target = pitch;
 	cam->rotation_smoothing = DEFAULT_ROTATION_SMOOTHING;
+	cam->smoothed_x = 0.0F;
+	cam->smoothed_y = 0.0F;
 
 	// Head bobbing
 	cam->bobbing_time = 0.0F;
@@ -130,41 +132,18 @@ void camera_fixed_update(Camera* cam)
 	}
 }
 
-// Fonction à appeler dans la boucle de jeu
-void camera_update(Camera* cam, float delta_time)
-{
-	// Accumule le temps pour la physique
-	cam->physics_accumulator += delta_time;
-
-	// Tant qu'il y a assez de temps pour une mise à jour physique
-	while (cam->physics_accumulator >= cam->fixed_timestep) {
-		camera_fixed_update(cam);
-		cam->physics_accumulator -= cam->fixed_timestep;
-	}
-
-	// Interpolation de la rotation (pour un rendu fluide)
-	float alpha = cam->rotation_smoothing;
-	cam->yaw = cam->yaw + ((cam->yaw_target - cam->yaw) * alpha);
-	cam->pitch = cam->pitch + ((cam->pitch_target - cam->pitch) * alpha);
-
-	camera_update_vectors(cam);
-}
-
 // Dans camera_process_mouse :
 void camera_process_mouse(Camera* cam, float xoffset, float yoffset)
 {
-	static float smoothed_x = 0.0F;
-	static float smoothed_y = 0.0F;
-
 	// Lissage des inputs souris (ajustable via cam->mouse_smoothing_factor)
-	smoothed_x = (cam->mouse_smoothing_factor * smoothed_x) +
-	             ((1.0F - cam->mouse_smoothing_factor) * xoffset);
-	smoothed_y = (cam->mouse_smoothing_factor * smoothed_y) +
-	             ((1.0F - cam->mouse_smoothing_factor) * yoffset);
+	cam->smoothed_x = (cam->mouse_smoothing_factor * cam->smoothed_x) +
+	                  ((1.0F - cam->mouse_smoothing_factor) * xoffset);
+	cam->smoothed_y = (cam->mouse_smoothing_factor * cam->smoothed_y) +
+	                  ((1.0F - cam->mouse_smoothing_factor) * yoffset);
 
 	// Application
-	cam->yaw_target += smoothed_x * cam->sensitivity;
-	cam->pitch_target -= smoothed_y * cam->sensitivity;
+	cam->yaw_target += cam->smoothed_x * cam->sensitivity;
+	cam->pitch_target -= cam->smoothed_y * cam->sensitivity;
 
 	// Clamping
 	if (cam->pitch_target > DEFAULT_MAX_PITCH) {

--- a/src/icosphere.c
+++ b/src/icosphere.c
@@ -38,10 +38,17 @@ void vec3array_init(Vec3Array* array)
 void vec3array_push(Vec3Array* array, vec3 vertex)
 {
 	if (array->size >= array->capacity) {
-		array->capacity = (array->capacity == 0) ? INITIAL_VEC3_CAPACITY
-		                                         : array->capacity * 2;
-		array->data =
-		    realloc(array->data, sizeof(vec3) * array->capacity);
+		size_t new_capacity = (array->capacity == 0)
+		                          ? INITIAL_VEC3_CAPACITY
+		                          : array->capacity * 2;
+		vec3* new_data =
+		    realloc(array->data, sizeof(vec3) * new_capacity);
+		if (new_data) {
+			array->data = new_data;
+			array->capacity = new_capacity;
+		} else {
+			return;
+		}
 	}
 	glm_vec3_copy(vertex, array->data[array->size++]);
 }
@@ -65,10 +72,17 @@ void uintarray_init(UintArray* array)
 void uintarray_push(UintArray* array, unsigned int value)
 {
 	if (array->size >= array->capacity) {
-		array->capacity = (array->capacity == 0) ? INITIAL_UINT_CAPACITY
-		                                         : array->capacity * 2;
-		array->data = realloc(array->data,
-		                      sizeof(unsigned int) * array->capacity);
+		size_t new_capacity = (array->capacity == 0)
+		                          ? INITIAL_UINT_CAPACITY
+		                          : array->capacity * 2;
+		unsigned int* new_data = realloc(
+		    array->data, sizeof(unsigned int) * new_capacity);
+		if (new_data) {
+			array->data = new_data;
+			array->capacity = new_capacity;
+		} else {
+			return;
+		}
 	}
 	array->data[array->size++] = value;
 }
@@ -123,12 +137,16 @@ static unsigned int get_midpoint(unsigned int point1, unsigned int point2,
 	size_t index = (size_t)(key % hash->capacity);
 
 	/* Open addressing with linear probing */
+	size_t start_index = index;
 	while (hash->entries[index].midpoint != 0) {
 		if (hash->entries[index].a == idx_a &&
 		    hash->entries[index].b == idx_b) {
 			return hash->entries[index].midpoint;
 		}
 		index = (index + 1) % hash->capacity;
+		if (index == start_index) {
+			return 0; /* Table full, shouldn't happen */
+		}
 	}
 
 	/* Not found, create new vertex */

--- a/src/icosphere.c
+++ b/src/icosphere.c
@@ -75,8 +75,8 @@ void uintarray_push(UintArray* array, unsigned int value)
 		size_t new_capacity = (array->capacity == 0)
 		                          ? INITIAL_UINT_CAPACITY
 		                          : array->capacity * 2;
-		unsigned int* new_data = realloc(
-		    array->data, sizeof(unsigned int) * new_capacity);
+		unsigned int* new_data =
+		    realloc(array->data, sizeof(unsigned int) * new_capacity);
 		if (new_data) {
 			array->data = new_data;
 			array->capacity = new_capacity;

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include "gl_common.h"
 #include "log.h"
 #include <stdlib.h>
+#include <string.h>
 
 int main(int argc, char* argv[])
 {
@@ -22,10 +23,12 @@ int main(int argc, char* argv[])
 		          "Failed to allocate memory for application");
 		return EXIT_FAILURE;
 	}
+	memset(app, 0, sizeof(App));
 
 	if (!app_init(app, WINDOW_WIDTH, WINDOW_HEIGHT, "Icosphere Phong")) {
 		LOG_ERROR("suckless-ogl.main",
 		          "Failed to initialize application");
+		app_cleanup(app);
 		free(app);
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
This PR addresses multiple issues identified in the project analysis:
1.  **Resource Leaks:** Added missing `glDeleteBuffers` for `lum_ssbo` in `app_cleanup`. Ensured `app_cleanup` is called even if `app_init` fails in `main.c`, and zero-initialized `App` struct to make this safe.
2.  **Dead Code:** Removed `camera_update` (unused/duplicate) and unused fields in `App` struct (`show_imgui_demo`, `show_debug_tex`, `debug_lod`) and `include/camera.h`.
3.  **Safety & Bugs:**
    *   Fixed unsafe `realloc` patterns in `app_env.c` (`app_scan_hdr_files`) and `icosphere.c` (`vec3array_push`, `uintarray_push`) to prevent leaks on failure.
    *   Moved `static` local variables (`smoothed_x/y` in `camera.c`, `banding_style_idx` in `app_input.c`) to `Camera` and `App` structs to fix state persistence issues.
    *   Added division-by-zero check for `app->height` in `app_render`.
    *   Added safety break in `icosphere.c` hash table probing to prevent infinite loops.

Verified with `ctest`. All tests passed.

---
*PR created automatically by Jules for task [3698892687338170888](https://jules.google.com/task/3698892687338170888) started by @yoyonel*