### PR TITLE
⚡ Perf: Double buffering in sphere sorting

### DIFF
--- a/include/sphere_sorting.h
+++ b/include/sphere_sorting.h
@@ -28,7 +28,9 @@ typedef struct {
 typedef struct {
 	SphereSortEntry* entries;       /**< Key array. */
 	SphereInstance* temp_instances; /**< Scratchpad for reordering. */
-	int capacity;                   /**< Allocated size. */
+	int capacity;     /**< Current allocated size of temp_instances. */
+	int min_capacity; /**< Minimum capacity to maintain (from
+	                     initialization). */
 } SphereSorter;
 
 /**
@@ -47,15 +49,21 @@ void sphere_sorter_cleanup(SphereSorter* sorter);
 /**
  * @brief Sorts the array of instances Back-to-Front (descending depth).
  *
- * This function Reorders the 'instances' array IN-PLACE using a temporary
- * buffer to avoid extra copies.
+ * This function Reorders the 'instances' array using a temporary
+ * buffer to avoid extra copies. It swaps the pointer provided by
+ * `instances_ptr` with its internal buffer.
+ *
+ * The provided `instances_ptr` will point to a buffer that is at least
+ * as large as the `initial_capacity` passed to `sphere_sorter_init`, or
+ * large enough for `count` instances, whichever is greater.
  *
  * @param sorter      Memory context.
- * @param instances   The array to sort.
+ * @param instances_ptr Pointer to the array pointer to sort. The pointer
+ * *instances_ptr will be updated to point to the sorted array.
  * @param count       Active element count.
  * @param camera_pos  World-space viewer position (for depth calculation).
  */
-void sphere_sorter_sort(SphereSorter* sorter, SphereInstance* instances,
+void sphere_sorter_sort(SphereSorter* sorter, SphereInstance** instances_ptr,
                         int count, vec3 camera_pos);
 
 #endif /* SPHERE_SORTING_H */

--- a/src/app.c
+++ b/src/app.c
@@ -434,7 +434,7 @@ void app_render(App* app)
 		                   GPU_PROFILER_SCENE_COLOR);
 		if (app->billboard_mode) {
 			sphere_sorter_sort(
-			    &app->sphere_sorter, app->sphere_instances,
+			    &app->sphere_sorter, &app->sphere_instances,
 			    app->sphere_instance_count, app->camera.position);
 			billboard_group_update(&app->billboard_group,
 			                       app->sphere_instances,

--- a/src/sphere_sorting.c
+++ b/src/sphere_sorting.c
@@ -35,6 +35,7 @@ void sphere_sorter_init(SphereSorter* sorter, int initial_capacity)
 		initial_capacity = INITIAL_CAPACITY;
 	}
 	sorter->capacity = initial_capacity;
+	sorter->min_capacity = initial_capacity;
 	sorter->entries = calloc(initial_capacity, sizeof(SphereSortEntry));
 
 	size_t size = initial_capacity * sizeof(SphereInstance);
@@ -60,18 +61,36 @@ void sphere_sorter_cleanup(SphereSorter* sorter)
 		sorter->temp_instances = NULL;
 	}
 	sorter->capacity = 0;
+	sorter->min_capacity = 0;
 }
 
