### PR TITLE
Enhance OpenGL Debugging and Headless Build Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,21 +169,25 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(stb)
 
-# 4. GLFW (Force FetchContent for Host IDE Support)
-# We deliberately skip pkg-config to ensure headers are available in build/_deps
-# This allows clangd on the host to index them even if they are not installed on the host system.
-message(STATUS "Forcing GLFW3 FetchContent for IDE compatibility...")
-FetchContent_Declare(
-    glfw
-    GIT_REPOSITORY https://github.com/glfw/glfw.git
-    GIT_TAG        3.3.8
-)
-set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
-set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(glfw)
-set(GLFW3_LIBRARIES glfw)
+option(BUILD_APP "Build the main application" ON)
+
+if(BUILD_APP)
+    # 4. GLFW (Force FetchContent for Host IDE Support)
+    # We deliberately skip pkg-config to ensure headers are available in build/_deps
+    # This allows clangd on the host to index them even if they are not installed on the host system.
+    message(STATUS "Forcing GLFW3 FetchContent for IDE compatibility...")
+    FetchContent_Declare(
+        glfw
+        GIT_REPOSITORY https://github.com/glfw/glfw.git
+        GIT_TAG        3.3.8
+    )
+    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+    set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(glfw)
+    set(GLFW3_LIBRARIES glfw)
+endif()
 
 # 5. cJSON (Static Build - CONFIGURATION AMÉLIORÉE)
 message(STATUS "Fetching cJSON...")
@@ -255,96 +259,98 @@ elseif(ENABLE_ASAN)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_PROFILING OFF)
 endif()
 
-# App target
-add_executable(app ${SOURCES})
+if(BUILD_APP)
+    # App target
+    add_executable(app ${SOURCES})
 
