### PR TITLE
Implement async_loader_cancel to prevent hang on PBO mapping failure

### DIFF
--- a/CMakeLists.txt.fetch
+++ b/CMakeLists.txt.fetch
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.14)
+project(dummy)
+include(FetchContent)
+FetchContent_Declare(
+    unity
+    GIT_REPOSITORY https://github.com/ThrowTheSwitch/Unity.git
+    GIT_TAG        v2.6.0
+)
+FetchContent_MakeAvailable(unity)

--- a/CMakeLists.txt.fetch
+++ b/CMakeLists.txt.fetch
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 3.14)
-project(dummy)
-include(FetchContent)
-FetchContent_Declare(
-    unity
-    GIT_REPOSITORY https://github.com/ThrowTheSwitch/Unity.git
-    GIT_TAG        v2.6.0
-)
-FetchContent_MakeAvailable(unity)

--- a/include/async_loader.h
+++ b/include/async_loader.h
@@ -104,4 +104,12 @@ bool async_loader_poll(AsyncLoader* loader, AsyncRequest* out_req);
 void async_loader_provide_pbo(AsyncLoader* loader, void* mapped_ptr,
                               GLuint pbo_id);
 
+/**
+ * @brief Cancels the current request if it is waiting for a PBO.
+ *
+ * Use this if the main thread fails to map a PBO and cannot proceed.
+ * @param loader The loader instance.
+ */
+void async_loader_cancel(AsyncLoader* loader);
+
 #endif /* ASYNC_LOADER_H */

--- a/src/app.c
+++ b/src/app.c
@@ -555,11 +555,7 @@ void app_update(App* app)
 			} else {
 				LOG_ERROR("suckless-ogl.app",
 				          "Failed to map PBO for async upload");
-				/* We should probably cancel the request here,
-				 * but related cleanup is tricky. The loader
-				 * will hang waiting for PBO if we don't signal.
-				 * TODO: Implement cancel or timeout in loader.
-				 */
+				async_loader_cancel(app->async_loader);
 			}
 		} else if (req.state == ASYNC_READY) {
 			/* Step 2: Upload from PBO (or legacy CPU buffer) */

--- a/src/async_loader.c
+++ b/src/async_loader.c
@@ -426,3 +426,36 @@ void async_loader_provide_pbo(AsyncLoader* loader, void* mapped_ptr,
 	TracyCZoneEnd(ctx);
 #endif
 }
+
+void async_loader_cancel(AsyncLoader* loader)
+{
+	if (!loader) {
+		return;
+	}
+#ifdef TRACY_ENABLE
+	TracyCZoneN(ctx, "async_loader_cancel", 1);
+	TracyCZoneN(mtx_ctx, "Cancel Mutex Lock", 1);
+#endif
+	pthread_mutex_lock(&loader->request_mutex);
+#ifdef TRACY_ENABLE
+	TracyCZoneEnd(mtx_ctx);
+#endif
+
+	if (loader->current_request.state == ASYNC_WAITING_FOR_PBO) {
+		/* Set state to FAILED to break the worker loop */
+		loader->current_request.state = ASYNC_FAILED;
+		transition_tracy_state(ASYNC_FAILED);
+		pthread_cond_signal(&loader->request_cond); /* Wake up worker */
+		LOG_INFO("suckless-ogl.async", "Request cancelled by main thread: %s",
+		         loader->current_request.path);
+	} else {
+		LOG_ERROR("suckless-ogl.async",
+		          "Attempted to cancel request but state is %d",
+		          loader->current_request.state);
+	}
+
+	pthread_mutex_unlock(&loader->request_mutex);
+#ifdef TRACY_ENABLE
+	TracyCZoneEnd(ctx);
+#endif
+}

--- a/src/async_loader.c
+++ b/src/async_loader.c
@@ -446,7 +446,8 @@ void async_loader_cancel(AsyncLoader* loader)
 		loader->current_request.state = ASYNC_FAILED;
 		transition_tracy_state(ASYNC_FAILED);
 		pthread_cond_signal(&loader->request_cond); /* Wake up worker */
-		LOG_INFO("suckless-ogl.async", "Request cancelled by main thread: %s",
+		LOG_INFO("suckless-ogl.async",
+		         "Request cancelled by main thread: %s",
 		         loader->current_request.path);
 	} else {
 		LOG_ERROR("suckless-ogl.async",

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -216,6 +216,9 @@ void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
 
 void glGetTexLevelParameteriv(GLenum target, GLint level, GLenum pname,
                               GLint* params);
+void* glMapBuffer(GLenum target, GLenum access);
+void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
+                       GLbitfield access);
 GLboolean glUnmapBuffer(GLenum target);
 
 #endif

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -497,6 +497,18 @@ void* glMapBuffer(GLenum target, GLenum access)
 	return dummy_buffer;
 }
 
+void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
+                       GLbitfield access)
+{
+	(void)target;
+	(void)offset;
+	(void)length;
+	(void)access;
+	/* Return a dummy pointer that is non-NULL */
+	static char dummy_buffer[1024];
+	return dummy_buffer;
+}
+
 GLboolean glUnmapBuffer(GLenum target)
 {
 	(void)target;

--- a/tests/mocks/standalone/mock_gpu_profiler.c
+++ b/tests/mocks/standalone/mock_gpu_profiler.c
@@ -1,9 +1,36 @@
 #include "gpu_profiler.h"
 
-void gpu_profiler_init(GPUProfiler* profiler) { (void)profiler; }
-void gpu_profiler_cleanup(GPUProfiler* profiler) { (void)profiler; }
-void gpu_profiler_begin_frame(GPUProfiler* profiler, uint64_t frame_index) { (void)profiler; (void)frame_index; }
-void gpu_profiler_set_enabled(GPUProfiler* profiler, bool enabled) { (void)profiler; (void)enabled; }
-void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name, uint32_t color) { (void)profiler; (void)name; (void)color; }
-void gpu_profiler_end_stage(GPUProfiler* profiler) { (void)profiler; }
-void gpu_profiler_reset_samplers(GPUProfiler* profiler, double current_time) { (void)profiler; (void)current_time; }
+void gpu_profiler_init(GPUProfiler* profiler)
+{
+	(void)profiler;
+}
+void gpu_profiler_cleanup(GPUProfiler* profiler)
+{
+	(void)profiler;
+}
+void gpu_profiler_begin_frame(GPUProfiler* profiler, uint64_t frame_index)
+{
+	(void)profiler;
+	(void)frame_index;
+}
+void gpu_profiler_set_enabled(GPUProfiler* profiler, bool enabled)
+{
+	(void)profiler;
+	(void)enabled;
+}
+void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
+                              uint32_t color)
+{
+	(void)profiler;
+	(void)name;
+	(void)color;
+}
+void gpu_profiler_end_stage(GPUProfiler* profiler)
+{
+	(void)profiler;
+}
+void gpu_profiler_reset_samplers(GPUProfiler* profiler, double current_time)
+{
+	(void)profiler;
+	(void)current_time;
+}

