### PR TITLE
Sentinel: Fix buffer overflow in billboard rendering

### DIFF
--- a/include/billboard_rendering.h
+++ b/include/billboard_rendering.h
@@ -22,10 +22,10 @@
 typedef struct {
 	GLuint
 	    vao; /**< Dedicated VAO linking quad geometry and instance data. */
-	GLuint instance_vbo;  /**< GPU buffer storing per-instance attributes
-	                         (position, color). */
-	int instance_count;   /**< Number of billboards in this group. */
-	int capacity;         /**< Maximum number of instances allocated in VBO. */
+	GLuint instance_vbo; /**< GPU buffer storing per-instance attributes
+	                        (position, color). */
+	int instance_count;  /**< Number of billboards in this group. */
+	int capacity; /**< Maximum number of instances allocated in VBO. */
 	GLuint vao_wire_quad; /**< VAO for debug wireframe quad. */
 	GLuint vao_wire_box;  /**< VAO for debug wireframe box. */
 } BillboardGroup;

--- a/include/billboard_rendering.h
+++ b/include/billboard_rendering.h
@@ -25,6 +25,7 @@ typedef struct {
 	GLuint instance_vbo;  /**< GPU buffer storing per-instance attributes
 	                         (position, color). */
 	int instance_count;   /**< Number of billboards in this group. */
+	int capacity;         /**< Maximum number of instances allocated in VBO. */
 	GLuint vao_wire_quad; /**< VAO for debug wireframe quad. */
 	GLuint vao_wire_box;  /**< VAO for debug wireframe box. */
 } BillboardGroup;

