### PR TITLE
chore(cleanup): remove unused functions in instanced_rendering module

### DIFF
--- a/include/instanced_rendering.h
+++ b/include/instanced_rendering.h
@@ -60,29 +60,11 @@ void instanced_group_bind_mesh(InstancedGroup* group, GLuint vbo, GLuint nbo,
                                GLuint ebo);
 
 /**
- * @brief Binds a quad mesh to the instanced group (fallback or specialized
- * use).
- * @param group Pointer to the group.
- * @param vbo Quad VBO.
- */
-void instanced_group_bind_billboard(InstancedGroup* group, GLuint vbo);
-
-/**
  * @brief Executes an indexed instanced draw call.
  * @param group Pointer to the group.
  * @param index_count Number of indices in the base mesh.
  */
 void instanced_group_draw(InstancedGroup* group, size_t index_count);
-
-/**
- * @brief Executes a non-indexed instanced draw call.
- * @param group Pointer to the group.
- * @param mode GL primitive mode (e.g., GL_TRIANGLES).
- * @param first Starting vertex index.
- * @param count Number of vertices per instance.
- */
-void instanced_group_draw_arrays(InstancedGroup* group, GLenum mode, int first,
-                                 int count);
 
 /**
  * @brief Releases all GPU resources for the instanced group.

--- a/src/instanced_rendering.c
+++ b/src/instanced_rendering.c
@@ -64,42 +64,6 @@ void instanced_group_bind_mesh(InstancedGroup* group, GLuint vbo, GLuint nbo,
 	glBindVertexArray(0);
 }
 
-void instanced_group_bind_billboard(InstancedGroup* group, GLuint vbo)
-{
-	if (group->vao != 0) {
-		glDeleteVertexArrays(1, &group->vao);
-		group->vao = 0;
-	}
-
-	glGenVertexArrays(1, &group->vao);
-	glBindVertexArray(group->vao);
-
-	// -- GÉOMÉTRIE (Quad) --
-	glBindBuffer(GL_ARRAY_BUFFER, vbo);
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void*)0);
-	glEnableVertexAttribArray(0);
-	glVertexAttribDivisor(0, 0);
-
-	/* Ensure unused attribute 1 has divisor 0 */
-	glVertexAttribDivisor(1, 0);
-
-	// Pas de normales (index 1) pour les billboards
-
-	// -- INSTANCES --
-	glBindBuffer(GL_ARRAY_BUFFER, group->instance_vbo);
-	setup_instance_attributes();
-
-	glBindVertexArray(0);
-}
-
-void instanced_group_draw_arrays(InstancedGroup* group, GLenum mode, int first,
-                                 int count)
-{
-	glBindVertexArray(group->vao);
-	glDrawArraysInstanced(mode, first, count, group->instance_count);
-	glBindVertexArray(0);
-}
-
 void instanced_group_draw(InstancedGroup* group, size_t index_count)
 {
 	glBindVertexArray(group->vao);

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -14,9 +14,12 @@ typedef long GLsizeiptr;
 typedef long GLintptr;
 
 #define GL_ARRAY_BUFFER 0
+#define GL_ELEMENT_ARRAY_BUFFER 0
 #define GL_DYNAMIC_DRAW 0
 #define GL_FLOAT 0
+#define GL_UNSIGNED_INT 0
 #define GL_CULL_FACE 0
+#define GL_TRIANGLES 0
 #define GL_TRIANGLE_STRIP 0
 #define GL_LINE_LOOP 0
 #define GL_LINES 0
@@ -111,6 +114,8 @@ void glVertexAttribDivisor(GLuint index, GLuint divisor);
 
 void glDrawArraysInstanced(GLenum mode, GLint first, GLsizei count,
                            GLsizei instancecount);
+void glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type,
+                             const void* indices, GLsizei instancecount);
 void glEnable(GLenum cap);
 void glDisable(GLenum cap);
 GLboolean glIsEnabled(GLenum cap);


### PR DESCRIPTION
Removed `instanced_group_bind_billboard` and `instanced_group_draw_arrays` from `instanced_rendering` module.
Verified that `make test` passes (syntax verification with mock headers).
Ran `clang-format` on modified files.

---
*PR created automatically by Jules for task [15059577728746993403](https://jules.google.com/task/15059577728746993403) started by @yoyonel*