### PR TITLE
chore(cleanup): remove unused functions in perf_mode module

### DIFF
--- a/include/perf_mode.h
+++ b/include/perf_mode.h
@@ -108,22 +108,6 @@ int perf_mode_request_start(PerfModeContext* ctx);
 int perf_mode_request_end(PerfModeContext* ctx);
 
 /**
- * @brief Get the current performance mode state.
- *
- * @param ctx Pointer to the context.
- * @return Current PerfModeState value.
- */
-PerfModeState perf_mode_get_state(const PerfModeContext* ctx);
-
-/**
- * @brief Get the detected backend type.
- *
- * @param ctx Pointer to the context.
- * @return Detected PerfModeBackend value.
- */
-PerfModeBackend perf_mode_get_backend(const PerfModeContext* ctx);
-
-/**
  * @brief Get a human-readable string for the current state.
  *
  * @param ctx Pointer to the context.
@@ -131,13 +115,5 @@ PerfModeBackend perf_mode_get_backend(const PerfModeContext* ctx);
  *         "Native SCHED_FIFO", "Off").
  */
 const char* perf_mode_get_state_string(const PerfModeContext* ctx);
-
-/**
- * @brief Check if performance mode is currently active.
- *
- * @param ctx Pointer to the context.
- * @return 1 if active, 0 if not.
- */
-int perf_mode_is_active(const PerfModeContext* ctx);
 
 #endif /* PERF_MODE_H */

--- a/src/perf_mode.c
+++ b/src/perf_mode.c
@@ -321,16 +321,6 @@ void perf_mode_cleanup(PerfModeContext* ctx)
 	LOG_INFO("suckless-ogl.perf", "Performance mode cleaned up");
 }
 
-PerfModeState perf_mode_get_state(const PerfModeContext* ctx)
-{
-	return ctx ? ctx->state : PERF_MODE_OFF;
-}
-
-PerfModeBackend perf_mode_get_backend(const PerfModeContext* ctx)
-{
-	return ctx ? ctx->backend : PERF_BACKEND_NONE;
-}
-
 const char* perf_mode_get_state_string(const PerfModeContext* ctx)
 {
 	if (!ctx) {
@@ -350,10 +340,4 @@ const char* perf_mode_get_state_string(const PerfModeContext* ctx)
 		default:
 			return "Unknown";
 	}
-}
-
-int perf_mode_is_active(const PerfModeContext* ctx)
-{
-	return ctx && ctx->state != PERF_MODE_OFF &&
-	       ctx->state != PERF_MODE_ERROR;
 }


### PR DESCRIPTION
Removed unused functions from the `perf_mode` module to reduce technical debt and codebase size.

Deleted functions:
- `perf_mode_get_state`
- `perf_mode_get_backend`
- `perf_mode_is_active`

Verified that these functions are not used in the codebase (including tests) via `grep`.
Verified that the changes do not introduce syntax errors via `gcc -fsyntax-only`.
Formatted the code with `clang-format`.

---
*PR created automatically by Jules for task [2856787785883234683](https://jules.google.com/task/2856787785883234683) started by @yoyonel*