--- a/src/billboard_rendering.c
+++ b/src/billboard_rendering.c
@@ -17,6 +17,7 @@ void billboard_group_init(BillboardGroup* group, const SphereInstance* data,
 	assert(group->instance_vbo == 0 && "Double initialization detected");
 
 	group->instance_count = count;
+	group->capacity = count;
 	group->vao = 0;
 	group->vao_wire_quad = 0;
 	group->vao_wire_box = 0;
@@ -37,11 +38,26 @@ void billboard_group_update(BillboardGroup* group, const SphereInstance* data,
 		return;
 	}
 
-	/* Update GPU buffer with new sorted data */
-	glBindBuffer(GL_ARRAY_BUFFER, group->instance_vbo);
-	/* Using glBufferSubData is fine for small updates (10-100 instances) */
-	glBufferSubData(GL_ARRAY_BUFFER, 0,
-	                (GLsizeiptr)(count * sizeof(SphereInstance)), data);
+	/* Update active count */
+	group->instance_count = count;
+
+	/* Check for overflow */
+	if (count > group->capacity) {
+		/* Reallocate buffer */
+		glBindBuffer(GL_ARRAY_BUFFER, group->instance_vbo);
+		glBufferData(GL_ARRAY_BUFFER,
+		             (GLsizeiptr)(count * sizeof(SphereInstance)), data,
+		             GL_DYNAMIC_DRAW);
+		group->capacity = count;
+	} else {
+		/* Update GPU buffer with new sorted data */
+		glBindBuffer(GL_ARRAY_BUFFER, group->instance_vbo);
+		/* Using glBufferSubData is fine for small updates (10-100
+		 * instances) */
+		glBufferSubData(GL_ARRAY_BUFFER, 0,
+		                (GLsizeiptr)(count * sizeof(SphereInstance)),
+		                data);
+	}
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.c")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_path_security_standalone\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_cleanup\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_toctou\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_overflow\\.c$")
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
 set(OPENGL_TESTS
@@ -183,6 +184,29 @@ target_link_libraries(test_billboard_cleanup PRIVATE cglm)
 
 add_test(NAME test_billboard_cleanup
          COMMAND test_billboard_cleanup)
+
+# =============================================================================
+# TEST BILLBOARD OVERFLOW (MOCKED)
+# =============================================================================
+add_executable(test_billboard_overflow
+    test_billboard_overflow.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+)
+
+target_include_directories(test_billboard_overflow PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_billboard_overflow PRIVATE cglm)
+
+add_test(NAME test_billboard_overflow
+         COMMAND test_billboard_overflow)
 
 # =============================================================================
 # NOTES ET DOCUMENTATION

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -6,12 +6,20 @@
 static GLuint g_generated_buffer_id = DEFAULT_BUFFER_ID;
 static GLuint g_last_deleted_buffer = 0;
 static int g_delete_buffer_call_count = 0;
+static int g_buffer_data_call_count = 0;
+static int g_buffer_sub_data_call_count = 0;
+static GLsizeiptr g_last_buffer_data_size = 0;
+static GLsizeiptr g_last_buffer_sub_data_size = 0;
 
 void mock_gl_reset_calls(void)
 {
 	g_generated_buffer_id = DEFAULT_BUFFER_ID;
 	g_last_deleted_buffer = 0;
 	g_delete_buffer_call_count = 0;
+	g_buffer_data_call_count = 0;
+	g_buffer_sub_data_call_count = 0;
+	g_last_buffer_data_size = 0;
+	g_last_buffer_sub_data_size = 0;
 }
 
 GLuint mock_gl_get_generated_buffer_id(void)
@@ -32,6 +40,26 @@ GLuint mock_gl_get_last_deleted_buffer(void)
 int mock_gl_get_delete_buffer_call_count(void)
 {
 	return g_delete_buffer_call_count;
+}
+
+int mock_gl_get_buffer_data_call_count(void)
+{
+	return g_buffer_data_call_count;
+}
+
+int mock_gl_get_buffer_sub_data_call_count(void)
+{
+	return g_buffer_sub_data_call_count;
+}
+
+GLsizeiptr mock_gl_get_last_buffer_data_size(void)
+{
+	return g_last_buffer_data_size;
+}
+
+GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void)
+{
+	return g_last_buffer_sub_data_size;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -56,9 +84,10 @@ void glBufferData(GLenum target, GLsizeiptr size, const void* data,
                   GLenum usage)
 {
 	(void)target;
-	(void)size;
 	(void)data;
 	(void)usage;
+	g_buffer_data_call_count++;
+	g_last_buffer_data_size = size;
 }
 
 void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
@@ -66,8 +95,9 @@ void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
 {
 	(void)target;
 	(void)offset;
-	(void)size;
 	(void)data;
+	g_buffer_sub_data_call_count++;
+	g_last_buffer_sub_data_size = size;
 }
 
 void glDeleteBuffers(GLsizei n, const GLuint* buffers)

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -59,5 +59,9 @@ GLuint mock_gl_get_generated_buffer_id(void);
 GLuint mock_gl_get_generated_vao_id(void);
 GLuint mock_gl_get_last_deleted_buffer(void);
 int mock_gl_get_delete_buffer_call_count(void);
+int mock_gl_get_buffer_data_call_count(void);
+int mock_gl_get_buffer_sub_data_call_count(void);
+GLsizeiptr mock_gl_get_last_buffer_data_size(void);
+GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void);
 
 #endif /* MOCK_GL_STANDALONE_H */

--- a/tests/test_billboard_overflow.c
+++ b/tests/test_billboard_overflow.c
@@ -1,0 +1,74 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "billboard_rendering.h"
+#include "mock_gl_standalone.h"
+#include "unity.h"
+
+/* Mock render_utils function */
+void render_utils_setup_sphere_instance_attributes(GLsizei stride,
+                                                   size_t offset_albedo,
+                                                   size_t offset_metallic)
+{
+	(void)stride;
+	(void)offset_albedo;
+	(void)offset_metallic;
+}
+
+#ifndef SYNC_ATTR_START
+#define SYNC_ATTR_START 10
+#endif
+#ifndef MAX_VERTEX_ATTRIBS_BASELINE
+#define MAX_VERTEX_ATTRIBS_BASELINE 16
+#endif
+
+/* Include source directly to access internal state if needed */
+#include "billboard_rendering.c"
+
+void setUp(void)
+{
+	mock_gl_reset_calls();
+}
+
+void tearDown(void)
+{
+}
+
+void test_billboard_group_update_handles_overflow(void)
+{
+	BillboardGroup group = {0};
+	SphereInstance instances[2]; /* Initial capacity 2 */
+	SphereInstance large_instances[4]; /* New count 4 */
+
+	/* Initialize the group with 2 instances */
+	billboard_group_init(&group, instances, 2);
+
+	/* Reset mocks to clear the glBufferData call from init */
+	mock_gl_reset_calls();
+
+	/* Update with 4 instances - should trigger reallocation */
+	billboard_group_update(&group, large_instances, 4);
+
+	/* Verify reallocation happened */
+	/* glBufferData should be called once (reallocation) */
+	TEST_ASSERT_EQUAL_MESSAGE(1, mock_gl_get_buffer_data_call_count(),
+	                          "Expected glBufferData (reallocation) to be called");
+
+	/* glBufferSubData should NOT be called */
+	TEST_ASSERT_EQUAL_MESSAGE(0, mock_gl_get_buffer_sub_data_call_count(),
+	                          "Expected glBufferSubData NOT to be called");
+
+	/* Verify size */
+	TEST_ASSERT_EQUAL_MESSAGE(4 * sizeof(SphereInstance),
+	                          mock_gl_get_last_buffer_data_size(),
+	                          "Expected buffer size to match new count");
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_billboard_group_update_handles_overflow);
+	return UNITY_END();
+}

