### PR TITLE
Fix OpenGL state leak in gpu_timer_start

### DIFF
--- a/src/perf_timer.c
+++ b/src/perf_timer.c
@@ -92,9 +92,13 @@ void gpu_timer_start(GPUTimer* timer)
 		return;
 	}
 
-	// Générer les query objects
-	glGenQueries(1, &timer->query_start);
-	glGenQueries(1, &timer->query_end);
+	// Générer les query objects (seulement s'ils n'existent pas déjà)
+	if (timer->query_start == 0) {
+		glGenQueries(1, &timer->query_start);
+	}
+	if (timer->query_end == 0) {
+		glGenQueries(1, &timer->query_end);
+	}
 
 	// Enregistrer le timestamp actuel sur le GPU
 	glQueryCounter(timer->query_start, GL_TIMESTAMP);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_path_security_standalone\\
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_cleanup\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_toctou\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_overflow\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_gpu_timer_leak\\.c$")
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
 set(OPENGL_TESTS
@@ -208,6 +209,29 @@ target_link_libraries(test_billboard_overflow PRIVATE cglm)
 
 add_test(NAME test_billboard_overflow
          COMMAND test_billboard_overflow)
+
+# =============================================================================
+# TEST GPU TIMER LEAK (MOCKED)
+# =============================================================================
+add_executable(test_gpu_timer_leak
+    test_gpu_timer_leak.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+)
+
+target_include_directories(test_gpu_timer_leak PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_gpu_timer_leak PRIVATE cglm m)
+
+add_test(NAME test_gpu_timer_leak
+         COMMAND test_gpu_timer_leak)
 
 # =============================================================================
 # NOTES ET DOCUMENTATION

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -11,6 +11,14 @@ static int g_buffer_sub_data_call_count = 0;
 static GLsizeiptr g_last_buffer_data_size = 0;
 static GLsizeiptr g_last_buffer_sub_data_size = 0;
 
+/* Query Object Stats */
+static int g_gen_queries_call_count = 0;
+static int g_delete_queries_call_count = 0;
+static int g_query_counter_call_count = 0;
+static int g_flush_call_count = 0;
+static int g_finish_call_count = 0;
+static GLuint g_next_query_id = DEFAULT_QUERY_ID_START;
+
 void mock_gl_reset_calls(void)
 {
 	g_generated_buffer_id = DEFAULT_BUFFER_ID;
@@ -20,6 +28,13 @@ void mock_gl_reset_calls(void)
 	g_buffer_sub_data_call_count = 0;
 	g_last_buffer_data_size = 0;
 	g_last_buffer_sub_data_size = 0;
+
+	g_gen_queries_call_count = 0;
+	g_delete_queries_call_count = 0;
+	g_query_counter_call_count = 0;
+	g_flush_call_count = 0;
+	g_finish_call_count = 0;
+	g_next_query_id = DEFAULT_QUERY_ID_START;
 }
 
 GLuint mock_gl_get_generated_buffer_id(void)
@@ -60,6 +75,31 @@ GLsizeiptr mock_gl_get_last_buffer_data_size(void)
 GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void)
 {
 	return g_last_buffer_sub_data_size;
+}
+
+int mock_gl_get_gen_queries_call_count(void)
+{
+	return g_gen_queries_call_count;
+}
+
+int mock_gl_get_delete_queries_call_count(void)
+{
+	return g_delete_queries_call_count;
+}
+
+int mock_gl_get_query_counter_call_count(void)
+{
+	return g_query_counter_call_count;
+}
+
+int mock_gl_get_flush_call_count(void)
+{
+	return g_flush_call_count;
+}
+
+int mock_gl_get_finish_call_count(void)
+{
+	return g_finish_call_count;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -254,6 +294,59 @@ void glGetIntegerv(GLenum pname, GLint* data)
 {
 	(void)pname;
 	(void)data;
+}
+
+/* Query Object Mocks */
+void glGenQueries(GLsizei n, GLuint* ids)
+{
+	if (!ids)
+		return;
+	g_gen_queries_call_count++;
+	for (GLsizei i = 0; i < n; i++) {
+		ids[i] = g_next_query_id++;
+	}
+}
+
+void glDeleteQueries(GLsizei n, const GLuint* ids)
+{
+	(void)ids;
+	g_delete_queries_call_count++;
+	(void)n;
+}
+
+void glQueryCounter(GLuint id, GLenum target)
+{
+	(void)id;
+	(void)target;
+	g_query_counter_call_count++;
+}
+
+void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params)
+{
+	(void)id;
+	(void)pname;
+	if (params) {
+		*params = 1000; /* Return a dummy timestamp */
+	}
+}
+
+void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params)
+{
+	(void)id;
+	(void)pname;
+	if (params) {
+		*params = GL_TRUE; /* Available */
+	}
+}
+
+void glFlush(void)
+{
+	g_flush_call_count++;
+}
+
+void glFinish(void)
+{
+	g_finish_call_count++;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -13,13 +13,21 @@ typedef unsigned char GLboolean;
 typedef float GLfloat;
 typedef long GLsizeiptr;
 typedef long GLintptr;
+typedef unsigned long long GLuint64;
+typedef long long GLint64;
 
 #define GL_FALSE 0
 #define GL_TRUE 1
 
+/* Query Object Constants */
+#define GL_TIMESTAMP 0x8E28
+#define GL_QUERY_RESULT 0x8866
+#define GL_QUERY_RESULT_AVAILABLE 0x8867
+
 /* Defaults */
 #define DEFAULT_BUFFER_ID 123
 #define DEFAULT_VAO_ID 456
+#define DEFAULT_QUERY_ID_START 1000
 
 /* Shader & Program APIs */
 GLuint glCreateShader(GLenum type);
@@ -53,6 +61,15 @@ void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
                         const float* value);
 void glPopDebugGroup(void);
 
