### PR TITLE
Sentinel: [HIGH] Prevent DoS via Shader Include Bomb

### DIFF
--- a/src/shader.c
+++ b/src/shader.c
@@ -147,12 +147,28 @@ static void ctx_add_buffer(IncludeContext* ctx, char* data)
 	ctx->buffers_head = loaded_buf;
 }
 
-static void ctx_add_chunk(IncludeContext* ctx, const char* ptr, size_t len)
+static bool ctx_add_chunk(IncludeContext* ctx, const char* ptr, size_t len)
 {
 	if (len == 0) {
-		return;
+		return true;
 	}
+
+	/* Prevent DoS via recursive include explosion */
+	if (len > MAX_SHADER_SOURCE_SIZE ||
+	    ctx->total_size > MAX_SHADER_SOURCE_SIZE - len) {
+		LOG_ERROR("suckless-ogl.shader",
+		          "Shader source expansion exceeds limit (%d bytes)",
+		          MAX_SHADER_SOURCE_SIZE);
+		return false;
+	}
+
 	Chunk* chunk = malloc(sizeof(Chunk));
+	if (!chunk) {
+		LOG_ERROR("suckless-ogl.shader",
+		          "Failed to allocate memory for shader chunk");
+		return false;
+	}
+
 	chunk->ptr = ptr;
 	chunk->len = len;
 	chunk->next = NULL;
@@ -164,6 +180,8 @@ static void ctx_add_chunk(IncludeContext* ctx, const char* ptr, size_t len)
 	}
 	ctx->chunks_tail = chunk;
 	ctx->total_size += len;
+
+	return true;
 }
 
 static void ctx_free(IncludeContext* ctx)