-# Apply Clang-Tidy only to this target
-if(ENABLE_CLANG_TIDY AND CLANG_TIDY_CMD)
-    set_target_properties(app PROPERTIES C_CLANG_TIDY "${CLANG_TIDY_CMD}")
-endif()
-
-# Target properties and includes
-target_include_directories(app PRIVATE src include ${stb_SOURCE_DIR})
-target_include_directories(app PRIVATE ${cjson_SOURCE_DIR})
-
-# Link avec la version statique de cJSON
-find_package(Threads REQUIRED)
-target_link_libraries(app PRIVATE
-    cglm
-    glad
-    cjson  # Ceci link automatiquement la version statique grâce aux options ci-dessus
-    ${GLFW3_LIBRARIES}
-    m
-    dl
-    Threads::Threads
-)
-
-# Optional GameMode integration for performance optimization
-# Requires both the library AND the header to be installed
-find_library(GAMEMODE_LIB NAMES gamemode)
-find_path(GAMEMODE_INCLUDE_DIR NAMES gamemode_client.h)
-if(GAMEMODE_LIB AND GAMEMODE_INCLUDE_DIR)
-    message(STATUS "GameMode found: ${GAMEMODE_LIB}")
-    message(STATUS "GameMode headers: ${GAMEMODE_INCLUDE_DIR}")
-    target_compile_definitions(app PRIVATE HAVE_GAMEMODE)
-    target_include_directories(app PRIVATE ${GAMEMODE_INCLUDE_DIR})
-    target_link_libraries(app PRIVATE ${GAMEMODE_LIB})
-else()
-    if(GAMEMODE_LIB AND NOT GAMEMODE_INCLUDE_DIR)
-        message(STATUS "GameMode library found but headers missing - install libgamemode-dev")
-    endif()
-    message(STATUS "GameMode not available - using native scheduling fallback")
-endif()
-
-target_compile_definitions(app PRIVATE GLFW_INCLUDE_NONE)
-
-# Compiler flags
-# Compiler flags
-if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-    target_compile_options(app PRIVATE -Wall -Wextra)
-
-    # Sentinel: Security Hardening Flags
-    # -fstack-protector-strong: Protects against stack buffer overflows
-    # -Wformat -Wformat-security: Warns about unsafe format string usage
-    target_compile_options(app PRIVATE
-        -fstack-protector-strong
-        -Wformat
-        -Wformat-security
-    )
-
-    # _FORTIFY_SOURCE=2: Enables compile-time and runtime checks for buffer overflows
-    # (Requires optimization level -O1 or higher)
-    target_compile_definitions(app PRIVATE _FORTIFY_SOURCE=2)
-
-    # Linker Hardening:
-    # -Wl,-z,relro: Read-only Relocations (protects GOT)
-    # -Wl,-z,now: Immediate Binding (protects PLT)
-    # -Wl,-z,noexecstack: Prevents code execution on the stack
-    target_link_options(app PRIVATE
-        -Wl,-z,relro
-        -Wl,-z,now
-        -Wl,-z,noexecstack
-    )
-
-    # -fno-omit-frame-pointer est CRUCIAL pour que les profilers (perf, gprof, callgrind)
-    # puissent reconstruire la pile d'appel (stack trace) correctement.
-    if(CMAKE_BUILD_TYPE STREQUAL "Profiling" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        target_compile_options(app PRIVATE -fno-omit-frame-pointer)
+    # Apply Clang-Tidy only to this target
+    if(ENABLE_CLANG_TIDY AND CLANG_TIDY_CMD)
+        set_target_properties(app PROPERTIES C_CLANG_TIDY "${CLANG_TIDY_CMD}")
     endif()
 
-    add_compile_definitions(_GNU_SOURCE)
-endif()
+    # Target properties and includes
+    target_include_directories(app PRIVATE src include ${stb_SOURCE_DIR})
+    target_include_directories(app PRIVATE ${cjson_SOURCE_DIR})
 
-if(ENABLE_SHADER_OPTIMIZATION)
-    target_compile_definitions(app PRIVATE ENABLE_SHADER_OPTIMIZATION)
-endif()
+    # Link avec la version statique de cJSON
+    find_package(Threads REQUIRED)
+    target_link_libraries(app PRIVATE
+        cglm
+        glad
+        cjson  # Ceci link automatiquement la version statique grâce aux options ci-dessus
+        ${GLFW3_LIBRARIES}
+        m
+        dl
+        Threads::Threads
+    )
 
-# Vérification post-build pour s'assurer que tout est statique
-add_custom_command(TARGET app POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies..."
-    COMMAND ldd $<TARGET_FILE:app> || true
-    COMMENT "Binary dependencies check"
-)
+    # Optional GameMode integration for performance optimization
+    # Requires both the library AND the header to be installed
+    find_library(GAMEMODE_LIB NAMES gamemode)
+    find_path(GAMEMODE_INCLUDE_DIR NAMES gamemode_client.h)
+    if(GAMEMODE_LIB AND GAMEMODE_INCLUDE_DIR)
+        message(STATUS "GameMode found: ${GAMEMODE_LIB}")
+        message(STATUS "GameMode headers: ${GAMEMODE_INCLUDE_DIR}")
+        target_compile_definitions(app PRIVATE HAVE_GAMEMODE)
+        target_include_directories(app PRIVATE ${GAMEMODE_INCLUDE_DIR})
+        target_link_libraries(app PRIVATE ${GAMEMODE_LIB})
+    else()
+        if(GAMEMODE_LIB AND NOT GAMEMODE_INCLUDE_DIR)
+            message(STATUS "GameMode library found but headers missing - install libgamemode-dev")
+        endif()
+        message(STATUS "GameMode not available - using native scheduling fallback")
+    endif()
+
+    target_compile_definitions(app PRIVATE GLFW_INCLUDE_NONE)
+
+    # Compiler flags
+    # Compiler flags
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(app PRIVATE -Wall -Wextra)
+
+        # Sentinel: Security Hardening Flags
+        # -fstack-protector-strong: Protects against stack buffer overflows
+        # -Wformat -Wformat-security: Warns about unsafe format string usage
+        target_compile_options(app PRIVATE
+            -fstack-protector-strong
+            -Wformat
+            -Wformat-security
+        )
+
+        # _FORTIFY_SOURCE=2: Enables compile-time and runtime checks for buffer overflows
+        # (Requires optimization level -O1 or higher)
+        target_compile_definitions(app PRIVATE _FORTIFY_SOURCE=2)
+
+        # Linker Hardening:
+        # -Wl,-z,relro: Read-only Relocations (protects GOT)
+        # -Wl,-z,now: Immediate Binding (protects PLT)
+        # -Wl,-z,noexecstack: Prevents code execution on the stack
+        target_link_options(app PRIVATE
+            -Wl,-z,relro
+            -Wl,-z,now
+            -Wl,-z,noexecstack
+        )
+
+        # -fno-omit-frame-pointer est CRUCIAL pour que les profilers (perf, gprof, callgrind)
+        # puissent reconstruire la pile d'appel (stack trace) correctement.
+        if(CMAKE_BUILD_TYPE STREQUAL "Profiling" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+            target_compile_options(app PRIVATE -fno-omit-frame-pointer)
+        endif()
+
+        add_compile_definitions(_GNU_SOURCE)
+    endif()
+
+    if(ENABLE_SHADER_OPTIMIZATION)
+        target_compile_definitions(app PRIVATE ENABLE_SHADER_OPTIMIZATION)
+    endif()
+
+    # Vérification post-build pour s'assurer que tout est statique
+    add_custom_command(TARGET app POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies..."
+        COMMAND ldd $<TARGET_FILE:app> || true
+        COMMENT "Binary dependencies check"
+    )
+endif()
 
 # --- Unit Testing ---
 enable_testing()

--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -104,34 +104,31 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 
 	entry->count++;
 
-	/* Log only the first occurrence to avoid flooding, matching Rust
-	 * behavior */
-	if (entry->count == 1) {
-		const char *src_str = get_source_str(source);
-		const char *type_str = get_type_str(type);
-		const char *sev_str = get_severity_str(severity);
+	/* Log ALL occurrences to ensure visibility of state inconsistencies */
+	const char *src_str = get_source_str(source);
+	const char *type_str = get_type_str(type);
+	const char *sev_str = get_severity_str(severity);
 
-		if (type == GL_DEBUG_TYPE_ERROR ||
-		    severity == GL_DEBUG_SEVERITY_HIGH) {
-			LOG_ERROR(LOG_TAG,
-			          "id: 0x%X, source: %s, type: %s, severity: "
-			          "%s, message: %s",
-			          message_id, src_str, type_str, sev_str,
-			          message);
-		} else if (severity == GL_DEBUG_SEVERITY_MEDIUM ||
-		           severity == GL_DEBUG_SEVERITY_LOW) {
-			LOG_WARNING(LOG_TAG,
-			            "id: 0x%X, source: %s, type: %s, severity: "
-			            "%s, message: %s",
-			            message_id, src_str, type_str, sev_str,
-			            message);
-		} else {
-			LOG_INFO(LOG_TAG,
-			         "id: 0x%X, source: %s, type: %s, severity: "
-			         "%s, message: %s",
-			         message_id, src_str, type_str, sev_str,
-			         message);
-		}
+	if (type == GL_DEBUG_TYPE_ERROR ||
+	    severity == GL_DEBUG_SEVERITY_HIGH) {
+		LOG_ERROR(LOG_TAG,
+		          "id: 0x%X, source: %s, type: %s, severity: "
+		          "%s, message: %s",
+		          message_id, src_str, type_str, sev_str,
+		          message);
+	} else if (severity == GL_DEBUG_SEVERITY_MEDIUM ||
+	           severity == GL_DEBUG_SEVERITY_LOW) {
+		LOG_WARNING(LOG_TAG,
+		            "id: 0x%X, source: %s, type: %s, severity: "
+		            "%s, message: %s",
+		            message_id, src_str, type_str, sev_str,
+		            message);
+	} else {
+		LOG_INFO(LOG_TAG,
+		         "id: 0x%X, source: %s, type: %s, severity: "
+		         "%s, message: %s",
+		         message_id, src_str, type_str, sev_str,
+		         message);
 	}
 }
 

--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -109,26 +109,22 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 	const char *type_str = get_type_str(type);
 	const char *sev_str = get_severity_str(severity);
 
-	if (type == GL_DEBUG_TYPE_ERROR ||
-	    severity == GL_DEBUG_SEVERITY_HIGH) {
+	if (type == GL_DEBUG_TYPE_ERROR || severity == GL_DEBUG_SEVERITY_HIGH) {
 		LOG_ERROR(LOG_TAG,
 		          "id: 0x%X, source: %s, type: %s, severity: "
 		          "%s, message: %s",
-		          message_id, src_str, type_str, sev_str,
-		          message);
+		          message_id, src_str, type_str, sev_str, message);
 	} else if (severity == GL_DEBUG_SEVERITY_MEDIUM ||
 	           severity == GL_DEBUG_SEVERITY_LOW) {
 		LOG_WARNING(LOG_TAG,
 		            "id: 0x%X, source: %s, type: %s, severity: "
 		            "%s, message: %s",
-		            message_id, src_str, type_str, sev_str,
-		            message);
+		            message_id, src_str, type_str, sev_str, message);
 	} else {
 		LOG_INFO(LOG_TAG,
 		         "id: 0x%X, source: %s, type: %s, severity: "
 		         "%s, message: %s",
-		         message_id, src_str, type_str, sev_str,
-		         message);
+		         message_id, src_str, type_str, sev_str, message);
 	}
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,99 +11,102 @@ set(TEST_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/include ${stb_
 # BIBLIOTHÈQUE PARTAGÉE POUR LES TESTS
 # =============================================================================
 
-# Convertir les chemins relatifs de SOURCES en chemins absolus
-set(TEST_LIB_SOURCES "")
-foreach(source ${SOURCES})
-    # Si le chemin est déjà absolu, le garder tel quel
-    if(IS_ABSOLUTE ${source})
-        list(APPEND TEST_LIB_SOURCES ${source})
-    else()
-        # Sinon, le préfixer avec CMAKE_SOURCE_DIR
-        list(APPEND TEST_LIB_SOURCES ${CMAKE_SOURCE_DIR}/${source})
-    endif()
-endforeach()
+if(BUILD_APP)
+    # Convertir les chemins relatifs de SOURCES en chemins absolus
+    set(TEST_LIB_SOURCES "")
+    foreach(source ${SOURCES})
+        # Si le chemin est déjà absolu, le garder tel quel
+        if(IS_ABSOLUTE ${source})
+            list(APPEND TEST_LIB_SOURCES ${source})
+        else()
+            # Sinon, le préfixer avec CMAKE_SOURCE_DIR
+            list(APPEND TEST_LIB_SOURCES ${CMAKE_SOURCE_DIR}/${source})
+        endif()
+    endforeach()
 
-# Exclure main.c
-list(FILTER TEST_LIB_SOURCES EXCLUDE REGEX ".*main\\.c$")
+    # Exclure main.c
+    list(FILTER TEST_LIB_SOURCES EXCLUDE REGEX ".*main\\.c$")
 
-# Créer la bibliothèque de test (compilée une seule fois)
-add_library(app_testlib STATIC ${TEST_LIB_SOURCES})
-target_include_directories(app_testlib PUBLIC ${TEST_INCLUDE_DIRS})
-target_link_libraries(app_testlib PUBLIC ${TEST_COMMON_LIBS})
-target_compile_definitions(app_testlib PUBLIC UNITY_INCLUDE_DOUBLE)
-# target_compile_definitions(app_testlib PUBLIC GLFW_INCLUDE_NONE _POSIX_C_SOURCE=199309L)
+    # Créer la bibliothèque de test (compilée une seule fois)
+    add_library(app_testlib STATIC ${TEST_LIB_SOURCES})
+    target_include_directories(app_testlib PUBLIC ${TEST_INCLUDE_DIRS})
+    target_link_libraries(app_testlib PUBLIC ${TEST_COMMON_LIBS})
+    target_compile_definitions(app_testlib PUBLIC UNITY_INCLUDE_DOUBLE)
+    # target_compile_definitions(app_testlib PUBLIC GLFW_INCLUDE_NONE _POSIX_C_SOURCE=199309L)
 
-# =============================================================================
-# AUTO-DÉCOUVERTE DES TESTS
-# =============================================================================
+    # =============================================================================
+    # AUTO-DÉCOUVERTE DES TESTS
+    # =============================================================================
 
-# Lister tous les fichiers test_*.c dans le répertoire tests/
-file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.c")
+    # Lister tous les fichiers test_*.c dans le répertoire tests/
+    file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.c")
 
-# Exclure les tests standalone de la boucle générique
-list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_path_security_standalone\\.c$")
-list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_cleanup\\.c$")
-list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_toctou\\.c$")
-list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_overflow\\.c$")
+    # Exclure les tests standalone de la boucle générique
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_path_security_standalone\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_cleanup\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_toctou\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_overflow\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_gl_debug_dedup\\.c$")
 
-# Tests qui nécessitent OpenGL (à mettre dans Xvfb)
-set(OPENGL_TESTS
-    test_shader
-    test_shader_api
-    test_texture
-    test_skybox
-    test_pbr
-    test_material
-    test_ui
-    test_instanced_rendering
-    test_ssbo_rendering
-    test_app
-    test_postprocess
-    test_fxaa_synthetic
-    test_render_utils
-    test_benchmark_histogram
-    test_texture_security
-    test_gpu_profiler
-    test_app_input
-    test_app_metrics
-    test_billboard_perf
-    test_shader_uniforms_loc
-    test_stencil_masking
-    test_env_transition
-)
+    # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
+    set(OPENGL_TESTS
+        test_shader
+        test_shader_api
+        test_texture
+        test_skybox
+        test_pbr
+        test_material
+        test_ui
+        test_instanced_rendering
+        test_ssbo_rendering
+        test_app
+        test_postprocess
+        test_fxaa_synthetic
+        test_render_utils
+        test_benchmark_histogram
+        test_texture_security
+        test_gpu_profiler
+        test_app_input
+        test_app_metrics
+        test_billboard_perf
+        test_shader_uniforms_loc
+        test_stencil_masking
+        test_env_transition
+    )
 
-# Pour chaque fichier test trouvé
-foreach(test_file ${TEST_SOURCES})
-    # Extraire le nom du test (sans .c)
-    get_filename_component(test_name ${test_file} NAME_WE)
+    # Pour chaque fichier test trouvé
+    foreach(test_file ${TEST_SOURCES})
+        # Extraire le nom du test (sans .c)
+        get_filename_component(test_name ${test_file} NAME_WE)
 
-    # Créer l'exécutable
-    add_executable(${test_name} ${test_file})
-    target_link_libraries(${test_name} PRIVATE app_testlib)
+        # Créer l'exécutable
+        add_executable(${test_name} ${test_file})
+        target_link_libraries(${test_name} PRIVATE app_testlib)
 
-    # Injecter les variables pour le test de sécurité du log
-    if(${test_name} STREQUAL "test_log_security")
-        target_compile_definitions(${test_name} PRIVATE
-            TEST_COMPILER=\"${CMAKE_C_COMPILER}\"
-            TEST_INCLUDE_DIR=\"${CMAKE_SOURCE_DIR}/include\"
-        )
-    endif()
+        # Injecter les variables pour le test de sécurité du log
+        if(${test_name} STREQUAL "test_log_security")
+            target_compile_definitions(${test_name} PRIVATE
+                TEST_COMPILER=\"${CMAKE_C_COMPILER}\"
+                TEST_INCLUDE_DIR=\"${CMAKE_SOURCE_DIR}/include\"
+            )
+        endif()
 
-    # Déterminer si c'est un test OpenGL
-    if(${test_name} IN_LIST OPENGL_TESTS)
-        # Test avec Xvfb
-        add_test(NAME ${test_name}
-                 COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:${test_name}>)
-        message(STATUS "Test OpenGL découvert: ${test_name} (avec Xvfb)")
-    else()
-        # Test simple
-        add_test(NAME ${test_name} COMMAND ${test_name})
-        message(STATUS "Test unitaire découvert: ${test_name}")
-    endif()
+        # Déterminer si c'est un test OpenGL
+        if(${test_name} IN_LIST OPENGL_TESTS)
+            # Test avec Xvfb
+            add_test(NAME ${test_name}
+                     COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:${test_name}>)
+            message(STATUS "Test OpenGL découvert: ${test_name} (avec Xvfb)")
+        else()
+            # Test simple
+            add_test(NAME ${test_name} COMMAND ${test_name})
+            message(STATUS "Test unitaire découvert: ${test_name}")
+        endif()
 
-    # Working directory = racine du projet
-    set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-endforeach()
+        # Working directory = racine du projet
+        set_tests_properties(${test_name} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    endforeach()
+endif()
 
 # =============================================================================
 # TEST STANDALONE (MOCKED)
@@ -208,6 +211,29 @@ target_link_libraries(test_billboard_overflow PRIVATE cglm)
 
 add_test(NAME test_billboard_overflow
          COMMAND test_billboard_overflow)
+
+# =============================================================================
+# TEST DEBUG DEDUP (STANDALONE)
+# =============================================================================
+add_executable(test_gl_debug_dedup
+    test_gl_debug_dedup.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+)
+
+target_include_directories(test_gl_debug_dedup PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_gl_debug_dedup PRIVATE m)
+
+add_test(NAME test_gl_debug_dedup
+         COMMAND test_gl_debug_dedup)
 
 # =============================================================================
 # NOTES ET DOCUMENTATION

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -129,6 +129,7 @@ void glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
 void glTexParameteri(GLenum target, GLenum pname, GLint param);
 void glGenerateMipmap(GLenum target);
 GLenum glGetError(void);
+void glGetIntegerv(GLenum pname, GLint* data);
 
 void glGenBuffers(GLsizei n, GLuint* buffers);
 void glBindBuffer(GLenum target, GLuint buffer);

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -78,7 +78,10 @@ typedef long GLintptr;
 #define GL_CONTEXT_FLAGS 0x821E
 #define GL_CONTEXT_FLAG_DEBUG_BIT 0x00000002
 
-typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+typedef void(APIENTRY* GLDEBUGPROC)(GLenum source, GLenum type, GLuint id,
+                                    GLenum severity, GLsizei length,
+                                    const GLchar* message,
+                                    const void* userParam);
 
 GLuint glCreateShader(GLenum type);
 void glShaderSource(GLuint shader, GLsizei count, const GLchar** string,
@@ -110,8 +113,9 @@ void glUniform4fv(GLint location, GLsizei count, const float* value);
 void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
                         const float* value);
 void glPopDebugGroup(void);
-void glDebugMessageCallback(GLDEBUGPROC callback, const void *userParam);
-void glDebugMessageControl(GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint *ids, GLboolean enabled);
+void glDebugMessageCallback(GLDEBUGPROC callback, const void* userParam);
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity,
+                           GLsizei count, const GLuint* ids, GLboolean enabled);
 void glDeleteTextures(GLsizei n, const GLuint* textures);
 
 void glGenTextures(GLsizei n, GLuint* textures);

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -50,6 +50,36 @@ typedef long GLintptr;
 #define GL_CLAMP_TO_EDGE 0x812F
 #define GL_NO_ERROR 0
 
+#define GL_DEBUG_SOURCE_API 0x8246
+#define GL_DEBUG_SOURCE_WINDOW_SYSTEM 0x8247
+#define GL_DEBUG_SOURCE_SHADER_COMPILER 0x8248
+#define GL_DEBUG_SOURCE_THIRD_PARTY 0x8249
+#define GL_DEBUG_SOURCE_APPLICATION 0x824A
+#define GL_DEBUG_SOURCE_OTHER 0x824B
+
+#define GL_DEBUG_TYPE_ERROR 0x824C
+#define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR 0x824D
+#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR 0x824E
+#define GL_DEBUG_TYPE_PORTABILITY 0x824F
+#define GL_DEBUG_TYPE_PERFORMANCE 0x8250
+#define GL_DEBUG_TYPE_OTHER 0x8251
+#define GL_DEBUG_TYPE_MARKER 0x8268
+#define GL_DEBUG_TYPE_PUSH_GROUP 0x8269
+#define GL_DEBUG_TYPE_POP_GROUP 0x826A
+
+#define GL_DEBUG_SEVERITY_HIGH 0x9146
+#define GL_DEBUG_SEVERITY_MEDIUM 0x9147
+#define GL_DEBUG_SEVERITY_LOW 0x9148
+#define GL_DEBUG_SEVERITY_NOTIFICATION 0x826B
+
+#define GL_DEBUG_OUTPUT 0x92E0
+#define GL_DEBUG_OUTPUT_SYNCHRONOUS 0x8242
+#define GL_DONT_CARE 0x1100
+#define GL_CONTEXT_FLAGS 0x821E
+#define GL_CONTEXT_FLAG_DEBUG_BIT 0x00000002
+
+typedef void (APIENTRY *GLDEBUGPROC)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+
 GLuint glCreateShader(GLenum type);
 void glShaderSource(GLuint shader, GLsizei count, const GLchar** string,
                     const GLint* length);
@@ -80,6 +110,8 @@ void glUniform4fv(GLint location, GLsizei count, const float* value);
 void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
                         const float* value);
 void glPopDebugGroup(void);
+void glDebugMessageCallback(GLDEBUGPROC callback, const void *userParam);
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint *ids, GLboolean enabled);
 void glDeleteTextures(GLsizei n, const GLuint* textures);
 
 void glGenTextures(GLsizei n, GLuint* textures);

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -252,8 +252,9 @@ void glDeleteTextures(GLsizei n, const GLuint* textures)
 
 void glGetIntegerv(GLenum pname, GLint* data)
 {
-	(void)pname;
-	(void)data;
+	if (pname == GL_CONTEXT_FLAGS && data) {
+		*data = GL_CONTEXT_FLAG_DEBUG_BIT;
+	}
 }
 
 /* -------------------------------------------------------------------------- */
