### PR TITLE
Fix/leak on gpu profiler UI

### DIFF
--- a/include/gpu_profiler_ui.h
+++ b/include/gpu_profiler_ui.h
@@ -46,4 +46,9 @@ void gpu_profiler_ui_toggle_visibility(GPUProfilerUI* profiler_ui);
  */
 void gpu_profiler_ui_toggle_position(GPUProfilerUI* profiler_ui);
 
+/**
+ * @brief Cleans up GPU resources used by the UI.
+ */
+void gpu_profiler_ui_cleanup(GPUProfilerUI* profiler_ui);
+
 #endif /* GPU_PROFILER_UI_H */

--- a/scripts/test_integration_asan.sh
+++ b/scripts/test_integration_asan.sh
@@ -57,14 +57,46 @@ xdotool windowactivate "$WID" || echo "Warning: windowactivate failed (expected 
 echo "Starting Integration Test Scenario..."
 # sleep 1
 
+# 0. Activate Functions
+
+echo "=> FPS Counter (F1)"
+for i in {1..6}; do
+    xdotool key --delay 200 F1
+done
+sleep 1
+
+echo "=> Help (F2)"
+xdotool key --delay 200 F2
+sleep 1
+xdotool key --delay 200 F2
+
+echo "=> Activate GPU Profiler (F3)"
+xdotool key --delay 200 F3
+sleep 1
+
+echo "=> Log on GPU Metrics (F4)"
+xdotool key --delay 200 F4
+sleep 1
+
+echo "=> Resetting Camera (R)"
+xdotool key --delay 200 R
+sleep 1
+
+echo "=> Test Full Screen (F)"
+xdotool key --delay 200 F
+sleep 1
+echo "=> Test Windowed (F)"
+xdotool key --delay 200 F
+sleep 1
+
 # 1. Environment Switching
 echo "=> Switching Environments (Page_Up / Page_Down)"
 xdotool key --delay 200 Page_Up
-sleep 2
+sleep 1
 xdotool key --delay 200 Page_Up
-sleep 2
+sleep 1
 xdotool key --delay 200 Page_Down
-sleep 2
+sleep 1
 
 # 2. Styles
 echo "=> Testing Styles (1-6)"
@@ -82,6 +114,8 @@ xdotool key --delay 500 g # Grain
 xdotool key --delay 500 b # Bloom
 xdotool key --delay 500 h # DoF
 xdotool key --delay 500 j # Auto Exposure
+xdotool key --delay 500 m # Motion Blur
+xdotool key --delay 500 x # FXAA
 
 xdotool key --delay 500 w # Wireframe ON
 xdotool key --delay 500 w # Wireframe OFF
@@ -92,19 +126,28 @@ xdotool keydown z; sleep 0.5; xdotool keyup z
 xdotool keydown d; sleep 0.5; xdotool keyup d
 xdotool keydown s; sleep 0.5; xdotool keyup s
 xdotool keydown a; sleep 0.5; xdotool keyup a
+xdotool keydown q; sleep 0.5; xdotool keyup q
+xdotool keydown e; sleep 0.5; xdotool keyup e
 
 # 5. PBR Debug Modes
 echo "=> Cycling PBR Debug Modes (F5)"
-for i in {1..5}; do
+for i in {1..9}; do
     xdotool key --delay 300 F5
 done
 
 # 6. Performance Mode
 echo "=> Toggling Performance Mode (F9)"
 xdotool key --delay 500 F9
-sleep 2
+sleep 1
 xdotool key --delay 500 F9
 # sleep 1
+
+# 7. Style 7 - Banding Modes
+echo "=> Testing Style 7 - Banding Modes"
+for i in {1..4}; do
+    xdotool key --delay 500 7
+done
+
 
 echo "=> Test Complete. Exiting..."
 xdotool key Escape

--- a/src/app.c
+++ b/src/app.c
@@ -297,6 +297,7 @@ void app_cleanup(App* app)
 	perf_mode_cleanup(&app->perf_context);
 
 	gpu_profiler_cleanup(&app->gpu_profiler);
+	gpu_profiler_ui_cleanup(&app->timeline_ui);
 
 	window_destroy(app->window);
 }

--- a/src/gpu_profiler_ui.c
+++ b/src/gpu_profiler_ui.c
@@ -101,7 +101,9 @@ static void gpu_profiler_ui_sync_stage(GPUProfilerUI* profiler_ui,
 		dest_idx = profiler_ui->display_profiler.stage_count++;
 		GPUStage* new_stage =
 		    &profiler_ui->display_profiler.stages[dest_idx];
-		*new_stage = (GPUStage){0};
+
+		/* Fix: Do NOT zero-init the whole struct, it overwrites
+		 * AdaptiveSamplers */
 		safe_strncpy(new_stage->name, sizeof(new_stage->name),
 		             live_stage->name, sizeof(new_stage->name) - 1);
 		new_stage->alpha = 0.0F;
@@ -342,4 +344,11 @@ void gpu_profiler_ui_toggle_visibility(GPUProfilerUI* profiler_ui)
 void gpu_profiler_ui_toggle_position(GPUProfilerUI* profiler_ui)
 {
 	profiler_ui->position = (profiler_ui->position == 0) ? 1 : 0;
+}
+
+void gpu_profiler_ui_cleanup(GPUProfilerUI* profiler_ui)
+{
+	if (profiler_ui) {
+		gpu_profiler_cleanup(&profiler_ui->display_profiler);
+	}
 }


### PR DESCRIPTION
## Overview
This PR fixes significant memory leaks (approx. 240 KB) in the GPU Profiler UI components reported by AddressSanitizer. 

## Root Causes
1. **Missing Cleanup**: The `GPUProfiler` instance used for display in `GPUProfilerUI` was initialized but never cleaned up, leaving `AdaptiveSampler` buffers allocated.
2. **Initialization Bug**: In [gpu_profiler_ui_sync_stage](src/gpu_profiler_ui.c:85:0-136:1), the `GPUStage` structure was being zero-initialized using [(GPUStage){0}](src/app.c:304:0-361:1). This overrode the previously initialized `AdaptiveSampler` pointers with `NULL`, leaking the allocated memory and causing losing state/leaks upon re-initialization.

## Changes
- **GPU Profiler UI**:
    - Implemented [gpu_profiler_ui_cleanup()](src/gpu_profiler_ui.c:348:0-353:1) to properly free internal resources (calls [gpu_profiler_cleanup](src/gpu_profiler.c:53:0-79:1)).
    - Refactored [gpu_profiler_ui_sync_stage()](src/gpu_profiler_ui.c:85:0-136:1) to initialize only necessary fields (name, alpha, etc.) instead of zeroing the entire structure, preserving the `AdaptiveSampler` members.
- **Header Updates**: Added the [gpu_profiler_ui_cleanup](src/gpu_profiler_ui.c:348:0-353:1) declaration to [gpu_profiler_ui.h](include/gpu_profiler_ui.h:0:0-0:0).
- **App Lifecycle**: Updated [app.c](src/app.c:0:0-0:0) to call the new cleanup function in `app_cleanup`.

## Verification Results
Verified with AddressSanitizer via the integration test suite:
```bash
make test-integration-asan
```