--- a/tests/mocks/standalone/mock_gpu_profiler.c
+++ b/tests/mocks/standalone/mock_gpu_profiler.c
@@ -1,0 +1,9 @@
+#include "gpu_profiler.h"
+
+void gpu_profiler_init(GPUProfiler* profiler) { (void)profiler; }
+void gpu_profiler_cleanup(GPUProfiler* profiler) { (void)profiler; }
+void gpu_profiler_begin_frame(GPUProfiler* profiler, uint64_t frame_index) { (void)profiler; (void)frame_index; }
+void gpu_profiler_set_enabled(GPUProfiler* profiler, bool enabled) { (void)profiler; (void)enabled; }
+void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name, uint32_t color) { (void)profiler; (void)name; (void)color; }
+void gpu_profiler_end_stage(GPUProfiler* profiler) { (void)profiler; }
+void gpu_profiler_reset_samplers(GPUProfiler* profiler, double current_time) { (void)profiler; (void)current_time; }

--- a/tests/mocks/standalone/mock_tracy_manager.c
+++ b/tests/mocks/standalone/mock_tracy_manager.c
@@ -2,20 +2,23 @@
 
 void tracy_manager_init(TracyManager* mgr, int width, int height)
 {
-    (void)mgr; (void)width; (void)height;
+	(void)mgr;
+	(void)width;
+	(void)height;
 }
 
 void tracy_manager_cleanup(TracyManager* mgr)
 {
-    (void)mgr;
+	(void)mgr;
 }
 
 void tracy_manager_async_transition(TracyManager* mgr, AsyncState new_state)
 {
-    (void)mgr; (void)new_state;
+	(void)mgr;
+	(void)new_state;
 }
 
 void tracy_manager_async_end(TracyManager* mgr)
 {
-    (void)mgr;
+	(void)mgr;
 }

--- a/tests/mocks/standalone/mock_tracy_manager.c
+++ b/tests/mocks/standalone/mock_tracy_manager.c
@@ -1,0 +1,21 @@
+#include "tracy_manager.h"
+
+void tracy_manager_init(TracyManager* mgr, int width, int height)
+{
+    (void)mgr; (void)width; (void)height;
+}
+
+void tracy_manager_cleanup(TracyManager* mgr)
+{
+    (void)mgr;
+}
+
+void tracy_manager_async_transition(TracyManager* mgr, AsyncState new_state)
+{
+    (void)mgr; (void)new_state;
+}
+
+void tracy_manager_async_end(TracyManager* mgr)
+{
+    (void)mgr;
+}

