### PR TITLE
fix: enable OpenGL debug context and resolve effect initialization leaks

### DIFF
--- a/src/effects/fx_auto_exposure.c
+++ b/src/effects/fx_auto_exposure.c
@@ -34,6 +34,7 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	    GL_FRAMEBUFFER_COMPLETE) {
 		LOG_ERROR("suckless-ogl.postprocess.ae",
 		          "Lum Downsample FBO incomplete!");
+		fx_auto_exposure_cleanup(post_processing);
 		return 0;
 	}
 
@@ -57,6 +58,7 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	if (!auto_exp->downsample_shader || !auto_exp->adapt_shader) {
 		LOG_ERROR("suckless-ogl.postprocess.ae",
 		          "Failed to load auto-exposure shaders");
+		fx_auto_exposure_cleanup(post_processing);
 		return 0;
 	}
 

--- a/src/effects/fx_bloom.c
+++ b/src/effects/fx_bloom.c
@@ -26,6 +26,7 @@ int fx_bloom_init(PostProcess* post_processing)
 	    !bloom->upsample_shader) {
 		LOG_ERROR("suckless-ogl.postprocess.bloom",
 		          "Failed to load bloom shaders");
+		fx_bloom_cleanup(post_processing);
 		return 0;
 	}
 

--- a/src/effects/fx_dof.c
+++ b/src/effects/fx_dof.c
@@ -16,6 +16,7 @@ int fx_dof_init(PostProcess* post_processing)
 	glBindFramebuffer(GL_FRAMEBUFFER, dof->fbo);
 
 	if (!fx_dof_resize(post_processing)) {
+		fx_dof_cleanup(post_processing);
 		return 0;
 	}
 
@@ -23,6 +24,7 @@ int fx_dof_init(PostProcess* post_processing)
 	    GL_FRAMEBUFFER_COMPLETE) {
 		LOG_ERROR("suckless-ogl.postprocess.dof",
 		          "Failed to create DoF framebuffer");
+		fx_dof_cleanup(post_processing);
 		return 0;
 	}
 

--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -114,10 +114,20 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 		const char* type_str = get_type_str(type);
 		const char* sev_str = get_severity_str(severity);
 
-		LOG_WARNING(
-		    LOG_TAG,
-		    "id: 0x%X, source: %s, type: %s, severity: %s, message: %s",
-		    message_id, src_str, type_str, sev_str, message);
+		if (type == GL_DEBUG_TYPE_ERROR ||
+		    severity == GL_DEBUG_SEVERITY_HIGH) {
+			LOG_ERROR(LOG_TAG,
+			          "id: 0x%X, source: %s, type: %s, severity: "
+			          "%s, message: %s",
+			          message_id, src_str, type_str, sev_str,
+			          message);
+		} else {
+			LOG_WARNING(LOG_TAG,
+			            "id: 0x%X, source: %s, type: %s, severity: "
+			            "%s, message: %s",
+			            message_id, src_str, type_str, sev_str,
+			            message);
+		}
 	}
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -18,6 +18,7 @@ GLFWwindow* window_create(int width, int height, const char* title, int samples)
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
 #ifdef __APPLE__
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif


### PR DESCRIPTION
This PR addresses OpenGL state inconsistencies and monitoring requirements.

1.  **High Sensitivity Debugging**: 
    - Enabled the OpenGL debug context in `src/window.c` to capture driver-side validation errors.
    - Updated `src/gl_debug.c` to escalate `GL_DEBUG_TYPE_ERROR` and `GL_DEBUG_SEVERITY_HIGH` messages to `LOG_ERROR` (writing to stderr), making them visible in CI logs.

2.  **Resource Leak Fixes**:
    - Identified and fixed resource leaks in the initialization routines of several post-processing effects (`Bloom`, `DoF`, `AutoExposure`). 
    - Previously, if a step (like shader loading) failed mid-initialization, the already-created Framebuffers and Textures were not released. Added explicit calls to their respective `*_cleanup` functions in these error paths.

3.  **Verification**:
    - Ran existing test suite in a headless environment with `LIBGL_ALWAYS_SOFTWARE=1`, `MESA_DEBUG=1`, and `EGL_LOG_LEVEL=debug`.
    - Confirmed that debug context is active and logging errors correctly via a temporary test case.
    - Confirmed no regressions in existing functionality.

---
*PR created automatically by Jules for task [11499107053751672125](https://jules.google.com/task/11499107053751672125) started by @yoyonel*