### PR TITLE
Fix OpenGL resource leaks on re-initialization and enhance debug logging

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -39,6 +39,11 @@
 
 int app_init(App* app, int width, int height, const char* title)
 {
+	/* Cleanup if re-initializing */
+	if (app->window != NULL) {
+		app_cleanup(app);
+	}
+
 	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 	(void)memset(
 	    app, 0,

--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -104,22 +104,27 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 
 	entry->count++;
 
-	/* Log only the first occurrence to avoid flooding, matching Rust
-	 * behavior */
-	if (entry->count == 1) {
-		const char *src_str = get_source_str(source);
-		const char *type_str = get_type_str(type);
-		const char *sev_str = get_severity_str(severity);
+	const char *src_str = get_source_str(source);
+	const char *type_str = get_type_str(type);
+	const char *sev_str = get_severity_str(severity);
 
-		if (type == GL_DEBUG_TYPE_ERROR ||
-		    severity == GL_DEBUG_SEVERITY_HIGH) {
-			LOG_ERROR(LOG_TAG,
-			          "id: 0x%X, source: %s, type: %s, severity: "
-			          "%s, message: %s",
-			          message_id, src_str, type_str, sev_str,
-			          message);
-		} else if (severity == GL_DEBUG_SEVERITY_MEDIUM ||
-		           severity == GL_DEBUG_SEVERITY_LOW) {
+	/* Always log Errors and High Severity messages to prevent hiding critical
+	 * issues */
+	if (type == GL_DEBUG_TYPE_ERROR ||
+	    severity == GL_DEBUG_SEVERITY_HIGH) {
+		LOG_ERROR(LOG_TAG,
+		          "id: 0x%X, source: %s, type: %s, severity: "
+		          "%s, message: %s (Count: %u)",
+		          message_id, src_str, type_str, sev_str, message,
+		          entry->count);
+		return;
+	}
+
+	/* Log only the first occurrence for less critical messages to avoid
+	 * flooding */
+	if (entry->count == 1) {
+		if (severity == GL_DEBUG_SEVERITY_MEDIUM ||
+		    severity == GL_DEBUG_SEVERITY_LOW) {
 			LOG_WARNING(LOG_TAG,
 			            "id: 0x%X, source: %s, type: %s, severity: "
 			            "%s, message: %s",

--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -108,10 +108,9 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 	const char *type_str = get_type_str(type);
 	const char *sev_str = get_severity_str(severity);
 
-	/* Always log Errors and High Severity messages to prevent hiding critical
-	 * issues */
-	if (type == GL_DEBUG_TYPE_ERROR ||
-	    severity == GL_DEBUG_SEVERITY_HIGH) {
+	/* Always log Errors and High Severity messages to prevent hiding
+	 * critical issues */
+	if (type == GL_DEBUG_TYPE_ERROR || severity == GL_DEBUG_SEVERITY_HIGH) {
 		LOG_ERROR(LOG_TAG,
 		          "id: 0x%X, source: %s, type: %s, severity: "
 		          "%s, message: %s (Count: %u)",

--- a/src/gpu_profiler.c
+++ b/src/gpu_profiler.c
@@ -17,6 +17,12 @@ void gpu_profiler_init(GPUProfiler* profiler)
 		return;
 	}
 
+	/* Check for potential double-initialization and clean up existing
+	 * resources */
+	if (profiler->buffers[0].queries[0].query_start != 0) {
+		gpu_profiler_cleanup(profiler);
+	}
+
 	/* 1. Safe Zero Initialization (replaces unsafe memset) */
 	*profiler = (GPUProfiler){0};
 

--- a/src/skybox.c
+++ b/src/skybox.c
@@ -7,6 +7,11 @@
 
 void skybox_init(Skybox* skybox, Shader* shader)
 {
+	/* Cleanup existing resources if re-initializing */
+	if (skybox->vao != 0) {
+		skybox_cleanup(skybox);
+	}
+
 	/* Cache uniform locations using robust shader API */
 	skybox->u_inv_view_proj =
 	    shader_get_uniform_location(shader, "m_inv_view_proj");

--- a/src/ui.c
+++ b/src/ui.c
@@ -254,6 +254,11 @@ int ui_init(UIContext* ui_context, const char* font_path, float font_size)
 		return 0;
 	}
 
+	/* Cleanup existing resources if re-initializing */
+	if (ui_context->texture != 0 || ui_context->vao != 0) {
+		ui_destroy(ui_context);
+	}
+
 	// Initialize to safe defaults (manual zeroing to avoid memset warning)
 	ui_context->texture = 0;
 	ui_context->shader = NULL;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,16 @@ target_link_libraries(app_testlib PUBLIC ${TEST_COMMON_LIBS})
 target_compile_definitions(app_testlib PUBLIC UNITY_INCLUDE_DOUBLE)
 # target_compile_definitions(app_testlib PUBLIC GLFW_INCLUDE_NONE _POSIX_C_SOURCE=199309L)
 
+# Force GLFW include for FetchContent usage if needed
+if(TARGET glfw)
+    target_include_directories(app_testlib PUBLIC ${glfw_SOURCE_DIR}/include)
+else()
+    # If glfw target is not defined (e.g. system provided or separate fetch), try to find where it is
+    if(EXISTS "${CMAKE_SOURCE_DIR}/build/_deps/glfw-src/include")
+        target_include_directories(app_testlib PUBLIC ${CMAKE_SOURCE_DIR}/build/_deps/glfw-src/include)
+    endif()
+endif()
+
 # =============================================================================
 # AUTO-DÉCOUVERTE DES TESTS
 # =============================================================================
@@ -80,7 +90,13 @@ foreach(test_file ${TEST_SOURCES})
 
     # Créer l'exécutable
     add_executable(${test_name} ${test_file})
-    target_link_libraries(${test_name} PRIVATE app_testlib)
+
+    # Check if test uses GLFW and link accordingly
+    if(${test_name} IN_LIST OPENGL_TESTS)
+        target_link_libraries(${test_name} PRIVATE app_testlib ${GLFW3_LIBRARIES})
+    else()
+        target_link_libraries(${test_name} PRIVATE app_testlib)
+    endif()
 
     # Injecter les variables pour le test de sécurité du log
     if(${test_name} STREQUAL "test_log_security")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_path_security_standalone\\
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_cleanup\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_toctou\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_overflow\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_reinit_leaks\\.c$")
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
 set(OPENGL_TESTS
@@ -208,6 +209,29 @@ target_link_libraries(test_billboard_overflow PRIVATE cglm)
 
 add_test(NAME test_billboard_overflow
          COMMAND test_billboard_overflow)
+
+# =============================================================================
+# TEST REINIT LEAKS (MOCKED)
+# =============================================================================
+add_executable(test_reinit_leaks
+    test_reinit_leaks.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+)
+
+target_include_directories(test_reinit_leaks PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_reinit_leaks PRIVATE cglm m)
+
+add_test(NAME test_reinit_leaks
+         COMMAND test_reinit_leaks)
 
 # =============================================================================
 # NOTES ET DOCUMENTATION

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -148,8 +148,14 @@ void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
                         const float* value);
 void glPopDebugGroup(void);
 void glDeleteTextures(GLsizei n, const GLuint* textures);
-void glDebugMessageCallback(void (*callback)(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam), const void* userParam);
-void glDebugMessageControl(GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint* ids, GLboolean enabled);
+void glDebugMessageCallback(void (*callback)(GLenum source, GLenum type,
+                                             GLuint id, GLenum severity,
+                                             GLsizei length,
+                                             const GLchar* message,
+                                             const void* userParam),
+                            const void* userParam);
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity,
+                           GLsizei count, const GLuint* ids, GLboolean enabled);
 
 void glGenTextures(GLsizei n, GLuint* textures);
 void glBindTexture(GLenum target, GLuint texture);
@@ -198,7 +204,8 @@ void glDrawArrays(GLenum mode, GLint first, GLsizei count);
 GLenum glCheckFramebufferStatus(GLenum target);
 const GLubyte* glGetString(GLenum name);
 void glDepthFunc(GLenum func);
-void glObjectLabel(GLenum identifier, GLuint name, GLsizei length, const GLchar* label);
+void glObjectLabel(GLenum identifier, GLuint name, GLsizei length,
+                   const GLchar* label);
 void glGetIntegerv(GLenum pname, GLint* data);
 void glPolygonMode(GLenum face, GLenum mode);
 void glBlendFunc(GLenum sfactor, GLenum dfactor);

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -2,6 +2,7 @@
 #define __glad_h_
 
 #include <stddef.h>
+#include <stdint.h>
 
 typedef unsigned int GLuint;
 typedef unsigned int GLenum;
@@ -9,18 +10,22 @@ typedef int GLint;
 typedef int GLsizei;
 typedef char GLchar;
 typedef unsigned char GLboolean;
+typedef unsigned char GLubyte;
 typedef float GLfloat;
 typedef long GLsizeiptr;
 typedef long GLintptr;
 
-#define GL_ARRAY_BUFFER 0
-#define GL_ELEMENT_ARRAY_BUFFER 0
-#define GL_DYNAMIC_DRAW 0
-#define GL_FLOAT 0
+#define GL_ARRAY_BUFFER 0x8892
+#define GL_ELEMENT_ARRAY_BUFFER 0x8893
+#define GL_STATIC_DRAW 0x88E4
+#define GL_DYNAMIC_DRAW 0x88E8
+#define GL_STREAM_READ 0x88E1
+#define GL_FLOAT 0x1406
 #define GL_UNSIGNED_INT 0
+#define GL_UNSIGNED_BYTE 0x1401
 #define GL_CULL_FACE 0
-#define GL_TRIANGLES 0
-#define GL_TRIANGLE_STRIP 0
+#define GL_TRIANGLES 0x0004
+#define GL_TRIANGLE_STRIP 0x0005
 #define GL_LINE_LOOP 0
 #define GL_LINES 0
 #define GL_FALSE 0
@@ -36,12 +41,18 @@ typedef long GLintptr;
 #define GL_ACTIVE_UNIFORM_MAX_LENGTH 0
 #define GL_PROGRAM_BINARY_LENGTH 0
 #define APIENTRY
+
+/* Textures */
 #define GL_TEXTURE_2D 0x0DE1
+#define GL_TEXTURE0 0x84C0
+#define GL_TEXTURE 0x1702
+#define GL_RED 0x1903
 #define GL_RGBA16F 0x881A
 #define GL_RGBA 0x1908
 #define GL_UNPACK_ALIGNMENT 0x0CF5
 #define GL_TEXTURE_MIN_FILTER 0x2801
 #define GL_TEXTURE_MAG_FILTER 0x2800
+#define GL_NEAREST 0x2600
 #define GL_LINEAR_MIPMAP_LINEAR 0x2703
 #define GL_LINEAR 0x2601
 #define GL_TEXTURE_WRAP_S 0x2802
@@ -49,6 +60,62 @@ typedef long GLintptr;
 #define GL_REPEAT 0x2901
 #define GL_CLAMP_TO_EDGE 0x812F
 #define GL_NO_ERROR 0
+
+/* Buffers & VAO */
+#define GL_BUFFER 0x82E0
+#define GL_VERTEX_ARRAY 0x8074
+
+/* Framebuffer */
+#define GL_FRAMEBUFFER 0x8D40
+#define GL_FRAMEBUFFER_COMPLETE 0x8CD5
+
+/* Drawing */
+#define GL_FILL 0x1B02
+
+/* Depth */
+#define GL_DEPTH_TEST 0x0B71
+#define GL_LEQUAL 0x0203
+#define GL_LESS 0x0201
+
+/* Strings */
+#define GL_VENDOR 0x1F00
+#define GL_RENDERER 0x1F01
+#define GL_VERSION 0x1F02
+
+/* Debug */
+#define GL_DEBUG_OUTPUT 0x92E0
+#define GL_DEBUG_OUTPUT_SYNCHRONOUS 0x8242
+#define GL_DEBUG_SOURCE_API 0x8246
+#define GL_DEBUG_SOURCE_WINDOW_SYSTEM 0x8247
+#define GL_DEBUG_SOURCE_SHADER_COMPILER 0x8248
+#define GL_DEBUG_SOURCE_THIRD_PARTY 0x8249
+#define GL_DEBUG_SOURCE_APPLICATION 0x824A
+#define GL_DEBUG_SOURCE_OTHER 0x824B
+#define GL_DEBUG_TYPE_ERROR 0x824C
+#define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR 0x824D
+#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR 0x824E
+#define GL_DEBUG_TYPE_PORTABILITY 0x824F
+#define GL_DEBUG_TYPE_PERFORMANCE 0x8250
+#define GL_DEBUG_TYPE_MARKER 0x8268
+#define GL_DEBUG_TYPE_PUSH_GROUP 0x8269
+#define GL_DEBUG_TYPE_POP_GROUP 0x826A
+#define GL_DEBUG_TYPE_OTHER 0x8251
+#define GL_DEBUG_SEVERITY_HIGH 0x9146
+#define GL_DEBUG_SEVERITY_MEDIUM 0x9147
+#define GL_DEBUG_SEVERITY_LOW 0x9148
+#define GL_DEBUG_SEVERITY_NOTIFICATION 0x826B
+#define GL_DONT_CARE 0x1100
+
+/* Blending & Polygon */
+#define GL_BLEND 0x0BE2
+#define GL_SRC_ALPHA 0x0302
+#define GL_ONE_MINUS_SRC_ALPHA 0x0303
+#define GL_POLYGON_MODE 0x0B40
+#define GL_FRONT_AND_BACK 0x0408
+
+/* Query */
+#define GL_QUERY_RESULT 0x8866
+#define GL_TIMESTAMP 0x8E28
 
 GLuint glCreateShader(GLenum type);
 void glShaderSource(GLuint shader, GLsizei count, const GLchar** string,
@@ -81,6 +148,8 @@ void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
                         const float* value);
 void glPopDebugGroup(void);
 void glDeleteTextures(GLsizei n, const GLuint* textures);
+void glDebugMessageCallback(void (*callback)(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam), const void* userParam);
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint* ids, GLboolean enabled);
 
 void glGenTextures(GLsizei n, GLuint* textures);
 void glBindTexture(GLenum target, GLuint texture);
@@ -101,6 +170,11 @@ void glBufferData(GLenum target, GLsizeiptr size, const void* data,
 void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
                      const void* data);
 void glDeleteBuffers(GLsizei n, const GLuint* buffers);
+void glGenQueries(GLsizei n, GLuint* ids);
+void glDeleteQueries(GLsizei n, const GLuint* ids);
+void glQueryCounter(GLuint id, GLenum target);
+typedef uint64_t GLuint64;
+void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params);
 
 void glGenVertexArrays(GLsizei n, GLuint* arrays);
 void glBindVertexArray(GLuint array);
@@ -119,5 +193,14 @@ void glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type,
 void glEnable(GLenum cap);
 void glDisable(GLenum cap);
 GLboolean glIsEnabled(GLenum cap);
+void glActiveTexture(GLenum texture);
+void glDrawArrays(GLenum mode, GLint first, GLsizei count);
+GLenum glCheckFramebufferStatus(GLenum target);
+const GLubyte* glGetString(GLenum name);
+void glDepthFunc(GLenum func);
+void glObjectLabel(GLenum identifier, GLuint name, GLsizei length, const GLchar* label);
+void glGetIntegerv(GLenum pname, GLint* data);
+void glPolygonMode(GLenum face, GLenum mode);
+void glBlendFunc(GLenum sfactor, GLenum dfactor);
 
 #endif

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -10,6 +10,8 @@ static int g_buffer_data_call_count = 0;
 static int g_buffer_sub_data_call_count = 0;
 static GLsizeiptr g_last_buffer_data_size = 0;
 static GLsizeiptr g_last_buffer_sub_data_size = 0;
+static int g_delete_query_call_count = 0;
+static int g_delete_texture_call_count = 0;
 
 void mock_gl_reset_calls(void)
 {
@@ -20,6 +22,8 @@ void mock_gl_reset_calls(void)
 	g_buffer_sub_data_call_count = 0;
 	g_last_buffer_data_size = 0;
 	g_last_buffer_sub_data_size = 0;
+	g_delete_query_call_count = 0;
+	g_delete_texture_call_count = 0;
 }
 
 GLuint mock_gl_get_generated_buffer_id(void)
@@ -60,6 +64,16 @@ GLsizeiptr mock_gl_get_last_buffer_data_size(void)
 GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void)
 {
 	return g_last_buffer_sub_data_size;
+}
+
+int mock_gl_get_delete_query_call_count(void)
+{
+	return g_delete_query_call_count;
+}
+
+int mock_gl_get_delete_texture_call_count(void)
+{
+	return g_delete_texture_call_count;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -247,13 +261,9 @@ GLenum glGetError(void)
 void glDeleteTextures(GLsizei n, const GLuint* textures)
 {
 	(void)n;
-	(void)textures;
-}
-
-void glGetIntegerv(GLenum pname, GLint* data)
-{
-	(void)pname;
-	(void)data;
+	if (textures) {
+		g_delete_texture_call_count++;
+	}
 }
 
 /* -------------------------------------------------------------------------- */
@@ -396,4 +406,99 @@ void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
 }
 void glPopDebugGroup(void)
 {
+}
+
+void glGenQueries(GLsizei n, GLuint* ids)
+{
+	(void)n;
+	if (ids) {
+		*ids = 999;
+	}
+}
+
+void glDeleteQueries(GLsizei n, const GLuint* ids)
+{
+	(void)n;
+	if (ids) {
+		g_delete_query_call_count++;
+	}
+}
+
+void glQueryCounter(GLuint id, GLenum target)
+{
+	(void)id;
+	(void)target;
+}
+
+void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params)
+{
+	(void)id;
+	(void)pname;
+	if (params) {
+		*params = 100;
+	}
+}
+
+void glTexImage2D(GLenum target, GLint level, GLint internalformat,
+                  GLsizei width, GLsizei height, GLint border, GLenum format,
+                  GLenum type, const void* pixels)
+{
+	(void)target;
+	(void)level;
+	(void)internalformat;
+	(void)width;
+	(void)height;
+	(void)border;
+	(void)format;
+	(void)type;
+	(void)pixels;
+}
+
+void glActiveTexture(GLenum texture)
+{
+	(void)texture;
+}
+
+void glDrawArrays(GLenum mode, GLint first, GLsizei count)
+{
+	(void)mode;
+	(void)first;
+	(void)count;
+}
+
+GLenum glCheckFramebufferStatus(GLenum target)
+{
+	(void)target;
+	return GL_FRAMEBUFFER_COMPLETE;
+}
+
+const GLubyte* glGetString(GLenum name)
+{
+	(void)name;
+	return (const GLubyte*)"Mock GL";
+}
+
+void glDepthFunc(GLenum func)
+{
+	(void)func;
+}
+
+void glGetIntegerv(GLenum pname, GLint* data)
+{
+	(void)pname;
+	if (data) {
+		*data = 0;
+	}
+}
+
+void glPolygonMode(GLenum face, GLenum mode)
+{
+	(void)face;
+	(void)mode;
+}
+
+void glBlendFunc(GLenum sfactor, GLenum dfactor)
+{
+	(void)sfactor;
+	(void)dfactor;
 }

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -1,9 +1,9 @@
 #ifndef MOCK_GL_STANDALONE_H
 #define MOCK_GL_STANDALONE_H
 
+#include "glad/glad.h"
 #include <stddef.h>
 #include <stdint.h>
-#include "glad/glad.h"
 
 /* Defaults */
 #define DEFAULT_BUFFER_ID 123

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -2,20 +2,8 @@
 #define MOCK_GL_STANDALONE_H
 
 #include <stddef.h>
-
-/* Define types compatible with GLAD/OpenGL */
-typedef unsigned int GLuint;
-typedef unsigned int GLenum;
-typedef int GLint;
-typedef int GLsizei;
-typedef char GLchar;
-typedef unsigned char GLboolean;
-typedef float GLfloat;
-typedef long GLsizeiptr;
-typedef long GLintptr;
-
-#define GL_FALSE 0
-#define GL_TRUE 1
+#include <stdint.h>
+#include "glad/glad.h"
 
 /* Defaults */
 #define DEFAULT_BUFFER_ID 123
@@ -53,6 +41,16 @@ void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
                         const float* value);
 void glPopDebugGroup(void);
 
+/* Additional APIs for tests */
+void glTexImage2D(GLenum target, GLint level, GLint internalformat,
+                  GLsizei width, GLsizei height, GLint border, GLenum format,
+                  GLenum type, const void* pixels);
+void glActiveTexture(GLenum texture);
+void glDrawArrays(GLenum mode, GLint first, GLsizei count);
+GLenum glCheckFramebufferStatus(GLenum target);
+const GLubyte* glGetString(GLenum name);
+void glDepthFunc(GLenum func);
+
 /* Control API */
 void mock_gl_reset_calls(void);
 GLuint mock_gl_get_generated_buffer_id(void);
@@ -63,5 +61,14 @@ int mock_gl_get_buffer_data_call_count(void);
 int mock_gl_get_buffer_sub_data_call_count(void);
 GLsizeiptr mock_gl_get_last_buffer_data_size(void);
 GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void);
+int mock_gl_get_delete_texture_call_count(void);
+
+/* Query API */
+void glGenQueries(GLsizei n, GLuint* ids);
+void glDeleteQueries(GLsizei n, const GLuint* ids);
+void glQueryCounter(GLuint id, GLenum target);
+void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params);
+
+int mock_gl_get_delete_query_call_count(void);
 
 #endif /* MOCK_GL_STANDALONE_H */

--- a/tests/test_gpu_profiler.c
+++ b/tests/test_gpu_profiler.c
@@ -59,7 +59,7 @@ void tearDown(void)
  */
 void test_gpu_profiler_init(void)
 {
-	GPUProfiler profiler;
+	GPUProfiler profiler = {0};
 	gpu_profiler_init(&profiler);
 
 	TEST_ASSERT_EQUAL(0, profiler.stage_count);
@@ -77,7 +77,7 @@ void test_gpu_profiler_init(void)
  */
 void test_gpu_profiler_double_buffering_swap(void)
 {
-	GPUProfiler profiler;
+	GPUProfiler profiler = {0};
 	gpu_profiler_init(&profiler);
 
 	// Initial State: Write 0, Read 1
@@ -105,7 +105,7 @@ void test_gpu_profiler_double_buffering_swap(void)
  */
 void test_gpu_profiler_stage_registration(void)
 {
-	GPUProfiler profiler;
+	GPUProfiler profiler = {0};
 	gpu_profiler_init(&profiler);
 	gpu_profiler_set_enabled(&profiler, true);
 
@@ -142,7 +142,7 @@ void test_gpu_profiler_stage_registration(void)
  */
 void test_gpu_profiler_result_retrieval(void)
 {
-	GPUProfiler profiler;
+	GPUProfiler profiler = {0};
 	gpu_profiler_init(&profiler);
 
 	// On boucle suffisamment pour amorcer le buffer circulaire (Ping-Pong)

--- a/tests/test_reinit_leaks.c
+++ b/tests/test_reinit_leaks.c
@@ -1,35 +1,81 @@
-#include "unity.h"
-#include "mock_gl_standalone.h"
 #include "log.h"
+#include "mock_gl_standalone.h"
 #include "shader.h"
+#include "unity.h"
 
 // Define mocks for functions needed by the source files
 
 // Mock log_message
-void log_message(LogLevel level, const char* tag, const char* fmt, ...) { (void)level; (void)tag; (void)fmt; }
+void log_message(LogLevel level, const char* tag, const char* fmt, ...)
+{
+	(void)level;
+	(void)tag;
+	(void)fmt;
+}
 
 // Mock shader functions
 // We can return a pointer to a static dummy shader
 static Shader dummy_shader = {0};
 
-Shader* shader_load(const char* v, const char* f) { (void)v; (void)f; return &dummy_shader; }
-void shader_destroy(Shader* s) { (void)s; }
-void shader_use(Shader* s) { (void)s; }
-void shader_set_mat4(Shader* s, const char* n, const float* v) { (void)s; (void)n; (void)v; }
-void shader_set_vec3(Shader* s, const char* n, const float* v) { (void)s; (void)n; (void)v; }
-void shader_set_float(Shader* s, const char* n, float v) { (void)s; (void)n; (void)v; }
-void shader_set_int(Shader* s, const char* n, int v) { (void)s; (void)n; (void)v; }
-void shader_set_vec2(Shader* s, const char* n, const float* v) { (void)s; (void)n; (void)v; }
+Shader* shader_load(const char* v, const char* f)
+{
+	(void)v;
+	(void)f;
+	return &dummy_shader;
+}
+void shader_destroy(Shader* s)
+{
+	(void)s;
+}
+void shader_use(Shader* s)
+{
+	(void)s;
+}
+void shader_set_mat4(Shader* s, const char* n, const float* v)
+{
+	(void)s;
+	(void)n;
+	(void)v;
+}
+void shader_set_vec3(Shader* s, const char* n, const float* v)
+{
+	(void)s;
+	(void)n;
+	(void)v;
+}
+void shader_set_float(Shader* s, const char* n, float v)
+{
+	(void)s;
+	(void)n;
+	(void)v;
+}
+void shader_set_int(Shader* s, const char* n, int v)
+{
+	(void)s;
+	(void)n;
+	(void)v;
+}
+void shader_set_vec2(Shader* s, const char* n, const float* v)
+{
+	(void)s;
+	(void)n;
+	(void)v;
+}
 
 // Helper to mock shader_get_uniform_location
-GLint shader_get_uniform_location(Shader* shader, const char* name) { (void)shader; (void)name; return 0; }
+GLint shader_get_uniform_location(Shader* shader, const char* name)
+{
+	(void)shader;
+	(void)name;
+	return 0;
+}
 
 // Include source files directly
 // Dependencies need to be included first or handled via headers
 
 #include "adaptive_sampler.c"
-#include "metric_stack.c"
 #include "gpu_profiler.c"
+#include "metric_stack.c"
 
 // ui.c includes ui.h -> shader.h
 #include "ui.c"
@@ -43,74 +89,81 @@ GLint shader_get_uniform_location(Shader* shader, const char* name) { (void)shad
 // stb implementation
 #include "stb_image_impl.c"
 
-void setUp(void) {
-    mock_gl_reset_calls();
+void setUp(void)
+{
+	mock_gl_reset_calls();
 }
 
-void tearDown(void) {
+void tearDown(void)
+{
 }
 
-void test_gpu_profiler_init_leak(void) {
-    GPUProfiler profiler = {0};
+void test_gpu_profiler_init_leak(void)
+{
+	GPUProfiler profiler = {0};
 
-    // First init
-    gpu_profiler_init(&profiler);
+	// First init
+	gpu_profiler_init(&profiler);
 
-    // Simulate that the profiler was used and has valid queries
-    // gpu_profiler_init creates queries and assigns them.
-    // Mock glGenQueries assigns 999.
+	// Simulate that the profiler was used and has valid queries
+	// gpu_profiler_init creates queries and assigns them.
+	// Mock glGenQueries assigns 999.
 
-    TEST_ASSERT_EQUAL(999, profiler.buffers[0].queries[0].query_start);
+	TEST_ASSERT_EQUAL(999, profiler.buffers[0].queries[0].query_start);
 
-    mock_gl_reset_calls();
+	mock_gl_reset_calls();
 
-    // Re-init WITHOUT cleanup. Should verify that it DOES call glDeleteQueries now.
-    gpu_profiler_init(&profiler);
+	// Re-init WITHOUT cleanup. Should verify that it DOES call
+	// glDeleteQueries now.
+	gpu_profiler_init(&profiler);
 
-    // Check that cleanup was called
-    TEST_ASSERT_GREATER_THAN(0, mock_gl_get_delete_query_call_count());
+	// Check that cleanup was called
+	TEST_ASSERT_GREATER_THAN(0, mock_gl_get_delete_query_call_count());
 
-    // Cleanup to be nice
-    gpu_profiler_cleanup(&profiler);
+	// Cleanup to be nice
+	gpu_profiler_cleanup(&profiler);
 }
 
-void test_ui_init_leak(void) {
-    UIContext ui = {0};
+void test_ui_init_leak(void)
+{
+	UIContext ui = {0};
 
-    // To properly test leak, we need ui_init to FAIL (so it cleans up?) or SUCCEED?
-    // If it succeeds, it overwrites.
+	// To properly test leak, we need ui_init to FAIL (so it cleans up?) or
+	// SUCCEED? If it succeeds, it overwrites.
 
-    // Pre-populate with a texture ID
-    ui.texture = 123;
+	// Pre-populate with a texture ID
+	ui.texture = 123;
 
-    // Calling ui_init with existing ID.
-    // It will likely fail because we didn't mock file reading for font, returning 0.
-    // But BEFORE failing, does it check texture? No.
-    // Does it overwrite texture? Yes: ui_context->texture = 0;
+	// Calling ui_init with existing ID.
+	// It will likely fail because we didn't mock file reading for font,
+	// returning 0. But BEFORE failing, does it check texture? No. Does it
+	// overwrite texture? Yes: ui_context->texture = 0;
 
-    // So if we check mock_gl_get_delete_buffer_call_count (for texture?) No, texture delete.
-    // We need mock_gl_get_delete_texture_call_count?
-    // mock_gl_standalone currently mocks glDeleteTextures but doesn't expose a counter?
-    // It exposes g_delete_buffer_call_count.
+	// So if we check mock_gl_get_delete_buffer_call_count (for texture?)
+	// No, texture delete. We need mock_gl_get_delete_texture_call_count?
+	// mock_gl_standalone currently mocks glDeleteTextures but doesn't
+	// expose a counter? It exposes g_delete_buffer_call_count.
 
-    // I need to update mock_gl_standalone.c to expose texture delete count.
-    // But wait, ui_init resets it to 0 immediately.
-    // So if it returns 0 (fail), ui.texture is 0.
-    // And if it didn't call delete, we leaked 123.
+	// I need to update mock_gl_standalone.c to expose texture delete count.
+	// But wait, ui_init resets it to 0 immediately.
+	// So if it returns 0 (fail), ui.texture is 0.
+	// And if it didn't call delete, we leaked 123.
 
-    // I will add mock_gl_get_delete_texture_call_count to mock_gl_standalone.
-    // For now, I can assert that ui.texture is 0 (it was overwritten).
+	// I will add mock_gl_get_delete_texture_call_count to
+	// mock_gl_standalone. For now, I can assert that ui.texture is 0 (it
+	// was overwritten).
 
-    int result = ui_init(&ui, "dummy_font.ttf", 16.0f);
-    TEST_ASSERT_EQUAL(0, result); // Expect fail due to font load
+	int result = ui_init(&ui, "dummy_font.ttf", 16.0f);
+	TEST_ASSERT_EQUAL(0, result);  // Expect fail due to font load
 
-    // Verify delete called (leak prevention)
-    TEST_ASSERT_EQUAL(1, mock_gl_get_delete_texture_call_count());
+	// Verify delete called (leak prevention)
+	TEST_ASSERT_EQUAL(1, mock_gl_get_delete_texture_call_count());
 }
 
-int main(void) {
-    UNITY_BEGIN();
-    RUN_TEST(test_gpu_profiler_init_leak);
-    RUN_TEST(test_ui_init_leak);
-    return UNITY_END();
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_gpu_profiler_init_leak);
+	RUN_TEST(test_ui_init_leak);
+	return UNITY_END();
 }

--- a/tests/test_reinit_leaks.c
+++ b/tests/test_reinit_leaks.c
@@ -1,0 +1,116 @@
+#include "unity.h"
+#include "mock_gl_standalone.h"
+#include "log.h"
+#include "shader.h"
+
+// Define mocks for functions needed by the source files
+
+// Mock log_message
+void log_message(LogLevel level, const char* tag, const char* fmt, ...) { (void)level; (void)tag; (void)fmt; }
+
+// Mock shader functions
+// We can return a pointer to a static dummy shader
+static Shader dummy_shader = {0};
+
+Shader* shader_load(const char* v, const char* f) { (void)v; (void)f; return &dummy_shader; }
+void shader_destroy(Shader* s) { (void)s; }
+void shader_use(Shader* s) { (void)s; }
+void shader_set_mat4(Shader* s, const char* n, const float* v) { (void)s; (void)n; (void)v; }
+void shader_set_vec3(Shader* s, const char* n, const float* v) { (void)s; (void)n; (void)v; }
+void shader_set_float(Shader* s, const char* n, float v) { (void)s; (void)n; (void)v; }
+void shader_set_int(Shader* s, const char* n, int v) { (void)s; (void)n; (void)v; }
+void shader_set_vec2(Shader* s, const char* n, const float* v) { (void)s; (void)n; (void)v; }
+
+// Helper to mock shader_get_uniform_location
+GLint shader_get_uniform_location(Shader* shader, const char* name) { (void)shader; (void)name; return 0; }
+
+// Include source files directly
+// Dependencies need to be included first or handled via headers
+
+#include "adaptive_sampler.c"
+#include "metric_stack.c"
+#include "gpu_profiler.c"
+
+// ui.c includes ui.h -> shader.h
+#include "ui.c"
+
+// render_utils.c
+#include "render_utils.c"
+
+// skybox.c
+#include "skybox.c"
+
+// stb implementation
+#include "stb_image_impl.c"
+
+void setUp(void) {
+    mock_gl_reset_calls();
+}
+
+void tearDown(void) {
+}
+
+void test_gpu_profiler_init_leak(void) {
+    GPUProfiler profiler = {0};
+
+    // First init
+    gpu_profiler_init(&profiler);
+
+    // Simulate that the profiler was used and has valid queries
+    // gpu_profiler_init creates queries and assigns them.
+    // Mock glGenQueries assigns 999.
+
+    TEST_ASSERT_EQUAL(999, profiler.buffers[0].queries[0].query_start);
+
+    mock_gl_reset_calls();
+
+    // Re-init WITHOUT cleanup. Should verify that it DOES call glDeleteQueries now.
+    gpu_profiler_init(&profiler);
+
+    // Check that cleanup was called
+    TEST_ASSERT_GREATER_THAN(0, mock_gl_get_delete_query_call_count());
+
+    // Cleanup to be nice
+    gpu_profiler_cleanup(&profiler);
+}
+
+void test_ui_init_leak(void) {
+    UIContext ui = {0};
+
+    // To properly test leak, we need ui_init to FAIL (so it cleans up?) or SUCCEED?
+    // If it succeeds, it overwrites.
+
+    // Pre-populate with a texture ID
+    ui.texture = 123;
+
+    // Calling ui_init with existing ID.
+    // It will likely fail because we didn't mock file reading for font, returning 0.
+    // But BEFORE failing, does it check texture? No.
+    // Does it overwrite texture? Yes: ui_context->texture = 0;
+
+    // So if we check mock_gl_get_delete_buffer_call_count (for texture?) No, texture delete.
+    // We need mock_gl_get_delete_texture_call_count?
+    // mock_gl_standalone currently mocks glDeleteTextures but doesn't expose a counter?
+    // It exposes g_delete_buffer_call_count.
+
+    // I need to update mock_gl_standalone.c to expose texture delete count.
+    // But wait, ui_init resets it to 0 immediately.
+    // So if it returns 0 (fail), ui.texture is 0.
+    // And if it didn't call delete, we leaked 123.
+
+    // I will add mock_gl_get_delete_texture_call_count to mock_gl_standalone.
+    // For now, I can assert that ui.texture is 0 (it was overwritten).
+
+    int result = ui_init(&ui, "dummy_font.ttf", 16.0f);
+    TEST_ASSERT_EQUAL(0, result); // Expect fail due to font load
+
+    // Verify delete called (leak prevention)
+    TEST_ASSERT_EQUAL(1, mock_gl_get_delete_texture_call_count());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_gpu_profiler_init_leak);
+    RUN_TEST(test_ui_init_leak);
+    return UNITY_END();
+}


### PR DESCRIPTION
This PR addresses OpenGL state inconsistencies identified during static and dynamic analysis.

Key changes:
1.  **Leak Prevention:** Initialization functions (`gpu_profiler_init`, `ui_init`, `skybox_init`, `app_init`) now explicitly check if the target structure already holds valid OpenGL resources (non-zero handles). If so, they invoke the corresponding cleanup/destroy function before resetting the structure. This prevents GPU memory leaks if these subsystems are re-initialized (e.g., during hot-reloading or state transitions).
2.  **Enhanced Debugging:** The `gl_debug_callback` was modified to force logging of all High Severity and Error type messages, removing the suppression logic that hid repeated errors. This ensures critical state issues are always visible.
3.  **Regression Testing:** A new standalone test `tests/test_reinit_leaks.c` was added. It uses the `mock_gl_standalone` framework to simulate OpenGL calls and asserts that `glDelete*` functions are invoked when initialization is attempted on an already-populated structure.
4.  **Mock Framework Updates:** The mock OpenGL headers and implementation were updated to include missing constants (`GL_STATIC_DRAW`, `GL_TEXTURE0`, etc.) and functions (`glGenQueries`, `glDeleteQueries`, `glGetIntegerv`) required for the new tests.

These changes ensure compliance with OpenGL 4.x resource management best practices and improve the robustness of the application's lifecycle management.

---
*PR created automatically by Jules for task [9654517406746976201](https://jules.google.com/task/9654517406746976201) started by @yoyonel*