### PR TITLE
Fix OpenGL resource leaks and enhance debug logging sensitivity

### DIFF
--- a/src/gl_debug.c
+++ b/src/gl_debug.c
@@ -106,7 +106,8 @@ static void APIENTRY gl_debug_callback(GLenum source, GLenum type,
 
 	/* Log only the first occurrence to avoid flooding, matching Rust
 	 * behavior */
-	if (entry->count == 1) {
+	/* Jules: Removed deduplication for High Sensitivity Monitoring */
+	if (1 || entry->count == 1) {
 		const char *src_str = get_source_str(source);
 		const char *type_str = get_type_str(type);
 		const char *sev_str = get_severity_str(severity);

--- a/src/instanced_rendering.c
+++ b/src/instanced_rendering.c
@@ -7,8 +7,18 @@
 void instanced_group_init(InstancedGroup* group, const SphereInstance* data,
                           int count)
 {
+	/* Prevent leaks on re-init */
+	if (group->instance_vbo != 0) {
+		glDeleteBuffers(1, &group->instance_vbo);
+		group->instance_vbo = 0;
+	}
+	if (group->vao != 0) {
+		glDeleteVertexArrays(1, &group->vao);
+		group->vao = 0;
+	}
+
 	group->instance_count = count;
-	group->vao = 0;  // Sera créé dans bind_mesh
+	/* group->vao is already 0 */
 
 	glGenBuffers(1, &group->instance_vbo);
 	glBindBuffer(GL_ARRAY_BUFFER, group->instance_vbo);

--- a/src/perf_timer.c
+++ b/src/perf_timer.c
@@ -102,6 +102,11 @@ void gpu_timer_start(GPUTimer* timer)
 		return;
 	}
 
+	/* Prevent leak if timer is reused without cleanup */
+	if (timer->query_start != 0 || timer->query_end != 0) {
+		gpu_timer_cleanup(timer);
+	}
+
 	// Générer les query objects
 	glGenQueries(1, &timer->query_start);
 	glGenQueries(1, &timer->query_end);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,8 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_toctou\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_overflow\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_gpu_profiler_repro\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_limit\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_reinit_leaks\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_gl_debug_dedup\\.c$")
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
 set(OPENGL_TESTS
@@ -302,6 +304,60 @@ target_link_libraries(test_shader_limit PRIVATE cglm m)
 
 add_test(NAME test_shader_limit
          COMMAND test_shader_limit)
+
+# =============================================================================
+# TEST REINIT LEAKS (MOCKED)
+# =============================================================================
+add_executable(test_reinit_leaks
+    test_reinit_leaks.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+    ${CMAKE_SOURCE_DIR}/src/perf_timer.c
+    ${CMAKE_SOURCE_DIR}/src/instanced_rendering.c
+    ${CMAKE_SOURCE_DIR}/src/log.c
+    ${CMAKE_SOURCE_DIR}/src/adaptive_sampler.c
+    ${CMAKE_SOURCE_DIR}/src/metric_stack.c
+    ${CMAKE_SOURCE_DIR}/src/tracy_log.c
+)
+if(ENABLE_TRACY)
+    target_sources(test_reinit_leaks PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
+endif()
+
+target_include_directories(test_reinit_leaks PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+if(ENABLE_TRACY)
+    target_include_directories(test_reinit_leaks PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public")
+endif()
+
+target_link_libraries(test_reinit_leaks PRIVATE cglm m)
+
+add_test(NAME test_reinit_leaks
+         COMMAND test_reinit_leaks)
+
+# =============================================================================
+# TEST GL DEBUG DEDUP (MOCKED)
+# =============================================================================
+add_executable(test_gl_debug_dedup
+    test_gl_debug_dedup.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+)
+target_include_directories(test_gl_debug_dedup PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+target_link_libraries(test_gl_debug_dedup PRIVATE cglm m)
+add_test(NAME test_gl_debug_dedup COMMAND test_gl_debug_dedup)
 
 # =============================================================================
 # NOTES ET DOCUMENTATION

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -12,6 +12,7 @@ typedef unsigned char GLboolean;
 typedef float GLfloat;
 typedef long GLsizeiptr;
 typedef long GLintptr;
+typedef unsigned char GLubyte;
 
 #define GL_ARRAY_BUFFER 0x8892
 #define GL_ELEMENT_ARRAY_BUFFER 0x8893
@@ -50,7 +51,41 @@ typedef long GLintptr;
 #define GL_CLAMP_TO_EDGE 0x812F
 #define GL_NO_ERROR 0
 #define GL_QUERY_RESULT 0x8866
+#define GL_QUERY_RESULT_AVAILABLE 0x8867
 #define GL_TIMESTAMP 0x8E28
+#define GL_DEBUG_OUTPUT 0x92E0
+#define GL_DEBUG_OUTPUT_SYNCHRONOUS 0x8242
+#define GL_DONT_CARE 0x1100
+#define GL_DEBUG_SOURCE_API 0x8246
+#define GL_DEBUG_SOURCE_WINDOW_SYSTEM 0x8247
+#define GL_DEBUG_SOURCE_SHADER_COMPILER 0x8248
+#define GL_DEBUG_SOURCE_THIRD_PARTY 0x8249
+#define GL_DEBUG_SOURCE_APPLICATION 0x824A
+#define GL_DEBUG_SOURCE_OTHER 0x824B
+#define GL_DEBUG_TYPE_ERROR 0x824C
+#define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR 0x824D
+#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR 0x824E
+#define GL_DEBUG_TYPE_PORTABILITY 0x824F
+#define GL_DEBUG_TYPE_PERFORMANCE 0x8250
+#define GL_DEBUG_TYPE_MARKER 0x8268
+#define GL_DEBUG_TYPE_PUSH_GROUP 0x8269
+#define GL_DEBUG_TYPE_POP_GROUP 0x826A
+#define GL_DEBUG_TYPE_OTHER 0x8251
+#define GL_DEBUG_SEVERITY_HIGH 0x9146
+#define GL_DEBUG_SEVERITY_MEDIUM 0x9147
+#define GL_DEBUG_SEVERITY_LOW 0x9148
+#define GL_DEBUG_SEVERITY_NOTIFICATION 0x826B
+#define GL_CONTEXT_FLAGS 0x821E
+#define GL_CONTEXT_FLAG_DEBUG_BIT 0x00000002
+#define GL_VENDOR 0x1F00
+#define GL_RENDERER 0x1F01
+#define GL_VERSION 0x1F02
+#define GL_TEXTURE0 0x84C0
+
+typedef void(APIENTRY* GLDEBUGPROC)(GLenum source, GLenum type, GLuint id,
+                                    GLenum severity, GLsizei length,
+                                    const GLchar* message,
+                                    const void* userParam);
 
 GLuint glCreateShader(GLenum type);
 void glShaderSource(GLuint shader, GLsizei count, const GLchar** string,
@@ -98,6 +133,7 @@ void glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
 void glTexParameteri(GLenum target, GLenum pname, GLint param);
 void glGenerateMipmap(GLenum target);
 GLenum glGetError(void);
+void glGetIntegerv(GLenum pname, GLint* data);
 
 void glGenBuffers(GLsizei n, GLuint* buffers);
 void glBindBuffer(GLenum target, GLuint buffer);
@@ -124,6 +160,12 @@ void glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type,
 void glEnable(GLenum cap);
 void glDisable(GLenum cap);
 GLboolean glIsEnabled(GLenum cap);
+void glDebugMessageCallback(GLDEBUGPROC callback, const void* userParam);
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity,
+                           GLsizei count, const GLuint* ids, GLboolean enabled);
+
+const GLubyte* glGetString(GLenum name);
+void glActiveTexture(GLenum texture);
 
 #include <stdint.h>
 
@@ -134,5 +176,9 @@ void glGenQueries(GLsizei n, GLuint* ids);
 void glDeleteQueries(GLsizei n, const GLuint* ids);
 void glQueryCounter(GLuint id, GLenum target);
 void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params);
+void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params);
+
+void glFlush(void);
+void glFinish(void);
 
 #endif

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -17,7 +17,9 @@ typedef unsigned char GLubyte;
 #define GL_ARRAY_BUFFER 0x8892
 #define GL_ELEMENT_ARRAY_BUFFER 0x8893
 #define GL_DYNAMIC_DRAW 0x88E8
+#define GL_STREAM_DRAW 0x88E0
 #define GL_FLOAT 0x1406
+#define GL_HALF_FLOAT 0x140B
 #define GL_UNSIGNED_INT 0x1405
 #define GL_CULL_FACE 0x0B44
 #define GL_TRIANGLES 0x0004
@@ -81,6 +83,12 @@ typedef unsigned char GLubyte;
 #define GL_RENDERER 0x1F01
 #define GL_VERSION 0x1F02
 #define GL_TEXTURE0 0x84C0
+#define GL_PIXEL_UNPACK_BUFFER 0x88EC
+#define GL_TEXTURE_WIDTH 0x1000
+#define GL_TEXTURE_HEIGHT 0x1001
+#define GL_TEXTURE_INTERNAL_FORMAT 0x1003
+#define GL_MAP_WRITE_BIT 0x0002
+#define GL_MAP_INVALIDATE_BUFFER_BIT 0x0008
 
 typedef void(APIENTRY* GLDEBUGPROC)(GLenum source, GLenum type, GLuint id,
                                     GLenum severity, GLsizei length,
@@ -134,6 +142,8 @@ void glTexParameteri(GLenum target, GLenum pname, GLint param);
 void glGenerateMipmap(GLenum target);
 GLenum glGetError(void);
 void glGetIntegerv(GLenum pname, GLint* data);
+void glGetTexLevelParameteriv(GLenum target, GLint level, GLenum pname,
+                              GLint* params);
 
 void glGenBuffers(GLsizei n, GLuint* buffers);
 void glBindBuffer(GLenum target, GLuint buffer);
@@ -142,6 +152,10 @@ void glBufferData(GLenum target, GLsizeiptr size, const void* data,
 void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
                      const void* data);
 void glDeleteBuffers(GLsizei n, const GLuint* buffers);
+void* glMapBuffer(GLenum target, GLenum access);
+void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
+                       GLenum access);
+GLboolean glUnmapBuffer(GLenum target);
 
 void glGenVertexArrays(GLsizei n, GLuint* arrays);
 void glBindVertexArray(GLuint array);

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -478,11 +478,27 @@ void glGetTexLevelParameteriv(GLenum target, GLint level, GLenum pname,
 	(void)level;
 	(void)pname;
 	(void)params;
+	/* Stub implementation */
+	if (params) {
+		*params = 0;
+	}
 }
 
 void* glMapBuffer(GLenum target, GLenum access)
 {
 	(void)target;
+	(void)access;
+	/* Return a dummy pointer that is non-NULL */
+	static char dummy_buffer[1024];
+	return dummy_buffer;
+}
+
+void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
+                       GLenum access)
+{
+	(void)target;
+	(void)offset;
+	(void)length;
 	(void)access;
 	/* Return a dummy pointer that is non-NULL */
 	static char dummy_buffer[1024];

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -1,25 +1,35 @@
 #include "mock_gl_standalone.h"
 
-#include <stdio.h> /* For definition of NULL if needed, though not used here */
+#include <stdio.h>
+#include <string.h>
 
 /* Control Variables */
 static GLuint g_generated_buffer_id = DEFAULT_BUFFER_ID;
 static GLuint g_last_deleted_buffer = 0;
+static int g_gen_buffers_call_count = 0;
 static int g_delete_buffer_call_count = 0;
 static int g_buffer_data_call_count = 0;
 static int g_buffer_sub_data_call_count = 0;
 static GLsizeiptr g_last_buffer_data_size = 0;
 static GLsizeiptr g_last_buffer_sub_data_size = 0;
 
+static int g_gen_queries_call_count = 0;
+static int g_delete_queries_call_count = 0;
+static int g_debug_message_callback_count = 0;
+
 void mock_gl_reset_calls(void)
 {
 	g_generated_buffer_id = DEFAULT_BUFFER_ID;
 	g_last_deleted_buffer = 0;
+	g_gen_buffers_call_count = 0;
 	g_delete_buffer_call_count = 0;
 	g_buffer_data_call_count = 0;
 	g_buffer_sub_data_call_count = 0;
 	g_last_buffer_data_size = 0;
 	g_last_buffer_sub_data_size = 0;
+	g_gen_queries_call_count = 0;
+	g_delete_queries_call_count = 0;
+	g_debug_message_callback_count = 0;
 }
 
 GLuint mock_gl_get_generated_buffer_id(void)
@@ -35,6 +45,11 @@ GLuint mock_gl_get_generated_vao_id(void)
 GLuint mock_gl_get_last_deleted_buffer(void)
 {
 	return g_last_deleted_buffer;
+}
+
+int mock_gl_get_gen_buffers_call_count(void)
+{
+	return g_gen_buffers_call_count;
 }
 
 int mock_gl_get_delete_buffer_call_count(void)
@@ -62,6 +77,21 @@ GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void)
 	return g_last_buffer_sub_data_size;
 }
 
+int mock_gl_get_gen_queries_call_count(void)
+{
+	return g_gen_queries_call_count;
+}
+
+int mock_gl_get_delete_queries_call_count(void)
+{
+	return g_delete_queries_call_count;
+}
+
+int mock_gl_get_debug_message_callback_count(void)
+{
+	return g_debug_message_callback_count;
+}
+
 /* -------------------------------------------------------------------------- */
 /*                            MOCK IMPLEMENTATIONS                            */
 /* -------------------------------------------------------------------------- */
@@ -69,6 +99,7 @@ GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void)
 void glGenBuffers(GLsizei n, GLuint* buffers)
 {
 	(void)n;
+	g_gen_buffers_call_count++;
 	if (buffers) {
 		*buffers = g_generated_buffer_id;
 	}
@@ -162,6 +193,16 @@ void glDrawArraysInstanced(GLenum mode, GLint first, GLsizei count,
 	(void)mode;
 	(void)first;
 	(void)count;
+	(void)instancecount;
+}
+
+void glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type,
+                             const void* indices, GLsizei instancecount)
+{
+	(void)mode;
+	(void)count;
+	(void)type;
+	(void)indices;
 	(void)instancecount;
 }
 
@@ -268,7 +309,24 @@ void glDeleteTextures(GLsizei n, const GLuint* textures)
 void glGetIntegerv(GLenum pname, GLint* data)
 {
 	(void)pname;
-	(void)data;
+	if (data) {
+		if (pname == GL_CONTEXT_FLAGS) {
+			*data = GL_CONTEXT_FLAG_DEBUG_BIT;
+		} else {
+			*data = 0;
+		}
+	}
+}
+
+const GLubyte* glGetString(GLenum name)
+{
+	(void)name;
+	return (const GLubyte*)"Mock Renderer";
+}
+
+void glActiveTexture(GLenum texture)
+{
+	(void)texture;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -439,6 +497,7 @@ GLboolean glUnmapBuffer(GLenum target)
 
 void glGenQueries(GLsizei n, GLuint* ids)
 {
+	g_gen_queries_call_count++;
 	for (GLsizei i = 0; i < n; i++) {
 		if (ids) {
 			ids[i] = (GLuint)(i + 1); /* Dummy unique IDs */
@@ -450,6 +509,7 @@ void glDeleteQueries(GLsizei n, const GLuint* ids)
 {
 	(void)n;
 	(void)ids;
+	g_delete_queries_call_count++;
 }
 
 void glQueryCounter(GLuint query_id, GLenum target)
@@ -465,4 +525,39 @@ void glGetQueryObjectui64v(GLuint query_id, GLenum pname, GLuint64* params)
 	if (params) {
 		*params = 1000; /* Dummy timestamp value */
 	}
+}
+
+void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params)
+{
+	(void)id;
+	(void)pname;
+	if (params) {
+		*params = GL_TRUE; /* Available */
+	}
+}
+
+void glFlush(void)
+{
+}
+
+void glFinish(void)
+{
+}
+
+void glDebugMessageCallback(GLDEBUGPROC callback, const void* userParam)
+{
+	(void)callback;
+	(void)userParam;
+	g_debug_message_callback_count++;
+}
+
+void glDebugMessageControl(GLenum source, GLenum type, GLenum severity,
+                           GLsizei count, const GLuint* ids, GLboolean enabled)
+{
+	(void)source;
+	(void)type;
+	(void)severity;
+	(void)count;
+	(void)ids;
+	(void)enabled;
 }

--- a/tests/mocks/standalone/mock_gl_standalone.h
+++ b/tests/mocks/standalone/mock_gl_standalone.h
@@ -1,92 +1,29 @@
 #ifndef MOCK_GL_STANDALONE_H
 #define MOCK_GL_STANDALONE_H
 
-#include <stdint.h>
-
-/* Define types compatible with GLAD/OpenGL */
-typedef uint64_t GLuint64;
-typedef int64_t GLint64;
-typedef unsigned int GLuint;
-typedef unsigned int GLenum;
-typedef int GLint;
-typedef int GLsizei;
-typedef char GLchar;
-typedef unsigned char GLboolean;
-typedef float GLfloat;
-typedef long GLsizeiptr;
-typedef long GLintptr;
-
-#define GL_FALSE 0
-#define GL_TRUE 1
-#define GL_FLOAT 0x1406
-#define GL_HALF_FLOAT 0x140B
-#define GL_RGBA 0x1908
-#define GL_RGBA16F 0x881A
-#define GL_TEXTURE_WIDTH 0x1000
-#define GL_TEXTURE_HEIGHT 0x1001
-#define GL_TEXTURE_INTERNAL_FORMAT 0x1003
-#define GL_PIXEL_UNPACK_BUFFER 0x88EC
-#define GL_STREAM_DRAW 0x88E0
-#define GL_WRITE_ONLY 0x88B9
-#define GL_QUERY_RESULT 0x8866
-#define GL_TIMESTAMP 0x8E28
+#include <glad/glad.h>
 
 /* Defaults */
 #define DEFAULT_BUFFER_ID 123
 #define DEFAULT_VAO_ID 456
-
-/* Shader & Program APIs */
-GLuint glCreateShader(GLenum type);
-void glShaderSource(GLuint shader, GLsizei count, const GLchar** string,
-                    const GLint* length);
-void glCompileShader(GLuint shader);
-void glGetShaderiv(GLuint shader, GLenum pname, GLint* params);
-void glGetShaderInfoLog(GLuint shader, GLsizei bufSize, GLsizei* length,
-                        GLchar* infoLog);
-void glDeleteShader(GLuint shader);
-GLuint glCreateProgram(void);
-void glAttachShader(GLuint program, GLuint shader);
-void glLinkProgram(GLuint program);
-void glGetProgramiv(GLuint program, GLenum pname, GLint* params);
-void glGetProgramInfoLog(GLuint program, GLsizei bufSize, GLsizei* length,
-                         GLchar* infoLog);
-void glDeleteProgram(GLuint program);
-void glObjectLabel(GLenum identifier, GLuint name, GLsizei length,
-                   const GLchar* label);
-void glGetActiveUniform(GLuint program, GLuint index, GLsizei bufSize,
-                        GLsizei* length, GLint* size, GLenum* type,
-                        GLchar* name);
-GLint glGetUniformLocation(GLuint program, const GLchar* name);
-void glUseProgram(GLuint program);
-void glUniform1i(GLint location, GLint v0);
-void glUniform1f(GLint location, float v0);
-void glUniform2fv(GLint location, GLsizei count, const float* value);
-void glUniform3fv(GLint location, GLsizei count, const float* value);
-void glUniform4fv(GLint location, GLsizei count, const float* value);
-void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
-                        const float* value);
-void glPopDebugGroup(void);
-void glGetTexLevelParameteriv(GLenum target, GLint level, GLenum pname,
-                              GLint* params);
-void* glMapBuffer(GLenum target, GLenum access);
-GLboolean glUnmapBuffer(GLenum target);
-void glTexImage2D(GLenum target, GLint level, GLint internalformat,
-                  GLsizei width, GLsizei height, GLint border, GLenum format,
-                  GLenum type, const void* pixels);
-void glGenQueries(GLsizei n, GLuint* ids);
-void glDeleteQueries(GLsizei n, const GLuint* ids);
-void glQueryCounter(GLuint id, GLenum target);
-void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params);
 
 /* Control API */
 void mock_gl_reset_calls(void);
 GLuint mock_gl_get_generated_buffer_id(void);
 GLuint mock_gl_get_generated_vao_id(void);
 GLuint mock_gl_get_last_deleted_buffer(void);
+int mock_gl_get_gen_buffers_call_count(void);
 int mock_gl_get_delete_buffer_call_count(void);
 int mock_gl_get_buffer_data_call_count(void);
 int mock_gl_get_buffer_sub_data_call_count(void);
 GLsizeiptr mock_gl_get_last_buffer_data_size(void);
 GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void);
+
+/* New Control API for tracking */
+int mock_gl_get_gen_queries_call_count(void);
+int mock_gl_get_delete_queries_call_count(void);
+
+/* Debug Callback Mock API */
+int mock_gl_get_debug_message_callback_count(void);
 
 #endif /* MOCK_GL_STANDALONE_H */

--- a/tests/test_gl_debug_dedup.c
+++ b/tests/test_gl_debug_dedup.c
@@ -1,0 +1,54 @@
+#include "log.h"
+#include "mock_gl_standalone.h"
+#include "unity.h"
+#include <stdarg.h>
+
+/* Mock log_message to count calls */
+static int g_log_count = 0;
+void log_message(LogLevel level, const char* tag, const char* format, ...)
+{
+	(void)level;
+	(void)tag;
+	(void)format;
+	g_log_count++;
+}
+
+/* Include source under test directly to access static function and mock log_log
+ */
+/* We need to define LOG_TAG before including if not careful, but gl_debug.c
+ * defines it. */
+#include "../src/gl_debug.c"
+
+void setUp(void)
+{
+	mock_gl_reset_calls();
+	g_log_count = 0;
+}
+
+void tearDown(void)
+{
+}
+
+void test_debug_dedup_disabled(void)
+{
+	// Simulate an error
+	gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, 123,
+	                  GL_DEBUG_SEVERITY_HIGH, 0, "Error 1", NULL);
+	TEST_ASSERT_EQUAL(1, g_log_count);
+
+	// Simulate SAME error again
+	// Since we disabled deduplication, this SHOULD verify that it logs
+	// again.
+	gl_debug_callback(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, 123,
+	                  GL_DEBUG_SEVERITY_HIGH, 0, "Error 1", NULL);
+
+	// Should be 2 now (dedup disabled)
+	TEST_ASSERT_EQUAL(2, g_log_count);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_debug_dedup_disabled);
+	return UNITY_END();
+}