--- a/tests/test_billboard_overflow.c
+++ b/tests/test_billboard_overflow.c
@@ -1,11 +1,10 @@
+#include "billboard_rendering.h"
+#include "mock_gl_standalone.h"
+#include "unity.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "billboard_rendering.h"
-#include "mock_gl_standalone.h"
-#include "unity.h"
 
 /* Mock render_utils function */
 void render_utils_setup_sphere_instance_attributes(GLsizei stride,
@@ -39,7 +38,7 @@ void tearDown(void)
 void test_billboard_group_update_handles_overflow(void)
 {
 	BillboardGroup group = {0};
-	SphereInstance instances[2]; /* Initial capacity 2 */
+	SphereInstance instances[2];       /* Initial capacity 2 */
 	SphereInstance large_instances[4]; /* New count 4 */
 
 	/* Initialize the group with 2 instances */
@@ -53,8 +52,9 @@ void test_billboard_group_update_handles_overflow(void)
 
 	/* Verify reallocation happened */
 	/* glBufferData should be called once (reallocation) */
-	TEST_ASSERT_EQUAL_MESSAGE(1, mock_gl_get_buffer_data_call_count(),
-	                          "Expected glBufferData (reallocation) to be called");
+	TEST_ASSERT_EQUAL_MESSAGE(
+	    1, mock_gl_get_buffer_data_call_count(),
+	    "Expected glBufferData (reallocation) to be called");
 
 	/* glBufferSubData should NOT be called */
 	TEST_ASSERT_EQUAL_MESSAGE(0, mock_gl_get_buffer_sub_data_call_count(),


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix buffer overflow in billboard rendering

**Vulnerability:**
The `billboard_group_update` function in `src/billboard_rendering.c` blindly called `glBufferSubData` with the current instance count, even if it exceeded the initial buffer capacity allocated in `billboard_group_init`. This could lead to out-of-bounds writes on the GPU buffer, causing memory corruption or driver crashes.

**Impact:**
If the number of spheres (instances) increases dynamically beyond the initial allocation (e.g., via scene updates or logic changes), the application would write past the end of the VBO.

**Fix:**
- Added a `capacity` field to `BillboardGroup` struct in `include/billboard_rendering.h`.
- Updated `billboard_group_init` to initialize `capacity`.
- Updated `billboard_group_update` to check `count > capacity`.
    - If overflow detected: Reallocate the buffer using `glBufferData` (which resizes it) and update `capacity`.
    - If no overflow: Continue using `glBufferSubData` for performance.

**Verification:**
- Added `tests/test_billboard_overflow.c` which simulates an overflow scenario using mocked OpenGL calls.
- Verified manually (due to environment limitations) that `glBufferData` is called when count increases, and `glBufferSubData` is not called in that case.
- Updated `mock_gl_standalone` to support verification of buffer data calls.

---
*PR created automatically by Jules for task [10031986742595226666](https://jules.google.com/task/10031986742595226666) started by @yoyonel*