### PR TITLE
Fix OpenGL debug context and resource leaks

### DIFF
--- a/src/effects/fx_auto_exposure.c
+++ b/src/effects/fx_auto_exposure.c
@@ -34,6 +34,7 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	    GL_FRAMEBUFFER_COMPLETE) {
 		LOG_ERROR("suckless-ogl.postprocess.ae",
 		          "Lum Downsample FBO incomplete!");
+		fx_auto_exposure_cleanup(post_processing);
 		return 0;
 	}
 
@@ -57,6 +58,7 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	if (!auto_exp->downsample_shader || !auto_exp->adapt_shader) {
 		LOG_ERROR("suckless-ogl.postprocess.ae",
 		          "Failed to load auto-exposure shaders");
+		fx_auto_exposure_cleanup(post_processing);
 		return 0;
 	}
 

--- a/src/effects/fx_bloom.c
+++ b/src/effects/fx_bloom.c
@@ -26,6 +26,7 @@ int fx_bloom_init(PostProcess* post_processing)
 	    !bloom->upsample_shader) {
 		LOG_ERROR("suckless-ogl.postprocess.bloom",
 		          "Failed to load bloom shaders");
+		fx_bloom_cleanup(post_processing);
 		return 0;
 	}
 

--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -114,10 +114,17 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 		const char* type_str = get_type_str(type);
 		const char* sev_str = get_severity_str(severity);
 
-		LOG_WARNING(
-		    LOG_TAG,
-		    "id: 0x%X, source: %s, type: %s, severity: %s, message: %s",
-		    message_id, src_str, type_str, sev_str, message);
+		if (type == GL_DEBUG_TYPE_ERROR) {
+			LOG_ERROR(
+			    LOG_TAG,
+			    "id: 0x%X, source: %s, type: %s, severity: %s, message: %s",
+			    message_id, src_str, type_str, sev_str, message);
+		} else {
+			LOG_WARNING(
+			    LOG_TAG,
+			    "id: 0x%X, source: %s, type: %s, severity: %s, message: %s",
+			    message_id, src_str, type_str, sev_str, message);
+		}
 	}
 }
 

--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -115,15 +115,17 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 		const char* sev_str = get_severity_str(severity);
 
 		if (type == GL_DEBUG_TYPE_ERROR) {
-			LOG_ERROR(
-			    LOG_TAG,
-			    "id: 0x%X, source: %s, type: %s, severity: %s, message: %s",
-			    message_id, src_str, type_str, sev_str, message);
+			LOG_ERROR(LOG_TAG,
+			          "id: 0x%X, source: %s, type: %s, severity: "
+			          "%s, message: %s",
+			          message_id, src_str, type_str, sev_str,
+			          message);
 		} else {
-			LOG_WARNING(
-			    LOG_TAG,
-			    "id: 0x%X, source: %s, type: %s, severity: %s, message: %s",
-			    message_id, src_str, type_str, sev_str, message);
+			LOG_WARNING(LOG_TAG,
+			            "id: 0x%X, source: %s, type: %s, severity: "
+			            "%s, message: %s",
+			            message_id, src_str, type_str, sev_str,
+			            message);
 		}
 	}
 }

--- a/src/window.c
+++ b/src/window.c
@@ -18,6 +18,7 @@ GLFWwindow* window_create(int width, int height, const char* title, int samples)
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
 #ifdef __APPLE__
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif


### PR DESCRIPTION
This PR addresses OpenGL state integrity issues by ensuring the debug context is correctly created and by fixing resource leaks in the post-processing initialization paths.

Changes:
1.  **Debug Context**: Added `glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE)` in `src/window.c`. This ensures that `glDebugMessageCallback` can receive high-severity messages and validation errors from the driver.
2.  **Debug Logging**: Modified `gl_debug_callback` in `src/gl_debug.c` to promote `GL_DEBUG_TYPE_ERROR` to `LOG_ERROR`. This makes critical OpenGL errors more visible in the logs.
3.  **Resource Leaks**:
    *   In `src/effects/fx_bloom.c`, added a call to `fx_bloom_cleanup` if shader loading fails in `fx_bloom_init`.
    *   In `src/effects/fx_auto_exposure.c`, added calls to `fx_auto_exposure_cleanup` if framebuffer status check fails or shader loading fails in `fx_auto_exposure_init`.

Verification:
- Ran `make test` with `LIBGL_ALWAYS_SOFTWARE=1 MESA_DEBUG=1 EGL_LOG_LEVEL=debug`.
- Verified "OpenGL Debug Callback initialized" message appears in logs.
- All tests passed.

---
*PR created automatically by Jules for task [9069769594449910644](https://jules.google.com/task/9069769594449910644) started by @yoyonel*