--- a/tests/test_async_loader_cancel.c
+++ b/tests/test_async_loader_cancel.c
@@ -55,8 +55,8 @@ void test_cancel_request(void)
 	while (attempts < MAX_ATTEMPTS) {
 		if (async_loader_poll(loader, &req)) {
 			// Poll returned true means we got a result.
-			// But we expect it to be waiting for PBO, which returns true
-			// with state ASYNC_WAITING_FOR_PBO.
+			// But we expect it to be waiting for PBO, which returns
+			// true with state ASYNC_WAITING_FOR_PBO.
 			if (req.state == ASYNC_WAITING_FOR_PBO) {
 				waiting = true;
 				break;
@@ -70,23 +70,24 @@ void test_cancel_request(void)
 	                         "Loader did not reach WAITING_FOR_PBO state");
 
 	// 3. Cancel the request
-	// Note: async_loader_cancel is not yet implemented, but we expect it to exist
-	// based on our plan. Compilation will fail until we implement it.
+	// Note: async_loader_cancel is not yet implemented, but we expect it to
+	// exist based on our plan. Compilation will fail until we implement it.
 	async_loader_cancel(loader);
 
 	// 4. Verify it transitions to FAILED (and then IDLE upon poll)
-	// After cancel, the worker should wake up, clean up, set state to FAILED.
-	// The next poll should return the FAILED state or IDLE.
-	// Actually, async_loader_poll returns true if state is READY or WAITING_FOR_PBO.
-	// If state is FAILED, it returns false but logs error and resets to IDLE.
-	// Wait, let's check async_loader_poll implementation again.
+	// After cancel, the worker should wake up, clean up, set state to
+	// FAILED. The next poll should return the FAILED state or IDLE.
+	// Actually, async_loader_poll returns true if state is READY or
+	// WAITING_FOR_PBO. If state is FAILED, it returns false but logs error
+	// and resets to IDLE. Wait, let's check async_loader_poll
+	// implementation again.
 
 	/*
 	} else if (loader->current_request.state == ASYNC_FAILED) {
-		// Failed loading, just reset
-		LOG_ERROR(..., "Async load failed for: %s", ...);
-		loader->current_request.state = ASYNC_IDLE;
-		transition_tracy_state(ASYNC_IDLE);
+	        // Failed loading, just reset
+	        LOG_ERROR(..., "Async load failed for: %s", ...);
+	        loader->current_request.state = ASYNC_IDLE;
+	        transition_tracy_state(ASYNC_IDLE);
 	}
 	*/
 	// It returns false if FAILED. But it resets state to IDLE.
@@ -102,8 +103,8 @@ void test_cancel_request(void)
 
 	// 5. Verify we can submit a new request
 	accepted = async_loader_request(loader, TEMP_FILENAME);
-	TEST_ASSERT_TRUE_MESSAGE(accepted,
-	                         "Should be able to submit new request after cancel");
+	TEST_ASSERT_TRUE_MESSAGE(
+	    accepted, "Should be able to submit new request after cancel");
 }
 
 int main(void)

--- a/tests/test_async_loader_cancel.c
+++ b/tests/test_async_loader_cancel.c
@@ -1,0 +1,114 @@
+// tests/test_async_loader_cancel.c
+#define _POSIX_C_SOURCE 199309L
+#include "async_loader.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unity.h>
+
+static const long MS_MULTIPLIER = 1000L;
+static AsyncLoader* loader;
+static const char* TEMP_FILENAME = "test_cancel_img.ppm";
+
+static void sleep_ms(long milliseconds)
+{
+	struct timespec req;
+	req.tv_sec = milliseconds / MS_MULTIPLIER;
+	req.tv_nsec =
+	    (milliseconds % MS_MULTIPLIER) * MS_MULTIPLIER * MS_MULTIPLIER;
+	nanosleep(&req, NULL);
+}
+
+void setUp(void)
+{
+	loader = async_loader_create(NULL);
+	// Create a valid dummy PPM file
+	FILE* f = fopen(TEMP_FILENAME, "wb");
+	if (f) {
+		fprintf(f, "P6\n1 1\n255\n");
+		unsigned char pixel[] = {255, 0, 0};
+		fwrite(pixel, 1, 3, f);
+		fclose(f);
+	}
+}
+
+void tearDown(void)
+{
+	async_loader_destroy(loader);
+	remove(TEMP_FILENAME);
+}
+
+void test_cancel_request(void)
+{
+	// 1. Submit request
+	bool accepted = async_loader_request(loader, TEMP_FILENAME);
+	TEST_ASSERT_TRUE(accepted);
+
+	// 2. Wait until it reaches ASYNC_WAITING_FOR_PBO
+	int attempts = 0;
+	bool waiting = false;
+	const int MAX_ATTEMPTS = 100;
+	const int POLL_INTERVAL_MS = 10;
+	AsyncRequest req = {0};
+
+	while (attempts < MAX_ATTEMPTS) {
+		if (async_loader_poll(loader, &req)) {
+			// Poll returned true means we got a result.
+			// But we expect it to be waiting for PBO, which returns true
+			// with state ASYNC_WAITING_FOR_PBO.
+			if (req.state == ASYNC_WAITING_FOR_PBO) {
+				waiting = true;
+				break;
+			}
+		}
+		sleep_ms(POLL_INTERVAL_MS);
+		attempts++;
+	}
+
+	TEST_ASSERT_TRUE_MESSAGE(waiting,
+	                         "Loader did not reach WAITING_FOR_PBO state");
+
+	// 3. Cancel the request
+	// Note: async_loader_cancel is not yet implemented, but we expect it to exist
+	// based on our plan. Compilation will fail until we implement it.
+	async_loader_cancel(loader);
+
+	// 4. Verify it transitions to FAILED (and then IDLE upon poll)
+	// After cancel, the worker should wake up, clean up, set state to FAILED.
+	// The next poll should return the FAILED state or IDLE.
+	// Actually, async_loader_poll returns true if state is READY or WAITING_FOR_PBO.
+	// If state is FAILED, it returns false but logs error and resets to IDLE.
+	// Wait, let's check async_loader_poll implementation again.
+
+	/*
+	} else if (loader->current_request.state == ASYNC_FAILED) {
+		// Failed loading, just reset
+		LOG_ERROR(..., "Async load failed for: %s", ...);
+		loader->current_request.state = ASYNC_IDLE;
+		transition_tracy_state(ASYNC_IDLE);
+	}
+	*/
+	// It returns false if FAILED. But it resets state to IDLE.
+
+	// So we wait a bit for worker to process cancellation
+	sleep_ms(50);
+
+	// Now polling should return false (because it was failed/cancelled)
+	// and internal state should be IDLE.
+	AsyncRequest dummy_req;
+	bool res = async_loader_poll(loader, &dummy_req);
+	TEST_ASSERT_FALSE(res);
+
+	// 5. Verify we can submit a new request
+	accepted = async_loader_request(loader, TEMP_FILENAME);
+	TEST_ASSERT_TRUE_MESSAGE(accepted,
+	                         "Should be able to submit new request after cancel");
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_cancel_request);
+	return UNITY_END();
+}