@@ -396,4 +397,20 @@ void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
 }
 void glPopDebugGroup(void)
 {
+}
+
+void glDebugMessageCallback(GLDEBUGPROC callback, const void *userParam)
+{
+	(void)callback;
+	(void)userParam;
+}
+
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint *ids, GLboolean enabled)
+{
+	(void)source;
+	(void)type;
+	(void)severity;
+	(void)count;
+	(void)ids;
+	(void)enabled;
 }

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -399,13 +399,14 @@ void glPopDebugGroup(void)
 {
 }
 
-void glDebugMessageCallback(GLDEBUGPROC callback, const void *userParam)
+void glDebugMessageCallback(GLDEBUGPROC callback, const void* userParam)
 {
 	(void)callback;
 	(void)userParam;
 }
 
-void glDebugMessageControl(GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint *ids, GLboolean enabled)
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity,
+                           GLsizei count, const GLuint* ids, GLboolean enabled)
 {
 	(void)source;
 	(void)type;

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -2,20 +2,7 @@
 #define MOCK_GL_STANDALONE_H
 
 #include <stddef.h>
-
-/* Define types compatible with GLAD/OpenGL */
-typedef unsigned int GLuint;
-typedef unsigned int GLenum;
-typedef int GLint;
-typedef int GLsizei;
-typedef char GLchar;
-typedef unsigned char GLboolean;
-typedef float GLfloat;
-typedef long GLsizeiptr;
-typedef long GLintptr;
-
-#define GL_FALSE 0
-#define GL_TRUE 1
+#include "glad/glad.h"
 
 /* Defaults */
 #define DEFAULT_BUFFER_ID 123

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -1,8 +1,8 @@
 #ifndef MOCK_GL_STANDALONE_H
 #define MOCK_GL_STANDALONE_H
 
-#include <stddef.h>
 #include "glad/glad.h"
+#include <stddef.h>
 
 /* Defaults */
 #define DEFAULT_BUFFER_ID 123

--- a/tests/test_gl_debug_dedup.c
+++ b/tests/test_gl_debug_dedup.c
@@ -1,9 +1,8 @@
-#include "unity.h"
 #include "gl_debug.h"
 #include "glad/glad.h"
 #include "log.h"
+#include "unity.h"
 #include "utils.h"
-
 #include <stdio.h>
 #include <string.h>
 
@@ -16,22 +15,31 @@ static char g_last_log_message[512];
 /* Implementation of log.h functions required by gl_debug.c */
 void log_message(LogLevel level, const char* tag, const char* format, ...)
 {
-    g_log_call_count++;
-    g_last_log_level = level;
-    if (tag) {
-        strncpy(g_last_log_tag, tag, sizeof(g_last_log_tag) - 1);
-        g_last_log_tag[sizeof(g_last_log_tag) - 1] = '\0';
-    }
+	g_log_call_count++;
+	g_last_log_level = level;
+	if (tag) {
+		strncpy(g_last_log_tag, tag, sizeof(g_last_log_tag) - 1);
+		g_last_log_tag[sizeof(g_last_log_tag) - 1] = '\0';
+	}
 
-    va_list args;
-    va_start(args, format);
-    vsnprintf(g_last_log_message, sizeof(g_last_log_message), format, args);
-    va_end(args);
+	va_list args;
+	va_start(args, format);
+	vsnprintf(g_last_log_message, sizeof(g_last_log_message), format, args);
+	va_end(args);
 }
 
-void log_set_callback(LogCallback callback) { (void)callback; }
-void log_set_level(LogLevel level) { (void)level; }
-LogLevel log_get_level(void) { return LOG_LEVEL_DEBUG; }
+void log_set_callback(LogCallback callback)
+{
+	(void)callback;
+}
+void log_set_level(LogLevel level)
+{
+	(void)level;
+}
+LogLevel log_get_level(void)
+{
+	return LOG_LEVEL_DEBUG;
+}
 
 /* Include the source file directly to access static functions/state */
 #include "../src/gl_debug.c"
@@ -39,10 +47,10 @@ LogLevel log_get_level(void) { return LOG_LEVEL_DEBUG; }
 /* Test Setup */
 void setUp(void)
 {
-    g_log_call_count = 0;
-    g_last_log_level = LOG_LEVEL_NOTSET;
-    memset(g_last_log_tag, 0, sizeof(g_last_log_tag));
-    memset(g_last_log_message, 0, sizeof(g_last_log_message));
+	g_log_call_count = 0;
+	g_last_log_level = LOG_LEVEL_NOTSET;
+	memset(g_last_log_tag, 0, sizeof(g_last_log_tag));
+	memset(g_last_log_message, 0, sizeof(g_last_log_message));
 }
 
 void tearDown(void)
@@ -53,38 +61,43 @@ void tearDown(void)
 
 void test_gl_debug_callback_deduplication_removed(void)
 {
-    /*
-     * Test Strategy:
-     * 1. Call gl_debug_callback with a specific message ID.
-     * 2. Verify log is called.
-     * 3. Call gl_debug_callback AGAIN with the SAME message ID.
-     * 4. Verify log is called AGAIN (count should be 2).
-     *
-     * If deduplication was active, count would be 1.
-     */
+	/*
+	 * Test Strategy:
+	 * 1. Call gl_debug_callback with a specific message ID.
+	 * 2. Verify log is called.
+	 * 3. Call gl_debug_callback AGAIN with the SAME message ID.
+	 * 4. Verify log is called AGAIN (count should be 2).
+	 *
+	 * If deduplication was active, count would be 1.
+	 */
 
-    GLuint message_id = 0x1234;
-    const char* message = "Test Error Message";
+	GLuint message_id = 0x1234;
+	const char* message = "Test Error Message";
 
-    /* First Call */
-    gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, message_id,
-                      GL_DEBUG_SEVERITY_HIGH, strlen(message), message, NULL);
+	/* First Call */
+	gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, message_id,
+	                  GL_DEBUG_SEVERITY_HIGH, strlen(message), message,
+	                  NULL);
 