@@ -331,7 +349,9 @@ static bool process_source(IncludeContext* ctx, const char* current_file_src,
 	while (cursor && *cursor) {
 		const char* next_tag = strstr(cursor, "@header");
 		if (!next_tag) {
-			ctx_add_chunk(ctx, cursor, strlen(cursor));
+			if (!ctx_add_chunk(ctx, cursor, strlen(cursor))) {
+				return false;
+			}
 			break;
 		}
 
@@ -342,13 +362,17 @@ static bool process_source(IncludeContext* ctx, const char* current_file_src,
 		if (!at_line_start) {
 			size_t len =
 			    (size_t)(next_tag - cursor) + HEADER_TAG_LEN;
-			ctx_add_chunk(ctx, cursor, len);
+			if (!ctx_add_chunk(ctx, cursor, len)) {
+				return false;
+			}
 			cursor = next_tag + HEADER_TAG_LEN;
 			continue;
 		}
 
 		/* Add chunk BEFORE the tag */
-		ctx_add_chunk(ctx, cursor, (size_t)(next_tag - cursor));
+		if (!ctx_add_chunk(ctx, cursor, (size_t)(next_tag - cursor))) {
+			return false;
+		}
 
 		/* Parse path */
 		char raw_inc_path[PATH_BUFFER_SIZE];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_cleanup\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_toctou\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_overflow\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_gpu_profiler_repro\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_limit\\.c$")
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
 set(OPENGL_TESTS
@@ -275,6 +276,29 @@ target_link_libraries(test_gpu_profiler_repro PRIVATE cglm m)
 
 add_test(NAME test_gpu_profiler_repro
          COMMAND test_gpu_profiler_repro)
+
+# =============================================================================
+# TEST SHADER LIMIT (MOCKED)
+# =============================================================================
+add_executable(test_shader_limit
+    test_shader_limit.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+)
+
+target_include_directories(test_shader_limit PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_shader_limit PRIVATE cglm m)
+
+add_test(NAME test_shader_limit
+         COMMAND test_shader_limit)
 
 # =============================================================================
 # NOTES ET DOCUMENTATION

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -125,9 +125,14 @@ void glEnable(GLenum cap);
 void glDisable(GLenum cap);
 GLboolean glIsEnabled(GLenum cap);
 
+#include <stdint.h>
+
+typedef uint64_t GLuint64;
+typedef int64_t GLint64;
+
 void glGenQueries(GLsizei n, GLuint* ids);
 void glDeleteQueries(GLsizei n, const GLuint* ids);
 void glQueryCounter(GLuint id, GLenum target);
-void glGetQueryObjectui64v(GLuint id, GLenum pname, unsigned long long* params);
+void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params);
 
 #endif

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -458,8 +458,7 @@ void glQueryCounter(GLuint query_id, GLenum target)
 	(void)target;
 }
 
-void glGetQueryObjectui64v(GLuint query_id, GLenum pname,
-                           unsigned long long* params)
+void glGetQueryObjectui64v(GLuint query_id, GLenum pname, GLuint64* params)
 {
 	(void)query_id;
 	(void)pname;

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -1,9 +1,11 @@
 #ifndef MOCK_GL_STANDALONE_H
 #define MOCK_GL_STANDALONE_H
 
-#include <stddef.h>
+#include <stdint.h>
 
 /* Define types compatible with GLAD/OpenGL */
+typedef uint64_t GLuint64;
+typedef int64_t GLint64;
 typedef unsigned int GLuint;
 typedef unsigned int GLenum;
 typedef int GLint;
@@ -74,7 +76,7 @@ void glTexImage2D(GLenum target, GLint level, GLint internalformat,
 void glGenQueries(GLsizei n, GLuint* ids);
 void glDeleteQueries(GLsizei n, const GLuint* ids);
 void glQueryCounter(GLuint id, GLenum target);
-void glGetQueryObjectui64v(GLuint id, GLenum pname, unsigned long long* params);
+void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params);
 
 /* Control API */
 void mock_gl_reset_calls(void);

--- a/tests/test_shader_limit.c
+++ b/tests/test_shader_limit.c
@@ -1,0 +1,84 @@
+#include "glad/glad.h"
+#include "log.h"
+#include "mock_gl_standalone.h"
+#include "unity.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Mock Logging */
+void log_message(LogLevel level, const char* tag, const char* format, ...)
+{
+	(void)level;
+	(void)tag;
+	(void)format;
+}
+void log_set_callback(LogCallback callback)
+{
+	(void)callback;
+}
+void log_set_level(LogLevel level)
+{
+	(void)level;
+}
+LogLevel log_get_level(void)
+{
+	return LOG_LEVEL_INFO;
+}
+
+/* Include source to test static functions */
+#include "shader.c"
+
+void setUp(void)
+{
+	mock_gl_reset_calls();
+}
+void tearDown(void)
+{
+}
+
+void test_ctx_add_chunk_limit(void)
+{
+	IncludeContext ctx = {0};
+
+	// 1. Fill up to limit - 1
+	ctx.total_size = MAX_SHADER_SOURCE_SIZE - 1;
+
+	// 2. Add 1 byte -> Should Succeed
+	bool res = ctx_add_chunk(&ctx, "a", 1);
+	TEST_ASSERT_TRUE_MESSAGE(
+	    res, "Adding small chunk within limit should succeed");
+	TEST_ASSERT_EQUAL_UINT_MESSAGE(MAX_SHADER_SOURCE_SIZE, ctx.total_size,
+	                               "Total size should reach limit");
+
+	// 3. Add 1 byte -> Should Fail (Exceeds limit)
+	res = ctx_add_chunk(&ctx, "b", 1);
+	TEST_ASSERT_FALSE_MESSAGE(res,
+	                          "Adding chunk exceeding limit should fail");
+
+	// Cleanup to prevent memory leaks (ctx_add_chunk allocates chunk)
+	// Since we manually constructed ctx, we need to manually clean up list
+	ctx_free(&ctx);
+}
+
+void test_ctx_add_chunk_large_overflow(void)
+{
+	IncludeContext ctx = {0};
+
+	// Add chunk larger than limit
+	bool res = ctx_add_chunk(&ctx, "large", MAX_SHADER_SOURCE_SIZE + 1);
+	TEST_ASSERT_FALSE_MESSAGE(res, "Adding huge chunk should fail");
+	TEST_ASSERT_EQUAL_UINT_MESSAGE(0, ctx.total_size,
+	                               "Total size should remain 0");
+
+	ctx_free(&ctx);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_ctx_add_chunk_limit);
+	RUN_TEST(test_ctx_add_chunk_large_overflow);
+	return UNITY_END();
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Prevent DoS via Shader Include Bomb

**Vulnerability:** The shader include mechanism (`@header`) allowed recursive file inclusion without checking the total accumulated size of the expanded source code. This could lead to a "Billion Laughs" style DoS attack where a small set of files expands exponentially, consuming all available memory and crashing the application.

**Fix:**
- Updated `ctx_add_chunk` in `src/shader.c` to enforcing the existing `MAX_SHADER_SOURCE_SIZE` (16MB) limit on the *accumulated* `ctx->total_size`.
- Added check for integer overflow in size accumulation (`len > MAX || total > MAX - len`).
- Added check for `malloc` failure when allocating new chunks.
- Propagated return values (bool) from `ctx_add_chunk` up the call stack to abort loading immediately upon failure.

**Verification:**
- Created `tests/test_shader_limit.c` which includes `src/shader.c` (whitebox test) and mocks the GL environment.
- Verified that `ctx_add_chunk` returns `false` when the size limit is exceeded.
- Verified that `ctx_add_chunk` returns `true` when adding chunks within the limit.
- Verified manually by compiling and running the test in the standalone environment (since full project build is blocked by missing system dependencies).

---
*PR created automatically by Jules for task [18423925373226676912](https://jules.google.com/task/18423925373226676912) started by @yoyonel*