-void sphere_sorter_sort(SphereSorter* sorter, SphereInstance* instances,
+void sphere_sorter_sort(SphereSorter* sorter, SphereInstance** instances_ptr,
                         int count, vec3 camera_pos)
 {
-	if (count <= 0 || !instances) {
+	if (count <= 0 || !instances_ptr || !*instances_ptr) {
 		return;
 	}
 
+	SphereInstance* instances = *instances_ptr;
+
+	/*
+	 * Determine required capacity.
+	 * We must maintain at least min_capacity to ensure the App receives
+	 * a buffer large enough for its max usage (assuming max <=
+	 * min_capacity). If count exceeds min_capacity, we grow.
+	 */
+	int required_capacity =
+	    (count > sorter->min_capacity) ? count : sorter->min_capacity;
+
 	/* 1. Ensure Capacity */
-	if (count > sorter->capacity) {
-		int new_cap = count * 2;
+	if (required_capacity > sorter->capacity) {
+		/* If growing beyond min_capacity, double for amortized O(1).
+		   Otherwise, just restore to min_capacity. */
+		int new_cap = required_capacity;
+		if (required_capacity > sorter->min_capacity) {
+			new_cap = required_capacity * 2;
+		}
+
 		SphereSortEntry* new_entries =
 		    realloc(sorter->entries, new_cap * sizeof(SphereSortEntry));
 
@@ -126,7 +145,17 @@ void sphere_sorter_sort(SphereSorter* sorter, SphereInstance* instances,
 		sorter->temp_instances[i] = instances[old_idx];
 	}
 
-	/* 5. Copy back to original array */
-	safe_memcpy(instances, count * sizeof(SphereInstance),
-	            sorter->temp_instances, count * sizeof(SphereInstance));
+	/* 5. Swap pointers instead of copying back */
+	*instances_ptr = sorter->temp_instances;
+	sorter->temp_instances = instances;
+
+	/*
+	 * We've swapped buffers. The buffer we now hold (old 'instances')
+	 * has an unknown capacity (at least 'count').
+	 * However, we enforce that the external buffer MUST be at least
+	 * 'min_capacity' in size. We rely on this contract to avoid
+	 * unnecessary reallocations when count < min_capacity.
+	 */
+	sorter->capacity =
+	    (count > sorter->min_capacity) ? count : sorter->min_capacity;
 }

--- a/tests/test_benchmark_sphere_sorting_perf.c
+++ b/tests/test_benchmark_sphere_sorting_perf.c
@@ -1,13 +1,13 @@
 #define _POSIX_C_SOURCE 200809L
-#include "sphere_sorting.h"
-#include "instanced_rendering.h"
 #include "gl_common.h"
+#include "instanced_rendering.h"
+#include "sphere_sorting.h"
+#include "utils.h"
+#include <cglm/cglm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <cglm/cglm.h>
-#include "utils.h"
 
 /* Baseline logic extracted from previous implementation */
 static int compare_depth_desc(const void* lhs, const void* rhs)
@@ -25,8 +25,9 @@ static int compare_depth_desc(const void* lhs, const void* rhs)
 }
 
 /* Re-implementation of the baseline sort logic (memcpy) */
-void sphere_sorter_sort_baseline(SphereSorter* sorter, SphereInstance* instances,
-                                 int count, vec3 camera_pos)
+void sphere_sorter_sort_baseline(SphereSorter* sorter,
+                                 SphereInstance* instances, int count,
+                                 vec3 camera_pos)
 {
 	if (count <= 0 || !instances) {
 		return;
@@ -55,7 +56,8 @@ void sphere_sorter_sort_baseline(SphereSorter* sorter, SphereInstance* instances
 	}
 
 	/* Copy Back (The overhead we are removing) */
-	memcpy(instances, sorter->temp_instances, count * sizeof(SphereInstance));
+	memcpy(instances, sorter->temp_instances,
+	       count * sizeof(SphereInstance));
 }
 
 int main(void)
@@ -76,15 +78,19 @@ int main(void)
 	SphereInstance* instances_baseline = NULL;
 	SphereInstance* instances_optimized = NULL;
 
-	posix_memalign((void**)&instances_baseline, SIMD_ALIGNMENT, COUNT * sizeof(SphereInstance));
-	posix_memalign((void**)&instances_optimized, SIMD_ALIGNMENT, COUNT * sizeof(SphereInstance));
+	posix_memalign((void**)&instances_baseline, SIMD_ALIGNMENT,
+	               COUNT * sizeof(SphereInstance));
+	posix_memalign((void**)&instances_optimized, SIMD_ALIGNMENT,
+	               COUNT * sizeof(SphereInstance));
 
 	/* Initialize data */
 	for (int i = 0; i < COUNT; ++i) {
 		glm_mat4_identity(instances_baseline[i].model);
-		instances_baseline[i].model[3][2] = (float)(rand() % 1000); /* Random Z depth */
+		instances_baseline[i].model[3][2] =
+		    (float)(rand() % 1000); /* Random Z depth */
 	}
-	memcpy(instances_optimized, instances_baseline, COUNT * sizeof(SphereInstance));
+	memcpy(instances_optimized, instances_baseline,
+	       COUNT * sizeof(SphereInstance));
 
 	vec3 camera_pos = {0.0f, 0.0f, 0.0f};
 
@@ -93,7 +99,8 @@ int main(void)
 	for (int i = 0; i < ITERATIONS; ++i) {
 		/* Randomize positions slightly to force sort work */
 		instances_baseline[0].model[3][2] = (float)(rand() % 1000);
-		sphere_sorter_sort_baseline(&sorter_baseline, instances_baseline, COUNT, camera_pos);
+		sphere_sorter_sort_baseline(
+		    &sorter_baseline, instances_baseline, COUNT, camera_pos);
 	}
 	clock_t end_base = clock();
 	double time_base = (double)(end_base - start_base) / CLOCKS_PER_SEC;
@@ -104,7 +111,8 @@ int main(void)
 	SphereInstance* current_instances_ptr = instances_optimized;
 	for (int i = 0; i < ITERATIONS; ++i) {
 		current_instances_ptr[0].model[3][2] = (float)(rand() % 1000);
-		sphere_sorter_sort(&sorter_optimized, &current_instances_ptr, COUNT, camera_pos);
+		sphere_sorter_sort(&sorter_optimized, &current_instances_ptr,
+		                   COUNT, camera_pos);
 	}
 	clock_t end_opt = clock();
 	double time_opt = (double)(end_opt - start_opt) / CLOCKS_PER_SEC;
@@ -112,18 +120,22 @@ int main(void)
 	printf("Baseline Total Time: %.4f s\n", time_base);
 	printf("Optimized Total Time: %.4f s\n", time_opt);
 	printf("Speedup: %.2fx\n", time_base / time_opt);
-	printf("Avg Time per Frame (Baseline): %.4f ms\n", (time_base / ITERATIONS) * 1000.0);
-	printf("Avg Time per Frame (Optimized): %.4f ms\n", (time_opt / ITERATIONS) * 1000.0);
+	printf("Avg Time per Frame (Baseline): %.4f ms\n",
+	       (time_base / ITERATIONS) * 1000.0);
+	printf("Avg Time per Frame (Optimized): %.4f ms\n",
+	       (time_opt / ITERATIONS) * 1000.0);
 
 	/* Cleanup */
 	sphere_sorter_cleanup(&sorter_baseline);
-	/* For optimized, sorter holds one buffer, current_instances_ptr holds the other */
+	/* For optimized, sorter holds one buffer, current_instances_ptr holds
+	 * the other */
 	/* sphere_sorter_cleanup will free the one inside sorter */
 	sphere_sorter_cleanup(&sorter_optimized);
 
 	/* Free the buffers we allocated initially */
 	free(instances_baseline);
-	/* For optimized, we need to free the one currently held by the app side */
+	/* For optimized, we need to free the one currently held by the app side
+	 */
 	free(current_instances_ptr);
 
 	return 0;

--- a/tests/test_benchmark_sphere_sorting_perf.c
+++ b/tests/test_benchmark_sphere_sorting_perf.c
@@ -1,0 +1,130 @@
+#define _POSIX_C_SOURCE 200809L
+#include "sphere_sorting.h"
+#include "instanced_rendering.h"
+#include "gl_common.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <cglm/cglm.h>
+#include "utils.h"
+
+/* Baseline logic extracted from previous implementation */
+static int compare_depth_desc(const void* lhs, const void* rhs)
+{
+	const SphereSortEntry* entry_a = (const SphereSortEntry*)lhs;
+	const SphereSortEntry* entry_b = (const SphereSortEntry*)rhs;
+
+	if (entry_a->depth < entry_b->depth) {
+		return 1;
+	}
+	if (entry_a->depth > entry_b->depth) {
+		return -1;
+	}
+	return 0;
+}
+
+/* Re-implementation of the baseline sort logic (memcpy) */
+void sphere_sorter_sort_baseline(SphereSorter* sorter, SphereInstance* instances,
+                                 int count, vec3 camera_pos)
+{
+	if (count <= 0 || !instances) {
+		return;
+	}
+
+	/* Capacity handling (simplified for benchmark as we pre-allocate) */
+	/* Assume sorter is initialized large enough */
+
+	/* Compute Depths */
+	for (int i = 0; i < count; ++i) {
+		vec3 pos = {instances[i].model[3][0], instances[i].model[3][1],
+		            instances[i].model[3][2]};
+
+		sorter->entries[i].original_index = i;
+		sorter->entries[i].depth = glm_vec3_distance2(pos, camera_pos);
+	}
+
+	/* Sort Indices */
+	qsort(sorter->entries, count, sizeof(SphereSortEntry),
+	      compare_depth_desc);
+
+	/* Reorder to Temp */
+	for (int i = 0; i < count; ++i) {
+		int old_idx = sorter->entries[i].original_index;
+		sorter->temp_instances[i] = instances[old_idx];
+	}
+
+	/* Copy Back (The overhead we are removing) */
+	memcpy(instances, sorter->temp_instances, count * sizeof(SphereInstance));
+}
+
+int main(void)
+{
+	const int COUNT = 100000;
+	const int ITERATIONS = 100;
+
+	printf("Running Sphere Sorting Benchmark\n");
+	printf("Instances: %d\n", COUNT);
+	printf("Iterations: %d\n", ITERATIONS);
+
+	SphereSorter sorter_baseline;
+	SphereSorter sorter_optimized;
+
+	sphere_sorter_init(&sorter_baseline, COUNT);
+	sphere_sorter_init(&sorter_optimized, COUNT);
+
+	SphereInstance* instances_baseline = NULL;
+	SphereInstance* instances_optimized = NULL;
+
+	posix_memalign((void**)&instances_baseline, SIMD_ALIGNMENT, COUNT * sizeof(SphereInstance));
+	posix_memalign((void**)&instances_optimized, SIMD_ALIGNMENT, COUNT * sizeof(SphereInstance));
+
+	/* Initialize data */
+	for (int i = 0; i < COUNT; ++i) {
+		glm_mat4_identity(instances_baseline[i].model);
+		instances_baseline[i].model[3][2] = (float)(rand() % 1000); /* Random Z depth */
+	}
+	memcpy(instances_optimized, instances_baseline, COUNT * sizeof(SphereInstance));
+
+	vec3 camera_pos = {0.0f, 0.0f, 0.0f};
+
+	/* Measure Baseline */
+	clock_t start_base = clock();
+	for (int i = 0; i < ITERATIONS; ++i) {
+		/* Randomize positions slightly to force sort work */
+		instances_baseline[0].model[3][2] = (float)(rand() % 1000);
+		sphere_sorter_sort_baseline(&sorter_baseline, instances_baseline, COUNT, camera_pos);
+	}
+	clock_t end_base = clock();
+	double time_base = (double)(end_base - start_base) / CLOCKS_PER_SEC;
+
+	/* Measure Optimized */
+	clock_t start_opt = clock();
+	/* Note: Optimized swaps the pointer, so we must track it */
+	SphereInstance* current_instances_ptr = instances_optimized;
+	for (int i = 0; i < ITERATIONS; ++i) {
+		current_instances_ptr[0].model[3][2] = (float)(rand() % 1000);
+		sphere_sorter_sort(&sorter_optimized, &current_instances_ptr, COUNT, camera_pos);
+	}
+	clock_t end_opt = clock();
+	double time_opt = (double)(end_opt - start_opt) / CLOCKS_PER_SEC;
+
+	printf("Baseline Total Time: %.4f s\n", time_base);
+	printf("Optimized Total Time: %.4f s\n", time_opt);
+	printf("Speedup: %.2fx\n", time_base / time_opt);
+	printf("Avg Time per Frame (Baseline): %.4f ms\n", (time_base / ITERATIONS) * 1000.0);
+	printf("Avg Time per Frame (Optimized): %.4f ms\n", (time_opt / ITERATIONS) * 1000.0);
+
+	/* Cleanup */
+	sphere_sorter_cleanup(&sorter_baseline);
+	/* For optimized, sorter holds one buffer, current_instances_ptr holds the other */
+	/* sphere_sorter_cleanup will free the one inside sorter */
+	sphere_sorter_cleanup(&sorter_optimized);
+
+	/* Free the buffers we allocated initially */
+	free(instances_baseline);
+	/* For optimized, we need to free the one currently held by the app side */
+	free(current_instances_ptr);
+
+	return 0;
+}

--- a/tests/test_sphere_sorting.c
+++ b/tests/test_sphere_sorting.c
@@ -1,8 +1,10 @@
 // tests/test_sphere_sorting.c
+#define _POSIX_C_SOURCE 200809L /* For posix_memalign */
 #include "sphere_sorting.h"
 #include "unity.h"
 #include <cglm/cglm.h>
 #include <stdlib.h>
+#include <string.h> /* For memset */
 
 static const int INIT_CAPACITY = 10;
 static const int TEST_COUNT_3 = 3;
@@ -25,11 +27,22 @@ void tearDown(void)
 {
 }
 
-/* Helper to generate dummy instances */
-static SphereInstance* create_dummy_instances(int count)
+/* Helper to generate dummy instances. Ensures allocation respects min_capacity
+ * contract. */
+static SphereInstance* create_dummy_instances(int count, int min_capacity)
 {
-	SphereInstance* instances =
-	    (SphereInstance*)calloc((size_t)count, sizeof(SphereInstance));
+	int alloc_count = (count > min_capacity) ? count : min_capacity;
+	SphereInstance* instances = NULL;
+	/* Use posix_memalign to match sorter allocation strategy (safe for
+	 * swapping) */
+	/* SIMD_ALIGNMENT is available via sphere_sorting.h ->
+	 * instanced_rendering.h -> gl_common.h */
+	if (posix_memalign((void**)&instances, SIMD_ALIGNMENT,
+	                   (size_t)alloc_count * sizeof(SphereInstance)) != 0) {
+		return NULL;
+	}
+	memset(instances, 0, (size_t)alloc_count * sizeof(SphereInstance));
+
 	for (int i = 0; i < count; ++i) {
 		glm_mat4_identity(instances[i].model);
 	}
@@ -58,6 +71,7 @@ void test_SphereSorter_Init_ShouldAllocateBuffers(void)
 	TEST_ASSERT_NOT_NULL(sorter.entries);
 	TEST_ASSERT_NOT_NULL(sorter.temp_instances);
 	TEST_ASSERT_EQUAL_INT(INIT_CAPACITY, sorter.capacity);
+	TEST_ASSERT_EQUAL_INT(INIT_CAPACITY, sorter.min_capacity);
 
 	sphere_sorter_cleanup(&sorter);
 }
@@ -71,6 +85,7 @@ void test_SphereSorter_Cleanup_ShouldFreeBuffers(void)
 	TEST_ASSERT_NULL(sorter.entries);
 	TEST_ASSERT_NULL(sorter.temp_instances);
 	TEST_ASSERT_EQUAL_INT(0, sorter.capacity);
+	TEST_ASSERT_EQUAL_INT(0, sorter.min_capacity);
 }
 
 void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
@@ -79,7 +94,10 @@ void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
 	sphere_sorter_init(&sorter, TEST_COUNT_4);
 
 	int count = TEST_COUNT_3;
-	SphereInstance* instances = create_dummy_instances(count);
+	/* Ensure allocated buffer is at least min_capacity (4) even if count is
+	 * 3 */
+	SphereInstance* instances =
+	    create_dummy_instances(count, sorter.min_capacity);
 
 	/* Camera at (0,0,0) looking down -Z */
 	vec3 camera_pos = {COORD_ZERO, COORD_ZERO, COORD_ZERO};
@@ -100,7 +118,7 @@ void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
 	/* Expected Order: Far (-20), Middle (-10), Near (-5) */
 	/* Indices should become: 1, 2, 0 */
 
-	sphere_sorter_sort(&sorter, instances, count, camera_pos);
+	sphere_sorter_sort(&sorter, &instances, count, camera_pos);
 
 	/* Check First (Furthest) */
 	const int MAT_Z_INDEX = 3;
@@ -129,15 +147,18 @@ void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
 void test_SphereSorter_Resize_ShouldHandleMoreThanCapacity(void)
 {
 	SphereSorter sorter;
-	sphere_sorter_init(&sorter, SMALL_CAPACITY); /* Small capacity */
+	sphere_sorter_init(&sorter, SMALL_CAPACITY); /* Small capacity (2) */
 
-	int count = TEST_COUNT_5;
-	SphereInstance* instances = create_dummy_instances(count);
+	int count = TEST_COUNT_5; /* 5 */
+	/* Allocates max(5, 2) = 5 */
+	SphereInstance* instances =
+	    create_dummy_instances(count, sorter.min_capacity);
 	vec3 camera_pos = {COORD_ZERO, COORD_ZERO, COORD_ZERO};
 
 	/* Just check it doesn't crash and resizes */
-	sphere_sorter_sort(&sorter, instances, count, camera_pos);
+	sphere_sorter_sort(&sorter, &instances, count, camera_pos);
 
+	/* Check that capacity grew */
 	TEST_ASSERT_GREATER_OR_EQUAL(count, sorter.capacity);
 
 	free(instances);


### PR DESCRIPTION
Implemented double buffering in sphere_sorter_sort to avoid redundant memcpy.
Changed `sphere_sorter_sort` signature to accept `SphereInstance**`.
Added `min_capacity` to `SphereSorter` to prevent heap corruption and allocation thrashing when count fluctuates.
Updated `tests/test_sphere_sorting.c` to use `posix_memalign` and verify correct behavior.
Verified with tests.

---
*PR created automatically by Jules for task [8152855694095346295](https://jules.google.com/task/8152855694095346295) started by @yoyonel*