-    TEST_ASSERT_EQUAL_INT(1, g_log_call_count);
-    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_ERROR, g_last_log_level);
-    TEST_ASSERT_EQUAL_STRING("id: 0x1234, source: API, type: Error, severity: High, message: Test Error Message", g_last_log_message);
+	TEST_ASSERT_EQUAL_INT(1, g_log_call_count);
+	TEST_ASSERT_EQUAL_INT(LOG_LEVEL_ERROR, g_last_log_level);
+	TEST_ASSERT_EQUAL_STRING(
+	    "id: 0x1234, source: API, type: Error, severity: High, message: "
+	    "Test Error Message",
+	    g_last_log_message);
 
-    /* Second Call (Same ID) */
-    gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, message_id,
-                      GL_DEBUG_SEVERITY_HIGH, strlen(message), message, NULL);
+	/* Second Call (Same ID) */
+	gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, message_id,
+	                  GL_DEBUG_SEVERITY_HIGH, strlen(message), message,
+	                  NULL);
 
-    /* With deduplication removed, count should be 2 */
-    TEST_ASSERT_EQUAL_INT(2, g_log_call_count);
+	/* With deduplication removed, count should be 2 */
+	TEST_ASSERT_EQUAL_INT(2, g_log_call_count);
 }
 
 int main(void)
 {
-    UNITY_BEGIN();
-    RUN_TEST(test_gl_debug_callback_deduplication_removed);
-    return UNITY_END();
+	UNITY_BEGIN();
+	RUN_TEST(test_gl_debug_callback_deduplication_removed);
+	return UNITY_END();
 }

