### PR TITLE
🛡️ Sentinel: Fix DoS/TOCTOU in texture loading

### DIFF
--- a/src/texture.c
+++ b/src/texture.c
@@ -12,32 +12,38 @@ enum { MAX_TEXTURE_DIMENSION = 8192 };
 float* texture_load_pixels(const char* path, int* width, int* height,
                            int* channels)
 {
-	CLEANUP_FILE FILE* f = fopen(path, "rb");
-	if (!f) {
+	CLEANUP_FILE FILE* file_ptr = fopen(path, "rb");
+	if (!file_ptr) {
 		LOG_ERROR("suckless-ogl.texture",
 		          "Failed to open HDR image: %s", path);
 		return NULL;
 	}
 
-	int w = 0;
-	int h = 0;
+	int img_width = 0;
+	int img_height = 0;
 	int comp = 0;
-	if (!stbi_info_from_file(f, &w, &h, &comp)) {
+	if (!stbi_info_from_file(file_ptr, &img_width, &img_height, &comp)) {
 		LOG_ERROR("suckless-ogl.texture",
 		          "Failed to read HDR image header: %s", path);
 		return NULL;
 	}
 
-	if (w > MAX_TEXTURE_DIMENSION || h > MAX_TEXTURE_DIMENSION) {
+	if (img_width > MAX_TEXTURE_DIMENSION ||
+	    img_height > MAX_TEXTURE_DIMENSION) {
 		LOG_ERROR("suckless-ogl.texture",
 		          "HDR image exceeds max dimensions: %s (%dx%d > %d)",
-		          path, w, h, MAX_TEXTURE_DIMENSION);
+		          path, img_width, img_height, MAX_TEXTURE_DIMENSION);
 		return NULL;
 	}
 
-	rewind(f);
+	if (fseek(file_ptr, 0, SEEK_SET) != 0) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Failed to rewind HDR image file: %s", path);
+		return NULL;
+	}
 
-	float* data = stbi_loadf_from_file(f, width, height, channels, 4);
+	float* data =
+	    stbi_loadf_from_file(file_ptr, width, height, channels, 4);
 	if (!data) {
 		LOG_ERROR("suckless-ogl.texture",
 		          "Failed to load HDR image: %s", path);
@@ -136,8 +142,8 @@ GLuint texture_load_hdr(const char* path, int* width, int* height)
 
 GLuint texture_load(const char* path)
 {
-	CLEANUP_FILE FILE* f = fopen(path, "rb");
-	if (!f) {
+	CLEANUP_FILE FILE* file_ptr = fopen(path, "rb");
+	if (!file_ptr) {
 		LOG_ERROR("suckless-ogl.texture", "Failed to open image: %s",
 		          path);
 		return 0;
@@ -147,7 +153,7 @@ GLuint texture_load(const char* path)
 	int height = 0;
 	int channels = 0;
 
-	if (!stbi_info_from_file(f, &width, &height, &channels)) {
+	if (!stbi_info_from_file(file_ptr, &width, &height, &channels)) {
 		LOG_ERROR("suckless-ogl.texture",
 		          "Failed to read image header: %s", path);
 		return 0;
@@ -160,11 +166,15 @@ GLuint texture_load(const char* path)
 		return 0;
 	}
 
-	rewind(f);
+	if (fseek(file_ptr, 0, SEEK_SET) != 0) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Failed to rewind image file: %s", path);
+		return 0;
+	}
 
 	/* Force 4 channels (RGBA) */
 	unsigned char* data =
-	    stbi_load_from_file(f, &width, &height, &channels, 4);
+	    stbi_load_from_file(file_ptr, &width, &height, &channels, 4);
 	if (!data) {
 		LOG_ERROR("suckless-ogl.texture", "Failed to load image: %s",
 		          path);

--- a/src/texture.c
+++ b/src/texture.c
@@ -12,18 +12,35 @@ enum { MAX_TEXTURE_DIMENSION = 8192 };
 float* texture_load_pixels(const char* path, int* width, int* height,
                            int* channels)
 {
-	float* data = stbi_loadf(path, width, height, channels, 4);
-	if (!data) {
+	CLEANUP_FILE FILE* f = fopen(path, "rb");
+	if (!f) {
 		LOG_ERROR("suckless-ogl.texture",
-		          "Failed to load HDR image: %s", path);
+		          "Failed to open HDR image: %s", path);
 		return NULL;
 	}
 
-	if (*width > MAX_TEXTURE_DIMENSION || *height > MAX_TEXTURE_DIMENSION) {
+	int w = 0;
+	int h = 0;
+	int comp = 0;
+	if (!stbi_info_from_file(f, &w, &h, &comp)) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Failed to read HDR image header: %s", path);
+		return NULL;
+	}
+
+	if (w > MAX_TEXTURE_DIMENSION || h > MAX_TEXTURE_DIMENSION) {
 		LOG_ERROR("suckless-ogl.texture",
 		          "HDR image exceeds max dimensions: %s (%dx%d > %d)",
-		          path, *width, *height, MAX_TEXTURE_DIMENSION);
-		stbi_image_free(data);
+		          path, w, h, MAX_TEXTURE_DIMENSION);
+		return NULL;
+	}
+
+	rewind(f);
+
+	float* data = stbi_loadf_from_file(f, width, height, channels, 4);
+	if (!data) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Failed to load HDR image: %s", path);
 		return NULL;
 	}
 
@@ -119,15 +136,20 @@ GLuint texture_load_hdr(const char* path, int* width, int* height)
 
 GLuint texture_load(const char* path)
 {
+	CLEANUP_FILE FILE* f = fopen(path, "rb");
+	if (!f) {
+		LOG_ERROR("suckless-ogl.texture", "Failed to open image: %s",
+		          path);
+		return 0;
+	}
+
 	int width = 0;
 	int height = 0;
 	int channels = 0;
 
-	/* Force 4 channels (RGBA) */
-	unsigned char* data = stbi_load(path, &width, &height, &channels, 4);
-	if (!data) {
-		LOG_ERROR("suckless-ogl.texture", "Failed to load image: %s",
-		          path);
+	if (!stbi_info_from_file(f, &width, &height, &channels)) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Failed to read image header: %s", path);
 		return 0;
 	}
 
@@ -135,7 +157,17 @@ GLuint texture_load(const char* path)
 		LOG_ERROR("suckless-ogl.texture",
 		          "Image exceeds max dimensions: %s (%dx%d > %d)", path,
 		          width, height, MAX_TEXTURE_DIMENSION);
-		stbi_image_free(data);
+		return 0;
+	}
+
+	rewind(f);
+
+	/* Force 4 channels (RGBA) */
+	unsigned char* data =
+	    stbi_load_from_file(f, &width, &height, &channels, 4);
+	if (!data) {
+		LOG_ERROR("suckless-ogl.texture", "Failed to load image: %s",
+		          path);
 		return 0;
 	}
 

--- a/tests/test_texture_security.c
+++ b/tests/test_texture_security.c
@@ -74,10 +74,28 @@ void test_texture_upload_valid_dimensions(void)
 	glDeleteTextures(1, &tex);
 }
 
+void test_texture_load_excessive_dimensions_dos(void)
+{
+	const char* filename = "test_dos_9000x1.ppm";
+	FILE* f = fopen(filename, "wb");
+	TEST_ASSERT_NOT_NULL_MESSAGE(f, "Failed to create test file");
+	fprintf(f, "P6\n9000 1\n255\n");
+	fclose(f);
+
+	/* Should return 0 (NULL) because dimensions exceed limit */
+	GLuint tex = texture_load(filename);
+	TEST_ASSERT_EQUAL_MESSAGE(0, tex,
+	                          "Should reject texture with width > "
+	                          "MAX_TEXTURE_DIMENSION (8192) during load");
+
+	remove(filename);
+}
+
 int main(void)
 {
 	UNITY_BEGIN();
 	RUN_TEST(test_texture_upload_excessive_dimensions);
 	RUN_TEST(test_texture_upload_valid_dimensions);
+	RUN_TEST(test_texture_load_excessive_dimensions_dos);
 	return UNITY_END();
 }


### PR DESCRIPTION
Refactored `src/texture.c` to use file-handle based loading (`stbi_info_from_file`, `stbi_load_from_file`) instead of path-based loading.
This enables checking image dimensions against `MAX_TEXTURE_DIMENSION` (8192) BEFORE allocating memory for the pixel data, preventing Denial of Service (DoS) attacks via crafted image headers.
Using an open `FILE*` handle throughout the check-then-load process also prevents Time-of-Check Time-of-Use (TOCTOU) race conditions.
Added regression test case `test_texture_load_excessive_dimensions_dos` in `tests/test_texture_security.c`.

---
*PR created automatically by Jules for task [11715096589175127293](https://jules.google.com/task/11715096589175127293) started by @yoyonel*