+/* Query Object APIs */
+void glGenQueries(GLsizei n, GLuint* ids);
+void glDeleteQueries(GLsizei n, const GLuint* ids);
+void glQueryCounter(GLuint id, GLenum target);
+void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params);
+void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params);
+void glFlush(void);
+void glFinish(void);
+
 /* Control API */
 void mock_gl_reset_calls(void);
 GLuint mock_gl_get_generated_buffer_id(void);
@@ -63,5 +80,12 @@ int mock_gl_get_buffer_data_call_count(void);
 int mock_gl_get_buffer_sub_data_call_count(void);
 GLsizeiptr mock_gl_get_last_buffer_data_size(void);
 GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void);
+
+/* Query Stats API */
+int mock_gl_get_gen_queries_call_count(void);
+int mock_gl_get_delete_queries_call_count(void);
+int mock_gl_get_query_counter_call_count(void);
+int mock_gl_get_flush_call_count(void);
+int mock_gl_get_finish_call_count(void);
 
 #endif /* MOCK_GL_STANDALONE_H */

--- a/tests/test_gpu_timer_leak.c
+++ b/tests/test_gpu_timer_leak.c
@@ -1,0 +1,52 @@
+#include "mock_gl_standalone.h"
+#include "unity.h"
+
+/* Include the source file directly to test static functions or internal state
+ * if needed */
+/* Also ensures we use the mock headers if include paths are set correctly */
+#include "perf_timer.c"
+
+void setUp(void)
+{
+	mock_gl_reset_calls();
+}
+
+void tearDown(void)
+{
+}
+
+void test_gpu_timer_start_leak(void)
+{
+	GPUTimer timer = {0};
+
+	/* First call: Should generate queries */
+	gpu_timer_start(&timer);
+
+	TEST_ASSERT_EQUAL_INT(2, mock_gl_get_gen_queries_call_count());
+	TEST_ASSERT_NOT_EQUAL(0, timer.query_start);
+	TEST_ASSERT_NOT_EQUAL(0, timer.query_end);
+
+	GLuint first_start = timer.query_start;
+	GLuint first_end = timer.query_end;
+
+	/* Second call: Should NOT generate new queries if fixed.
+	   But currently it DOES, so we expect count to increase to 4.
+	   Once fixed, this expectation should change to 2. */
+
+	gpu_timer_start(&timer);
+
+	/* Assert the FIX (no leak) */
+	/* Expect count to remain 2 (no new queries generated) */
+	TEST_ASSERT_EQUAL_INT(2, mock_gl_get_gen_queries_call_count());
+
+	/* Also check that IDs did NOT change (reused) */
+	TEST_ASSERT_EQUAL(first_start, timer.query_start);
+	TEST_ASSERT_EQUAL(first_end, timer.query_end);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_gpu_timer_start_leak);
+	return UNITY_END();
+}


### PR DESCRIPTION
Detected and fixed an OpenGL state inconsistency in `src/perf_timer.c`: `gpu_timer_start` was generating new Query Objects (`glGenQueries`) on every invocation without checking for existing handles, leading to resource exhaustion and state leaks.

Changes:
- Modified `gpu_timer_start` to only generate queries if handles are zero (lazy initialization).
- Extended `mock_gl_standalone` to support Query Object functions (`glGenQueries`, `glQueryCounter`, etc.) and call tracking.
- Added regression test `tests/test_gpu_timer_leak.c` confirming the fix (asserts 0 re-allocations on subsequent starts).
- Registered the new test in `tests/CMakeLists.txt`.

---
*PR created automatically by Jules for task [18226296114240661045](https://jules.google.com/task/18226296114240661045) started by @yoyonel*