### PR TITLE
Sentinel: Fix path traversal in texture loading

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -113,6 +113,28 @@ static inline void safe_strncat(char* dest, size_t dest_size, const char* src)
 }
 
 /**
+ * @brief Checks if a path is safe (no traversal, no absolute paths).
+ * @param path The path to check.
+ * @return true if safe, false otherwise.
+ */
+static inline bool is_safe_path(const char* path)
+{
+	if (strstr(path, "..")) {
+		return false;
+	}
+	if (path[0] == '/') {
+		return false;
+	}
+	if (strchr(path, '\\')) {
+		return false;
+	}
+	if (strstr(path, ":")) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * @brief RAII callback for `FILE*`.
  */
 static inline void cleanup_file(FILE** file_ptr)

--- a/src/shader.c
+++ b/src/shader.c
@@ -205,23 +205,6 @@ static bool get_dir_from_path(const char* path, char* out_dir, size_t size)
 	return true;
 }
 
-static bool is_safe_path(const char* path)
-{
-	if (strstr(path, "..")) {
-		return false;
-	}
-	if (path[0] == '/') {
-		return false;
-	}
-	if (strchr(path, '\\')) {
-		return false;
-	}
-	if (strstr(path, ":")) {
-		return false;
-	}
-	return true;
-}
-
 /*
  * Helper to resolve and parse an included file.
  * Returns true on success, false on error.

--- a/src/texture.c
+++ b/src/texture.c
@@ -11,6 +11,12 @@
 float* texture_load_pixels(const char* path, int* width, int* height,
                            int* channels)
 {
+	if (!is_safe_path(path)) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Security Violation: Unsafe path detected: %s", path);
+		return NULL;
+	}
+
 	CLEANUP_FILE FILE* file = fopen(path, "rb");
 	if (!file) {
 		LOG_ERROR("suckless-ogl.texture",

--- a/tests/test_texture_path_traversal.c
+++ b/tests/test_texture_path_traversal.c
@@ -52,7 +52,8 @@ void test_texture_load_pixels_path_traversal(void)
 	TEST_ASSERT_NULL_MESSAGE(pixels, "Should reject path with '..'");
 
 	// 6. Cleanup
-	if (pixels) free(pixels);
+	if (pixels)
+		free(pixels);
 	remove(filename);
 	rmdir(subdir);
 }

--- a/tests/test_texture_path_traversal.c
+++ b/tests/test_texture_path_traversal.c
@@ -1,0 +1,65 @@
+#include "texture.h"
+#include "unity.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#define mkdir(dir, mode) _mkdir(dir)
+#define rmdir _rmdir
+#else
+#include <unistd.h>
+#endif
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_texture_load_pixels_path_traversal(void)
+{
+	// 1. Create a valid PFM file in current directory
+	const char* filename = "traversal_test.pfm";
+	FILE* f = fopen(filename, "wb");
+	if (!f) {
+		TEST_IGNORE_MESSAGE("Cannot write to current directory");
+		return;
+	}
+	fprintf(f, "PF\n1 1\n-1.0\n");
+	float data[3] = {1.0f, 0.0f, 0.0f};
+	fwrite(data, sizeof(float), 3, f);
+	fclose(f);
+
+	// 2. Create a subdirectory to traverse from
+	const char* subdir = "traversal_subdir";
+	mkdir(subdir, 0755);
+
+	// 3. Construct traversal path: "traversal_subdir/../traversal_test.pfm"
+	char path[256];
+	sprintf(path, "%s/../%s", subdir, filename);
+
+	// 4. Try to load it
+	int width, height, channels;
+	float* pixels = texture_load_pixels(path, &width, &height, &channels);
+
+	// 5. Assert failure (NULL) due to security check
+	TEST_ASSERT_NULL_MESSAGE(pixels, "Should reject path with '..'");
+
+	// 6. Cleanup
+	if (pixels) free(pixels);
+	remove(filename);
+	rmdir(subdir);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_texture_load_pixels_path_traversal);
+	return UNITY_END();
+}


### PR DESCRIPTION
Refactored `is_safe_path` to `utils.h` and applied it to `texture_load_pixels` in `src/texture.c` to prevent path traversal attacks. Added regression test `tests/test_texture_path_traversal.c`.

---
*PR created automatically by Jules for task [16098176761376750987](https://jules.google.com/task/16098176761376750987) started by @yoyonel*