--- a/tests/test_gl_debug_dedup.c
+++ b/tests/test_gl_debug_dedup.c
@@ -1,0 +1,90 @@
+#include "unity.h"
+#include "gl_debug.h"
+#include "glad/glad.h"
+#include "log.h"
+#include "utils.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* Mock Log System */
+static int g_log_call_count = 0;
+static LogLevel g_last_log_level = LOG_LEVEL_NOTSET;
+static char g_last_log_tag[64];
+static char g_last_log_message[512];
+
+/* Implementation of log.h functions required by gl_debug.c */
+void log_message(LogLevel level, const char* tag, const char* format, ...)
+{
+    g_log_call_count++;
+    g_last_log_level = level;
+    if (tag) {
+        strncpy(g_last_log_tag, tag, sizeof(g_last_log_tag) - 1);
+        g_last_log_tag[sizeof(g_last_log_tag) - 1] = '\0';
+    }
+
+    va_list args;
+    va_start(args, format);
+    vsnprintf(g_last_log_message, sizeof(g_last_log_message), format, args);
+    va_end(args);
+}
+
+void log_set_callback(LogCallback callback) { (void)callback; }
+void log_set_level(LogLevel level) { (void)level; }
+LogLevel log_get_level(void) { return LOG_LEVEL_DEBUG; }
+
+/* Include the source file directly to access static functions/state */
+#include "../src/gl_debug.c"
+
+/* Test Setup */
+void setUp(void)
+{
+    g_log_call_count = 0;
+    g_last_log_level = LOG_LEVEL_NOTSET;
+    memset(g_last_log_tag, 0, sizeof(g_last_log_tag));
+    memset(g_last_log_message, 0, sizeof(g_last_log_message));
+}
+
+void tearDown(void)
+{
+}
+
+/* Test Cases */
+
+void test_gl_debug_callback_deduplication_removed(void)
+{
+    /*
+     * Test Strategy:
+     * 1. Call gl_debug_callback with a specific message ID.
+     * 2. Verify log is called.
+     * 3. Call gl_debug_callback AGAIN with the SAME message ID.
+     * 4. Verify log is called AGAIN (count should be 2).
+     *
+     * If deduplication was active, count would be 1.
+     */
+
+    GLuint message_id = 0x1234;
+    const char* message = "Test Error Message";
+
+    /* First Call */
+    gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, message_id,
+                      GL_DEBUG_SEVERITY_HIGH, strlen(message), message, NULL);
+
+    TEST_ASSERT_EQUAL_INT(1, g_log_call_count);
+    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_ERROR, g_last_log_level);
+    TEST_ASSERT_EQUAL_STRING("id: 0x1234, source: API, type: Error, severity: High, message: Test Error Message", g_last_log_message);
+
+    /* Second Call (Same ID) */
+    gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, message_id,
+                      GL_DEBUG_SEVERITY_HIGH, strlen(message), message, NULL);
+
+    /* With deduplication removed, count should be 2 */
+    TEST_ASSERT_EQUAL_INT(2, g_log_call_count);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_gl_debug_callback_deduplication_removed);
+    return UNITY_END();
+}


