### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Texture Loading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** `stbi_load` allocated memory based on dimensions read from file header before application validation, allowing a small file to trigger massive allocation (DoS).
 **Learning:** Helper libraries often prioritize convenience over security. Trusting external input to determine allocation size without validation is dangerous.
 **Prevention:** Use a "Peek & Validate" pattern: parse metadata first (`stbi_info`), validate against constraints, then allocate/load.
+
+## 2026-02-19 - [Path Traversal] Unprotected Texture Loading
+**Vulnerability:** `texture_load_pixels` in `src/texture.c` lacked path validation, allowing traversal attacks via crafted filenames, despite earlier logs suggesting it was secured. `is_safe_path` was isolated in `src/shader.c`.
+**Learning:** Security functions like `is_safe_path` must be centralized (e.g., in `utils.h`) to ensure consistent application across all modules (Texture, Shader, Audio, etc.). Code duplication leads to inconsistent security posture.
+**Prevention:** Moved `is_safe_path` to `include/utils.h` and enforced it in `texture_load_pixels`. Always verify that security controls are applied to ALL input vectors, not just the one currently being worked on (e.g., shaders).

--- a/include/utils.h
+++ b/include/utils.h
@@ -182,4 +182,26 @@ static inline void raii_satisfy_analyzer_free(
 		_tmp_ptr;                         \
 	})
 
+/**
+ * @brief Checks if a file path is safe (prevents directory traversal).
+ * @param path The path to check.
+ * @return true if the path is safe, false otherwise.
+ */
+static inline bool is_safe_path(const char* path)
+{
+	if (strstr(path, "..")) {
+		return false;
+	}
+	if (path[0] == '/') {
+		return false;
+	}
+	if (strchr(path, '\\')) {
+		return false;
+	}
+	if (strstr(path, ":")) {
+		return false;
+	}
+	return true;
+}
+
 #endif /* UTILS_H */

--- a/src/shader.c
+++ b/src/shader.c
@@ -205,23 +205,6 @@ static bool get_dir_from_path(const char* path, char* out_dir, size_t size)
 	return true;
 }
 
-static bool is_safe_path(const char* path)
-{
-	if (strstr(path, "..")) {
-		return false;
-	}
-	if (path[0] == '/') {
-		return false;
-	}
-	if (strchr(path, '\\')) {
-		return false;
-	}
-	if (strstr(path, ":")) {
-		return false;
-	}
-	return true;
-}
-
 /*
  * Helper to resolve and parse an included file.
  * Returns true on success, false on error.

--- a/src/texture.c
+++ b/src/texture.c
@@ -11,6 +11,12 @@
 float* texture_load_pixels(const char* path, int* width, int* height,
                            int* channels)
 {
+	if (!is_safe_path(path)) {
+		LOG_ERROR("suckless-ogl.texture",
+		          "Security Violation: Unsafe texture path: %s", path);
+		return NULL;
+	}
+
 	CLEANUP_FILE FILE* file = fopen(path, "rb");
 	if (!file) {
 		LOG_ERROR("suckless-ogl.texture",


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `texture_load_pixels` in `src/texture.c` did not validate file paths, allowing directory traversal attacks (e.g., `../../etc/passwd`). `is_safe_path` check was implemented but isolated in `src/shader.c`, leaving other modules unprotected.
🎯 Impact: An attacker could read arbitrary files (if permissions allow) or potentially crash the application via path traversal, bypassing intended asset directories.
🔧 Fix: Moved `is_safe_path` from `src/shader.c` to `include/utils.h` to make it a shared utility. Updated `src/texture.c` to enforce `is_safe_path` before opening any file.
✅ Verification: Verified with a standalone test `test_texture_path_traversal_standalone` which confirmed the vulnerability existed (prior to fix) and was blocked (after fix). Also verified existing shader security tests still pass.

---
*PR created automatically by Jules for task [2043236992703494670](https://jules.google.com/task/2043236992703494670) started by @yoyonel*