### PR TITLE
chore(cleanup): remove unused functions in postprocess module

### DIFF
--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -429,39 +429,8 @@ int postprocess_is_enabled(PostProcess* post_processing,
 
 /* --- Parameter Tuning --- */
 
-void postprocess_set_white_balance(PostProcess* post_processing,
-                                   float temperature, float tint);
-void postprocess_set_color_grading(PostProcess* post_processing,
-                                   float saturation, float contrast,
-                                   float gamma, float gain, float offset);
-void postprocess_set_tonemapper(PostProcess* post_processing, float slope,
-                                float toe, float shoulder, float black_clip,
-                                float white_clip);
-void postprocess_set_grading_ue_default(PostProcess* post_processing);
-void postprocess_set_vignette(PostProcess* post_processing, float intensity,
-                              float smoothness, float roundness);
-void postprocess_set_grain(PostProcess* post_processing, float intensity);
 void postprocess_set_exposure(PostProcess* post_processing, float exposure);
-void postprocess_set_chrom_abbr(PostProcess* post_processing, float strength);
-void postprocess_set_bloom(PostProcess* post_processing, float intensity,
-                           float threshold, float soft_threshold);
-void postprocess_set_dof(PostProcess* post_processing, float focal_distance,
-                         float focal_range, float bokeh_scale);
 float postprocess_get_exposure(PostProcess* post_processing);
-void postprocess_set_auto_exposure(PostProcess* post_processing,
-                                   float min_luminance, float max_luminance,
-                                   float speed_up, float speed_down,
-                                   float key_value);
-void postprocess_set_fxaa(PostProcess* post_processing, float subpix,
-                          float edge_threshold, float edge_threshold_min);
-void postprocess_set_banding(PostProcess* post_processing, BandingMode mode,
-                             float levels);
-void postprocess_set_banding_dither(PostProcess* post_processing,
-                                    float strength);
-void postprocess_set_banding_perceptual(PostProcess* post_processing,
-                                        float gamma);
-void postprocess_set_banding_channels(PostProcess* post_processing, float red,
-                                      float green, float blue);
 
 /**
  * @brief Updates view-projection matrices for effects requiring

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -323,158 +323,15 @@ int postprocess_is_enabled(PostProcess* post_processing,
 	return (post_processing->active_effects & (unsigned int)effect) != 0;
 }
 
-void postprocess_set_vignette(PostProcess* post_processing, float intensity,
-                              float smoothness, float roundness)
-{
-	post_processing->vignette.intensity = intensity;
-	post_processing->vignette.smoothness = smoothness;
-	post_processing->vignette.roundness = roundness;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_grain(PostProcess* post_processing, float intensity)
-{
-	post_processing->grain.intensity = intensity;
-	post_processing->ubo_dirty = true;
-}
-
 void postprocess_set_exposure(PostProcess* post_processing, float exposure)
 {
 	post_processing->exposure.exposure = exposure;
 	post_processing->ubo_dirty = true;
 }
 
-void postprocess_set_chrom_abbr(PostProcess* post_processing, float strength)
-{
-	post_processing->chrom_abbr.strength = strength;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_white_balance(PostProcess* post_processing,
-                                   float temperature, float tint)
-{
-	post_processing->white_balance.temperature = temperature;
-	post_processing->white_balance.tint = tint;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_color_grading(PostProcess* post_processing,
-                                   float saturation, float contrast,
-                                   float gamma, float gain, float offset)
-{
-	post_processing->color_grading.saturation = saturation;
-	post_processing->color_grading.contrast = contrast;
-	post_processing->color_grading.gamma = gamma;
-	post_processing->color_grading.gain = gain;
-	post_processing->color_grading.offset = offset;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_tonemapper(PostProcess* post_processing, float slope,
-                                float toe, float shoulder, float black_clip,
-                                float white_clip)
-{
-	post_processing->tonemapper.slope = slope;
-	post_processing->tonemapper.toe = toe;
-	post_processing->tonemapper.shoulder = shoulder;
-	post_processing->tonemapper.black_clip = black_clip;
-	post_processing->tonemapper.white_clip = white_clip;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_bloom(PostProcess* post_processing, float intensity,
-                           float threshold, float soft_threshold)
-{
-	post_processing->bloom.intensity = intensity;
-	post_processing->bloom.threshold = threshold;
-	post_processing->bloom.soft_threshold = soft_threshold;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_dof(PostProcess* post_processing, float focal_distance,
-                         float focal_range, float bokeh_scale)
-{
-	post_processing->dof.focal_distance = focal_distance;
-	post_processing->dof.focal_range = focal_range;
-	post_processing->dof.bokeh_scale = bokeh_scale;
-	post_processing->ubo_dirty = true;
-}
-
 float postprocess_get_exposure(PostProcess* post_processing)
 {
 	return fx_auto_exposure_get_current_exposure(post_processing);
-}
-
-void postprocess_set_auto_exposure(PostProcess* post_processing,
-                                   float min_luminance, float max_luminance,
-                                   float speed_up, float speed_down,
-                                   float key_value)
-{
-	post_processing->auto_exposure.min_luminance = min_luminance;
-	post_processing->auto_exposure.max_luminance = max_luminance;
-	post_processing->auto_exposure.speed_up = speed_up;
-	post_processing->auto_exposure.speed_down = speed_down;
-	post_processing->auto_exposure.key_value = key_value;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_fxaa(PostProcess* post_processing, float subpix,
-                          float edge_threshold, float edge_threshold_min)
-{
-	post_processing->fxaa.subpix = subpix;
-	post_processing->fxaa.edge_threshold = edge_threshold;
-	post_processing->fxaa.edge_threshold_min = edge_threshold_min;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_banding(PostProcess* post_processing, BandingMode mode,
-                             float levels)
-{
-	post_processing->banding.mode = (int32_t)mode;
-	post_processing->banding.levels = levels;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_banding_dither(PostProcess* post_processing,
-                                    float strength)
-{
-	post_processing->banding.dither_strength = strength;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_banding_perceptual(PostProcess* post_processing,
-                                        float gamma)
-{
-	post_processing->banding.perceptual_gamma = gamma;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_banding_channels(PostProcess* post_processing, float red,
-                                      float green, float blue)
-{
-	post_processing->banding.channel_levels[0] = red;
-	post_processing->banding.channel_levels[1] = green;
-	post_processing->banding.channel_levels[2] = blue;
-	post_processing->ubo_dirty = true;
-}
-
-void postprocess_set_grading_ue_default(PostProcess* post_processing)
-{
-	/* * Valeurs par défaut d'Unreal Engine (Section "Global").
-	 * Le "look" UE vient de l'application de ces valeurs neutres
-	 * combinées à la courbe de tone mapping ACES dans le shader.
-	 */
-	post_processing->color_grading.saturation =
-	    1.0F;                                       /* Pas de changement */
-	post_processing->color_grading.contrast = 1.0F; /* Pas de changement */
-	post_processing->color_grading.gamma = 1.0F;    /* Pas de changement */
-	post_processing->color_grading.gain = 1.0F;     /* Pas de changement */
-	post_processing->color_grading.offset = 0.0F;   /* Pas de changement */
-	post_processing->ubo_dirty = true;
-
-	/* On s'assure que l'effet est activé pour passer dans le pipeline ACES
-	 */
-	postprocess_enable(post_processing, POSTFX_COLOR_GRADING);
 }
 
 void postprocess_apply_preset(PostProcess* post_processing,

--- a/tests/test_postprocess.c
+++ b/tests/test_postprocess.c
@@ -337,34 +337,9 @@ void test_postprocess_render_pipeline(void)
 
 	/* Cover many setters and state changes (correcting signatures) */
 	postprocess_set_exposure(&post_proc, 1.5F);
-	postprocess_set_tonemapper(&post_proc, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F);
-	postprocess_set_vignette(&post_proc, 0.5F, 0.5F, 1.0F);
-	postprocess_set_bloom(&post_proc, 1.0F, 0.8F, 0.5F);
-	postprocess_set_dof(&post_proc, 10.0F, 5.0F, 1.0F);
-	postprocess_set_grain(&post_proc, 0.1F);
-	postprocess_set_chrom_abbr(&post_proc, 0.05F);
-	postprocess_set_color_grading(&post_proc, 1.1F, 1.1F, 1.0F, 1.0F, 0.0F);
-	postprocess_set_white_balance(&post_proc, 6500.00F, 0.1F);
-	postprocess_set_fxaa(&post_proc, 0.75F, 0.125F, 0.063F);
-	postprocess_set_banding(&post_proc, BANDING_MODE_LINEAR, 256.0F);
-	postprocess_set_auto_exposure(&post_proc, 0.1F, 10.0F, 1.0F, 1.0F,
-	                              1.0F);
 
 	/* Check some internal state */
 	TEST_ASSERT_TRUE(post_proc.ubo_dirty);
-
-	postprocess_cleanup(&post_proc);
-}
-
-void test_postprocess_banding_variants(void)
-{
-	PostProcess post_proc = {0};
-	postprocess_init(&post_proc, &gpu_profiler_system, SmallTestWidth,
-	                 SmallTestHeight);
-
-	postprocess_set_banding_dither(&post_proc, 0.5F);
-	postprocess_set_banding_perceptual(&post_proc, 2.2F);
-	postprocess_set_banding_channels(&post_proc, 128.0F, 128.0F, 128.0F);
 
 	postprocess_cleanup(&post_proc);
 }
@@ -383,7 +358,6 @@ int main(void)
 	RUN_TEST(test_postprocess_cache_overflow_benchmark);
 	RUN_TEST(test_postprocess_large_working_set);
 	RUN_TEST(test_postprocess_render_pipeline);
-	RUN_TEST(test_postprocess_banding_variants);
 	RUN_TEST(test_postprocess_cleanup);
 	return UNITY_END();
 }


### PR DESCRIPTION
Removed unused setter functions from `postprocess` module. These functions were dead code as the application relies on presets or direct struct manipulation via `postprocess_apply_preset`. `postprocess_set_exposure` was kept as it is used. `tests/test_postprocess.c` was updated to reflect these changes.

---
*PR created automatically by Jules for task [13543361532341939997](https://jules.google.com/task/13543361532341939997) started by @yoyonel*