### PR TITLE
Refactor `include/utils.h` to remove NOLINT suppressions

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -104,13 +104,7 @@ static inline void cleanup_file(FILE** file_ptr)
  * @brief Satisfies Static Analyzers for file resource management.
  */
 #ifdef __clang_analyzer__
-static inline void raii_satisfy_analyzer_file(
-    FILE* f)  // NOLINT(readability-identifier-length)
-{
-	if (f) {
-		(void)fclose(f);
-	}
-}
+void raii_satisfy_analyzer_file(FILE* file_ptr);
 #define RAII_SATISFY_FILE(f) raii_satisfy_analyzer_file(f)
 #else
 #define RAII_SATISFY_FILE(f) (void)0
@@ -134,11 +128,7 @@ static inline void cleanup_free(void* ptr_ptr)
  * @brief Satisfies Static Analyzers for memory resource management.
  */
 #ifdef __clang_analyzer__
-static inline void raii_satisfy_analyzer_free(
-    void* p)  // NOLINT(readability-identifier-length)
-{
-	free(p);
-}
+void raii_satisfy_analyzer_free(void* ptr);
 #define RAII_SATISFY_FREE(p) raii_satisfy_analyzer_free(p)
 #else
 #define RAII_SATISFY_FREE(p) (void)0

--- a/src/utils.c
+++ b/src/utils.c
@@ -142,3 +142,17 @@ bool is_safe_relative_path(const char* path)
 	}
 	return true;
 }
+
+#ifdef __clang_analyzer__
+void raii_satisfy_analyzer_file(FILE* file_ptr)
+{
+	if (file_ptr) {
+		(void)fclose(file_ptr);
+	}
+}
+
+void raii_satisfy_analyzer_free(void* ptr)
+{
+	free(ptr);
+}
+#endif


### PR DESCRIPTION
Refactored `raii_satisfy_analyzer_file` and `raii_satisfy_analyzer_free` by moving their implementations from `include/utils.h` to `src/utils.c`.
Renamed function arguments (`f` -> `file_ptr`, `p` -> `ptr`) to comply with `readability-identifier-length` linting rules natively, allowing the removal of `// NOLINT` directives.
This reduces cognitive load by keeping the header clean and enforces "Zero Tolerance" for suppressions.
Verified with `make lint` (clang-tidy-14) and `make test`.

---
*PR created automatically by Jules for task [8662859339231585728](https://jules.google.com/task/8662859339231585728) started by @yoyonel*