### PR DESCRIPTION
This PR enhances the OpenGL state monitoring capabilities of the application by ensuring all OpenGL debug messages are logged, regardless of repetition. It also improves the build system to support headless CI/CD environments where X11 headers might be missing.

**Key Changes:**
1.  **High Sensitivity Debugging:** Removed the deduplication logic in `gl_debug_callback`. Previously, only the first occurrence of an error message ID was logged. Now, every occurrence is logged to allow detection of recurring state inconsistencies (e.g., per-frame errors).
2.  **Headless Build Support:** Introduced a `BUILD_APP` CMake option (default `ON`). Setting `-DBUILD_APP=OFF` allows building standalone tests without compiling the main application or fetching GLFW, resolving build failures in environments lacking `libxrandr-dev`.
3.  **Verification Test:** Added `tests/test_gl_debug_dedup.c`, a standalone test that mocks the GL environment and verifies that multiple calls to the debug callback trigger multiple log messages.
4.  **Mock Updates:** Updated `tests/mocks/glad/glad.h` and `tests/mocks/standalone/mock_gl_standalone.c` to include `GL_DEBUG_*` definitions and stub implementations for debug callbacks.

**Analysis Findings:**
During the static analysis phase, the following potential state inconsistency was identified:
-   **`src/app_ui.c`**: In `compute_luminance_histogram` and `app_render_ui`, if `glMapBuffer` returns `NULL` (failure), the code correctly skips `glUnmapBuffer` but proceeds to call `glGetTexImage`. Since the buffer remains bound, `glGetTexImage` attempts to write to it. While likely safe from a crash perspective (OpenGL handles writes to unmapped buffers or generates an error), the buffer content becomes indeterminate.

**Verification:**
-   `test_gl_debug_dedup` passed in a simulated headless environment.
-   Manual code review confirmed the safety of other critical paths (`postprocess.c`, `billboard_rendering.c`).

---
*PR created automatically by Jules for task [1466788902618045432](https://jules.google.com/task/1466788902618045432) started by @yoyonel*