--- a/tests/test_texture_toctou.c
+++ b/tests/test_texture_toctou.c
@@ -12,17 +12,6 @@
 #include "stb_image.h"
 #include "unity.h"
 
-/* Define GL types/constants missing from mock_gl_standalone.h */
-#ifndef GL_MAP_READ_BIT
-typedef unsigned int GLbitfield;
-#define GL_MAP_READ_BIT 0x0001
-#define GL_MAP_WRITE_BIT 0x0002
-#define GL_MAP_INVALIDATE_RANGE_BIT 0x0004
-#define GL_MAP_INVALIDATE_BUFFER_BIT 0x0008
-#define GL_MAP_FLUSH_EXPLICIT_BIT 0x0010
-#define GL_MAP_UNSYNCHRONIZED_BIT 0x0020
-#endif
-
 /*
  * Global Mocks for functions NOT provided by other files in the target.
  * We don't use 'static' so that other files in the same target (like io.c)
@@ -61,17 +50,6 @@ void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
 void gpu_profiler_end_stage(GPUProfiler* profiler)
 {
 	(void)profiler;
-}
-
-// GL Mocks missing from mock_gl_standalone.c
-void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
-                       GLbitfield access)
-{
-	(void)target;
-	(void)offset;
-	(void)length;
-	(void)access;
-	return NULL;
 }
 
 // Include source under test


### PR DESCRIPTION
Implemented `async_loader_cancel` to allow the main thread to cancel a pending async load request if it cannot provide the required PBO. This prevents the worker thread from hanging indefinitely. Added a comprehensive unit test `tests/test_async_loader_cancel.c` and necessary mocks to verify the fix in a standalone environment.

---
*PR created automatically by Jules for task [9851360959593228771](https://jules.google.com/task/9851360959593228771) started by @yoyonel*