### PR TITLE
⚡ Remove redundant glPolygonMode calls in app_render

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -442,8 +442,6 @@ void app_render(App* app)
 		}
 
 		if (app->billboard_mode) {
-			glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-
 			// 1. Activer le Blending UNIQUEMENT pour la couleur
 			// (Attachment 0) Cela permet à ton 'edgeFactor' de
 			// lisser les bords de la sphère
@@ -483,7 +481,6 @@ void app_render(App* app)
 		GPU_STAGE_PROFILER(&app->gpu_profiler, "Spheres",
 		                   GPU_PROFILER_TOTAL_FRAME_COLOR);
 		if (app->billboard_mode) {
-			glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 			app_render_billboards(app, view, proj, camera_pos);
 		} else {
 			glPolygonMode(GL_FRONT_AND_BACK,


### PR DESCRIPTION
💡 **What:** Removed redundant `glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)` calls inside `billboard_mode` checks in `src/app.c`.
🎯 **Why:** To reduce redundant state changes and clean up the code.
📊 **Measured Improvement:**
- Baseline: ~18.56 ms/frame
- Optimized: ~19.14 ms/frame
- Result: No measurable improvement (difference within noise margin). However, removing redundant API calls is a best practice to minimize driver overhead.


---
*PR created automatically by Jules for task [9784846991883477171](https://jules.google.com/task/9784846991883477171) started by @yoyonel*