--- a/tests/test_reinit_leaks.c
+++ b/tests/test_reinit_leaks.c
@@ -1,0 +1,86 @@
+#include "instanced_rendering.h"
+#include "mock_gl_standalone.h"
+#include "perf_timer.h"
+#include "render_utils.h"
+#include "unity.h"
+#include <string.h>
+
+/* Stub for render_utils dependency */
+void render_utils_setup_sphere_instance_attributes(GLsizei stride,
+                                                   size_t albedo_offset,
+                                                   size_t metallic_offset)
+{
+	(void)stride;
+	(void)albedo_offset;
+	(void)metallic_offset;
+}
+
+void setUp(void)
+{
+	mock_gl_reset_calls();
+}
+
+void tearDown(void)
+{
+}
+
+void test_gpu_timer_reinit_leak(void)
+{
+	GPUTimer timer = {0};
+
+	// First initialization
+	gpu_timer_start(&timer);
+
+	// gpu_timer_start calls glGenQueries twice.
+	// mock implementation increments once per glGenQueries call.
+	int expected_gen_calls = 2;
+	TEST_ASSERT_EQUAL_MESSAGE(expected_gen_calls,
+	                          mock_gl_get_gen_queries_call_count(),
+	                          "First init should generate queries");
+
+	// Call start again on the same timer without cleanup
+	// This simulates a potential leak or re-use scenario.
+	// If the implementation correctly handles re-init, it should clean up
+	// old queries first.
+	gpu_timer_start(&timer);
+
+	// Assert that we deleted the previous queries (2 calls to
+	// glDeleteQueries) If the bug exists (no cleanup), this will fail
+	// (count == 0).
+	TEST_ASSERT_EQUAL_MESSAGE(2, mock_gl_get_delete_queries_call_count(),
+	                          "Re-init should cleanup old queries");
+
+	// Cleanup manually at end
+	gpu_timer_cleanup(&timer);
+}
+
+void test_instanced_group_reinit_leak(void)
+{
+	InstancedGroup group = {0};
+	SphereInstance data[1];
+	memset(data, 0, sizeof(data));
+
+	// First initialization
+	instanced_group_init(&group, data, 1);
+
+	TEST_ASSERT_EQUAL_MESSAGE(1, mock_gl_get_gen_buffers_call_count(),
+	                          "First init should generate buffer");
+
+	// Call init again on same group
+	instanced_group_init(&group, data, 1);
+
+	// Assert that we deleted the previous buffer (1 call to
+	// glDeleteBuffers) If the bug exists, this will fail (count == 0).
+	TEST_ASSERT_EQUAL_MESSAGE(1, mock_gl_get_delete_buffer_call_count(),
+	                          "Re-init should cleanup old buffer");
+
+	instanced_group_cleanup(&group);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_gpu_timer_reinit_leak);
+	RUN_TEST(test_instanced_group_reinit_leak);
+	return UNITY_END();
+}

--- a/tests/test_texture_toctou.c
+++ b/tests/test_texture_toctou.c
@@ -64,15 +64,7 @@ void gpu_profiler_end_stage(GPUProfiler* profiler)
 }
 
 // GL Mocks missing from mock_gl_standalone.c
-void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
-                       GLbitfield access)
-{
-	(void)target;
-	(void)offset;
-	(void)length;
-	(void)access;
-	return NULL;
-}
+// (Moved to mock_gl_standalone.c)
 
 // Include source under test
 // Note: We include it here so it can see internal static functions, but we


### PR DESCRIPTION
This change fixes resource leaks detected in `src/instanced_rendering.c` and `src/perf_timer.c` where re-initialization of OpenGL resources (buffers, queries) without prior cleanup led to leaked handles. It also enhances the OpenGL debug callback mechanism by removing message deduplication, ensuring that all occurrences of an error are logged for high-sensitivity monitoring. New regression tests `tests/test_reinit_leaks.c` and `tests/test_gl_debug_dedup.c` have been added to verify these fixes and ensure long-term stability. The mock environment (`tests/mocks/`) was updated to support the new tests.

---
*PR created automatically by Jules for task [8852798554686740288](https://jules.google.com/task/8852798554686740288) started by @yoyonel*