### PR TITLE
Feature/sh bake coefs

### DIFF
--- a/include/scene.h
+++ b/include/scene.h
@@ -94,6 +94,7 @@ typedef struct {
 	GLint probe_grid_max;     /**< Location of 'u_ProbeGridMax' */
 	GLint probe_grid_dim;     /**< Location of 'u_ProbeGridDim' */
 	GLint gi_mode;            /**< Location of 'u_GIMode' */
+	GLint grid_to_idx_scale;  /**< Location of 'u_GridToIdxScale' */
 	GLint
 	    sh_textures[SH_TEXTURE_COUNT]; /**< Locations of 'u_SHTexture0-6' */
 } BillboardUniforms;

--- a/shaders/sh_probe.glsl
+++ b/shaders/sh_probe.glsl
@@ -4,6 +4,7 @@ uniform vec3 u_ProbeGridMin;
 uniform vec3 u_ProbeGridMax;
 uniform ivec3 u_ProbeGridDim;
 uniform int u_GIMode;  // 0: OFF, 1: 3D Texture, 2: SSBO
+uniform vec3 u_GridToIdxScale;
 
 /* 7x 3D textures for SH coefficients (Units 8-14)
    - Tex 0-5: Coeffs 0-7 (RGBA16F, each holds 4 channels)
@@ -197,12 +198,22 @@ vec3 eval_sh_irradiance_packed(vec3 normal, vec4 t0, vec4 t1, vec4 t2, vec4 t3,
 
 vec3 eval_sh_irradiance_ssbo(vec3 normal, vec3 worldPos)
 {
-	vec3 grid_size = u_ProbeGridMax - u_ProbeGridMin;
-	vec3 local_pos = worldPos - u_ProbeGridMin;
-	vec3 t = local_pos / max(grid_size, vec3(0.001));
+	// vec3 grid_size = u_ProbeGridMax - u_ProbeGridMin;
+	// vec3 local_pos = worldPos - u_ProbeGridMin;
+	// vec3 t = local_pos / max(grid_size, vec3(0.001));
 
-	// Calculate base probe index and interpolation weights
-	vec3 float_idx = t * vec3(max(u_ProbeGridDim - ivec3(1), ivec3(1)));
+	// // Calculate base probe index and interpolation weights
+	// vec3 float_idx = t * vec3(max(u_ProbeGridDim - ivec3(1), ivec3(1)));
+
+	vec3 local_pos = worldPos - u_ProbeGridMin;
+	vec3 float_idx = local_pos * u_GridToIdxScale;
+
+	// Dans la fonction sampler3D, t s'obtient simplement par :
+	vec3 t =
+	    local_pos / max(u_ProbeGridMax - u_ProbeGridMin,
+	                    vec3(0.001));  // Le compilateur optimisera le max()
+	                                   // car ce sont des uniforms
+
 	ivec3 base_idx = min(ivec3(floor(float_idx)),
 	                     max(u_ProbeGridDim - ivec3(2), ivec3(0)));
 	vec3 weights = float_idx - vec3(base_idx);

--- a/shaders/sh_probe.glsl
+++ b/shaders/sh_probe.glsl
@@ -41,6 +41,107 @@ const float A0 = 3.14159265359;
 const float A1 = 2.09439510239;
 const float A2 = 0.78539816339;
 
+#define USE_SH_BAKE_FACTORS
+
+#ifdef USE_SH_BAKE_FACTORS
+vec3 eval_sh_irradiance_packed(vec3 normal, vec4 t0, vec4 t1, vec4 t2, vec4 t3,
+                               vec4 t4, vec4 t5, vec4 t6)
+{
+	float x = normal.x;
+	float y = normal.y;
+	float z = normal.z;
+
+	vec3 L[9];
+	/* TEX 0: {0,0}, {0,1}, {0,2}, {1,0} */
+	L[0] = t0.rgb;
+	L[1].r = t0.a;
+	/* TEX 1: {1,1}, {1,2}, {2,0}, {2,1} */
+	L[1].gb = t1.rg;
+	L[2].rg = t1.ba;
+	/* TEX 2: {2,2}, {3,0}, {3,1}, {3,2} */
+	L[2].b = t2.r;
+	L[3] = t2.gba;
+	/* TEX 3: {4,0}, {4,1}, {4,2}, {5,0} */
+	L[4] = t3.rgb;
+	L[5].r = t3.a;
+	/* TEX 4: {5,1}, {5,2}, {6,0}, {6,1} */
+	L[5].gb = t4.rg;
+	L[6].rg = t4.ba;
+	/* TEX 5: {6,2}, {7,0}, {7,1}, {7,2} */
+	L[6].b = t5.r;
+	L[7] = t5.gba;
+	/* TEX 6: {8,0}, {8,1}, {8,2}, {-1,-1} */
+	L[8] = t6.rgb;
+
+	vec3 color = L[0];  // L[0] multiplié par 1.0
+	color += L[1] * y;
+	color += L[2] * z;
+	color += L[3] * x;
+	color += L[4] * (x * y);
+	color += L[5] * (y * z);
+	color += L[6] * (3.0 * z * z - 1.0);
+	color += L[7] * (x * z);
+	color += L[8] * (x * x - y * y);
+
+	return max(color, vec3(0.0));
+}
+
+vec3 eval_sh_irradiance_ssbo(vec3 normal, vec3 worldPos)
+{
+	vec3 grid_size = u_ProbeGridMax - u_ProbeGridMin;
+	vec3 local_pos = worldPos - u_ProbeGridMin;
+	vec3 t = local_pos / max(grid_size, vec3(0.001));
+
+	// Calculate base probe index and interpolation weights
+	vec3 float_idx = t * vec3(max(u_ProbeGridDim - ivec3(1), ivec3(1)));
+	ivec3 base_idx = min(ivec3(floor(float_idx)),
+	                     max(u_ProbeGridDim - ivec3(2), ivec3(0)));
+
+	vec3 weights = float_idx - vec3(base_idx);
+	weights = clamp(weights, 0.0, 1.0);
+
+	vec4 interpolated_coeffs[9];
+	for (int j = 0; j < 9; ++j) {
+		interpolated_coeffs[j] = vec4(0.0);
+	}
+
+	for (int i = 0; i < 8; ++i) {
+		ivec3 offset = ivec3(i & 1, (i >> 1) & 1, (i >> 2) & 1);
+		ivec3 p = clamp(base_idx + offset, ivec3(0),
+		                u_ProbeGridDim - ivec3(1));
+
+		int idx = (p.z * u_ProbeGridDim.y * u_ProbeGridDim.x) +
+		          (p.y * u_ProbeGridDim.x) + p.x;
+
+		// mix(x, y, a) retourne x quand a=0, et y quand a=1.
+		// vec3(offset) contient exactement des 0.0 ou des 1.0
+		vec3 w3 = mix(1.0 - weights, weights, vec3(offset));
+		float w = w3.x * w3.y * w3.z;
+
+		for (int j = 0; j < 9; ++j) {
+			interpolated_coeffs[j] += probes[idx].coeffs[j] * w;
+		}
+	}
+
+	float x = normal.x;
+	float y = normal.y;
+	float z = normal.z;
+
+	// Reconstruction ultra-rapide avec les coefficients "cuits"
+	vec3 color =
+	    interpolated_coeffs[0].rgb;  // Multiplié implicitement par 1.0
+	color += interpolated_coeffs[1].rgb * y;
+	color += interpolated_coeffs[2].rgb * z;
+	color += interpolated_coeffs[3].rgb * x;
+	color += interpolated_coeffs[4].rgb * (x * y);
+	color += interpolated_coeffs[5].rgb * (y * z);
+	color += interpolated_coeffs[6].rgb * (3.0 * z * z - 1.0);
+	color += interpolated_coeffs[7].rgb * (x * z);
+	color += interpolated_coeffs[8].rgb * (x * x - y * y);
+
+	return max(color, vec3(0.0));
+}
+#else
 vec3 eval_sh_irradiance_packed(vec3 normal, vec4 t0, vec4 t1, vec4 t2, vec4 t3,
                                vec4 t4, vec4 t5, vec4 t6)
 {
@@ -119,10 +220,10 @@ vec3 eval_sh_irradiance_ssbo(vec3 normal, vec3 worldPos)
 		int idx = (p.z * u_ProbeGridDim.y * u_ProbeGridDim.x) +
 		          (p.y * u_ProbeGridDim.x) + p.x;
 
-		float w = 1.0;
-		w *= (offset.x == 0) ? (1.0 - weights.x) : weights.x;
-		w *= (offset.y == 0) ? (1.0 - weights.y) : weights.y;
-		w *= (offset.z == 0) ? (1.0 - weights.z) : weights.z;
+		// mix(x, y, a) retourne x quand a=0, et y quand a=1.
+		// vec3(offset) contient exactement des 0.0 ou des 1.0
+		vec3 w3 = mix(1.0 - weights, weights, vec3(offset));
+		float w = w3.x * w3.y * w3.z;
 
 		for (int j = 0; j < 9; ++j) {
 			interpolated_coeffs[j] += probes[idx].coeffs[j] * w;
@@ -156,6 +257,7 @@ vec3 eval_sh_irradiance_ssbo(vec3 normal, vec3 worldPos)
 
 	return max(color, vec3(0.0));
 }
+#endif
 
 vec3 get_probe_irradiance(vec3 N, vec3 worldPos)
 {

--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -20,6 +20,7 @@
 #endif
 
 #define USE_SH_BAKE_FACTORS 1
+#define SH_COEFF_COUNT 9
 
 /*
  * GI 1-Bounce Configuration
@@ -56,6 +57,15 @@ enum {
 };
 #define GI_HALF 0.5F
 #define GI_ZERO 0.0F
+
+typedef struct {
+	vec3 pos;
+	float radius;
+	float min_d_sq;      // Distance minimale au carré
+	float max_d_sq;      // Distance maximale au carré
+	float diffuse_base;  // Facteur pré-calculé
+	const float* albedo;
+} CachedSphere;
 
 /* Helper to get position from POD */
 static void get_sphere_pos(const SphereInstance_POD* sphere, vec3 dest)
@@ -163,48 +173,43 @@ void light_probe_grid_free_cpu(LightProbeGrid* grid)
 	pthread_cond_destroy(&grid->cond);
 }
 
-static void compute_probe_sh(const SphereInstance_POD* local_scene,
-                             int local_count, vec3 probe_pos, SH9* sh_data)
+static void compute_probe_sh(const CachedSphere* cached_scene, int local_count,
+                             vec3 probe_pos, SH9* sh_data)
 {
 	for (int sphere_idx = 0; sphere_idx < local_count; sphere_idx++) {
-		const SphereInstance_POD* sphere = &local_scene[sphere_idx];
-		vec3 sphere_pos;
-		get_sphere_pos(sphere, sphere_pos);
-		float radius = get_sphere_radius(sphere);
+		const CachedSphere* sphere = &cached_scene[sphere_idx];
 
 		vec3 delta;
-		glm_vec3_sub(probe_pos, sphere_pos, delta);
+		glm_vec3_sub(probe_pos, (float*)sphere->pos, delta);
 		float dist_sq = glm_vec3_norm2(delta);
 
 		/* Early-out: coincident or inside sphere */
 		if (dist_sq < GI_EPSILON) {
 			continue;
 		}
-		float dist = sqrtf(dist_sq);
 
 		/* Too close: SH ringing */
-		float min_d = GI_MIN_DIST_RADII * radius;
-		if (dist < min_d) {
+		if (dist_sq < sphere->min_d_sq) {
 			continue;
 		}
 
 		/* Too far: negligible */
-		float max_d = GI_MAX_DIST_RADII * radius;
-		if (dist > max_d) {
+		if (dist_sq > sphere->max_d_sq) {
 			continue;
 		}
 
-		/* Form factor: r^2 / d^2 */
-		float form_factor = (radius * radius) / dist_sq;
+		float dist = sqrtf(dist_sq);
+
+		/* Form factor: r^2 / d^2 (r^2 is already baked in diffuse_base)
+		 */
+		float form_factor = 1.0F / dist_sq;
 
 		/* Direction probe → sphere */
 		vec3 dir;
-		glm_vec3_sub(sphere_pos, probe_pos, dir);
-		glm_vec3_scale(dir, 1.0F / dist, dir);
+		glm_vec3_scale(delta, -1.0F / dist, dir);
 
 		/* Metals don't bounce diffuse light */
-		float diffuse = (1.0F - (sphere->metallic * 0.0F)) *
-		                form_factor * GI_BOUNCE_SCALE;
+		float diffuse = sphere->diffuse_base * form_factor;
 
 		vec3 radiance;
 		glm_vec3_scale((float*)sphere->albedo, diffuse, radiance);
@@ -214,18 +219,15 @@ static void compute_probe_sh(const SphereInstance_POD* local_scene,
 }
 
 static int is_probe_inside_sphere(vec3 probe_pos,
-                                  const SphereInstance_POD* local_scene,
+                                  const CachedSphere* cached_scene,
                                   int local_count)
 {
 	for (int sphere_idx = 0; sphere_idx < local_count; sphere_idx++) {
-		const SphereInstance_POD* sphere = &local_scene[sphere_idx];
-		vec3 sphere_pos;
-		get_sphere_pos(sphere, sphere_pos);
-		float radius = get_sphere_radius(sphere);
+		const CachedSphere* sphere = &cached_scene[sphere_idx];
 
 		vec3 delta;
-		glm_vec3_sub(probe_pos, sphere_pos, delta);
-		if (glm_vec3_norm2(delta) < (radius * radius)) {
+		glm_vec3_sub(probe_pos, (float*)sphere->pos, delta);
+		if (glm_vec3_norm2(delta) < (sphere->radius * sphere->radius)) {
 			return 1;
 		}
 	}
@@ -233,9 +235,10 @@ static int is_probe_inside_sphere(vec3 probe_pos,
 }
 
 #ifdef USE_SH_BAKE_FACTORS
-static void light_probe_worker_compute_probe(
-    LightProbeGrid* grid, int grid_x, int grid_y, int grid_z,
-    const SphereInstance_POD* local_scene, int local_count)
+static void light_probe_worker_compute_probe(LightProbeGrid* grid, int grid_x,
+                                             int grid_y, int grid_z,
+                                             const CachedSphere* cached_scene,
+                                             int local_count)
 {
 	int idx = (grid_z * grid->grid_dim[1] * grid->grid_dim[0]) +
 	          (grid_y * grid->grid_dim[0]) + grid_x;
@@ -245,39 +248,40 @@ static void light_probe_worker_compute_probe(
 	probe_pos[1] = grid->aabb_min[1] + ((float)grid_y * grid->cell_size[1]);
 	probe_pos[2] = grid->aabb_min[2] + ((float)grid_z * grid->cell_size[2]);
 
-	if (is_probe_inside_sphere(probe_pos, local_scene, local_count)) {
+	if (is_probe_inside_sphere(probe_pos, cached_scene, local_count)) {
 		grid->probes[idx].sh_data.coeffs[0][3] = -1.0F;
 		return;
 	}
 
 	// Calcul de base des harmoniques (inchangé)
-	compute_probe_sh(local_scene, local_count, probe_pos,
+	compute_probe_sh(cached_scene, local_count, probe_pos,
 	                 &grid->probes[idx].sh_data);
 
 	/* --- NOUVEAU : Cuisson des constantes (A * Y) --- */
-	static const float SH_BAKE_FACTORS[9] = {
-	    0.88622692545f, /* L00:  A0 * Y00 */
-	    1.02332670794f, /* L1-1: A1 * Y1n1 */
-	    1.02332670794f, /* L10:  A1 * Y10 */
-	    1.02332670794f, /* L11:  A1 * Y11 */
-	    0.85808553081f, /* L2-2: A2 * Y2n2 */
-	    0.85808553081f, /* L2-1: A2 * Y2n1 */
-	    0.24770795610f, /* L20:  A2 * Y20 */
-	    0.85808553081f, /* L21:  A2 * Y21 */
-	    0.42904276540f  /* L22:  A2 * Y22 */
+	static const float SH_BAKE_FACTORS[SH_COEFF_COUNT] = {
+	    0.88622692545F, /* L00:  A0 * Y00 */
+	    1.02332670794F, /* L1-1: A1 * Y1n1 */
+	    1.02332670794F, /* L10:  A1 * Y10 */
+	    1.02332670794F, /* L11:  A1 * Y11 */
+	    0.85808553081F, /* L2-2: A2 * Y2n2 */
+	    0.85808553081F, /* L2-1: A2 * Y2n1 */
+	    0.24770795610F, /* L20:  A2 * Y20 */
+	    0.85808553081F, /* L21:  A2 * Y21 */
+	    0.42904276540F  /* L22:  A2 * Y22 */
 	};
 
 	// On multiplie directement les canaux RGB de chaque coefficient
-	for (int i = 0; i < 9; i++) {
+	for (int i = 0; i < SH_COEFF_COUNT; i++) {
 		grid->probes[idx].sh_data.coeffs[i][0] *= SH_BAKE_FACTORS[i];
 		grid->probes[idx].sh_data.coeffs[i][1] *= SH_BAKE_FACTORS[i];
 		grid->probes[idx].sh_data.coeffs[i][2] *= SH_BAKE_FACTORS[i];
 	}
 }
 #else
-static void light_probe_worker_compute_probe(
-    LightProbeGrid* grid, int grid_x, int grid_y, int grid_z,
-    const SphereInstance_POD* local_scene, int local_count)
+static void light_probe_worker_compute_probe(LightProbeGrid* grid, int grid_x,
+                                             int grid_y, int grid_z,
+                                             const CachedSphere* cached_scene,
+                                             int local_count)
 {
 	int idx = (grid_z * grid->grid_dim[1] * grid->grid_dim[0]) +
 	          (grid_y * grid->grid_dim[0]) + grid_x;
@@ -291,17 +295,43 @@ static void light_probe_worker_compute_probe(
 	 * half-spacing away from centers. Mark
 	 * as invalid/skip if inside sphere for
 	 * robustness. */
-	if (is_probe_inside_sphere(probe_pos, local_scene, local_count)) {
+	if (is_probe_inside_sphere(probe_pos, cached_scene, local_count)) {
 		/* Mark as invalid for debug
 		 * shader */
 		grid->probes[idx].sh_data.coeffs[0][3] = -1.0F;
 		return;
 	}
 
-	compute_probe_sh(local_scene, local_count, probe_pos,
+	compute_probe_sh(cached_scene, local_count, probe_pos,
 	                 &grid->probes[idx].sh_data);
 }
 #endif
+
+static void* precompute_cached_spheres(SphereInstance_POD* local_scene,
+                                       int local_count)
+{
+	CachedSphere* cached_scene = malloc(local_count * sizeof(CachedSphere));
+	for (int i = 0; i < local_count; i++) {
+		get_sphere_pos(&local_scene[i], cached_scene[i].pos);
+		float radius = get_sphere_radius(&local_scene[i]);
+		cached_scene[i].radius = radius;
+
+		// On précalcule les distances au carré pour éviter les
+		// sqrt() plus tard
+		cached_scene[i].min_d_sq =
+		    (GI_MIN_DIST_RADII * radius) * (GI_MIN_DIST_RADII * radius);
+		cached_scene[i].max_d_sq =
+		    (GI_MAX_DIST_RADII * radius) * (GI_MAX_DIST_RADII * radius);
+
+		// Le (sphere->metallic * 0.0F) semble être un
+		// placeholder, je le garde tel quel
+		cached_scene[i].diffuse_base =
+		    (1.0F - (local_scene[i].metallic * 0.0F)) *
+		    (radius * radius) * GI_BOUNCE_SCALE;
+		cached_scene[i].albedo = local_scene[i].albedo;
+	}
+	return cached_scene;
+}
 
 static void* light_probe_worker(void* arg)
 {
@@ -355,6 +385,9 @@ static void* light_probe_worker(void* arg)
 		    (size_t)grid->total_probes * sizeof(LightProbe), 0,
 		    (size_t)grid->total_probes * sizeof(LightProbe));
 
+		CachedSphere* cached_scene =
+		    precompute_cached_spheres(local_scene, local_count);
+
 		for (int grid_z = 0; grid_z < grid->grid_dim[2]; grid_z++) {
 			for (int grid_y = 0; grid_y < grid->grid_dim[1];
 			     grid_y++) {
@@ -362,12 +395,13 @@ static void* light_probe_worker(void* arg)
 				     grid_x++) {
 					light_probe_worker_compute_probe(
 					    grid, grid_x, grid_y, grid_z,
-					    local_scene, local_count);
+					    cached_scene, local_count);
 				}
 			}
 		}
 
 		free(local_scene);
+		free(cached_scene);
 
 		double worker_ms = perf_timer_elapsed_ms(&worker_timer);
 		LOG_DEBUG("perf.gi",
@@ -666,6 +700,25 @@ void light_probe_render_debug(LightProbeGrid* grid, mat4 view, mat4 proj)
 
 	shader_set_vec3(grid->debug_shader, "u_ProbeGridMin", grid->aabb_min);
 	shader_set_vec3(grid->debug_shader, "u_ProbeGridMax", grid->aabb_max);
+
+	vec3 grid_size;
+	glm_vec3_sub(grid->aabb_max, grid->aabb_min, grid_size);
+
+	vec3 grid_scale;
+	grid_scale[0] = (grid->grid_dim[0] > 1)
+	                    ? (float)(grid->grid_dim[0] - 1) /
+	                          fmaxf(grid_size[0], GI_EPSILON)
+	                    : 0.0F;
+	grid_scale[1] = (grid->grid_dim[1] > 1)
+	                    ? (float)(grid->grid_dim[1] - 1) /
+	                          fmaxf(grid_size[1], GI_EPSILON)
+	                    : 0.0F;
+	grid_scale[2] = (grid->grid_dim[2] > 1)
+	                    ? (float)(grid->grid_dim[2] - 1) /
+	                          fmaxf(grid_size[2], GI_EPSILON)
+	                    : 0.0F;
+
+	shader_set_vec3(grid->debug_shader, "u_GridToIdxScale", grid_scale);
 
 	GLint loc_dim =
 	    shader_get_uniform_location(grid->debug_shader, "u_ProbeGridDim");

--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -19,6 +19,8 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+#define USE_SH_BAKE_FACTORS 1
+
 /*
  * GI 1-Bounce Configuration
  *
@@ -230,6 +232,49 @@ static int is_probe_inside_sphere(vec3 probe_pos,
 	return 0;
 }
 
+#ifdef USE_SH_BAKE_FACTORS
+static void light_probe_worker_compute_probe(
+    LightProbeGrid* grid, int grid_x, int grid_y, int grid_z,
+    const SphereInstance_POD* local_scene, int local_count)
+{
+	int idx = (grid_z * grid->grid_dim[1] * grid->grid_dim[0]) +
+	          (grid_y * grid->grid_dim[0]) + grid_x;
+
+	vec3 probe_pos;
+	probe_pos[0] = grid->aabb_min[0] + ((float)grid_x * grid->cell_size[0]);
+	probe_pos[1] = grid->aabb_min[1] + ((float)grid_y * grid->cell_size[1]);
+	probe_pos[2] = grid->aabb_min[2] + ((float)grid_z * grid->cell_size[2]);
+
+	if (is_probe_inside_sphere(probe_pos, local_scene, local_count)) {
+		grid->probes[idx].sh_data.coeffs[0][3] = -1.0F;
+		return;
+	}
+
+	// Calcul de base des harmoniques (inchangé)
+	compute_probe_sh(local_scene, local_count, probe_pos,
+	                 &grid->probes[idx].sh_data);
+
+	/* --- NOUVEAU : Cuisson des constantes (A * Y) --- */
+	static const float SH_BAKE_FACTORS[9] = {
+	    0.88622692545f, /* L00:  A0 * Y00 */
+	    1.02332670794f, /* L1-1: A1 * Y1n1 */
+	    1.02332670794f, /* L10:  A1 * Y10 */
+	    1.02332670794f, /* L11:  A1 * Y11 */
+	    0.85808553081f, /* L2-2: A2 * Y2n2 */
+	    0.85808553081f, /* L2-1: A2 * Y2n1 */
+	    0.24770795610f, /* L20:  A2 * Y20 */
+	    0.85808553081f, /* L21:  A2 * Y21 */
+	    0.42904276540f  /* L22:  A2 * Y22 */
+	};
+
+	// On multiplie directement les canaux RGB de chaque coefficient
+	for (int i = 0; i < 9; i++) {
+		grid->probes[idx].sh_data.coeffs[i][0] *= SH_BAKE_FACTORS[i];
+		grid->probes[idx].sh_data.coeffs[i][1] *= SH_BAKE_FACTORS[i];
+		grid->probes[idx].sh_data.coeffs[i][2] *= SH_BAKE_FACTORS[i];
+	}
+}
+#else
 static void light_probe_worker_compute_probe(
     LightProbeGrid* grid, int grid_x, int grid_y, int grid_z,
     const SphereInstance_POD* local_scene, int local_count)
@@ -256,6 +301,7 @@ static void light_probe_worker_compute_probe(
 	compute_probe_sh(local_scene, local_count, probe_pos,
 	                 &grid->probes[idx].sh_data);
 }
+#endif
 
 static void* light_probe_worker(void* arg)
 {
@@ -486,7 +532,7 @@ void light_probe_grid_sync(LightProbeGrid* grid)
 	float* pack_buffer = malloc(float_count * sizeof(float));
 
 	if (pack_buffer) {
-		const int mapping[SH_TEXTURE_COUNT][4][2] = {
+		static const int mapping[SH_TEXTURE_COUNT][4][2] = {
 		    /* {coeff_idx, channel_idx} */
 		    {{0, 0}, {0, 1}, {0, 2}, {1, 0}},  /* Tex 0 */
 		    {{1, 1}, {1, 2}, {2, 0}, {2, 1}},  /* Tex 1 */

--- a/src/scene.c
+++ b/src/scene.c
@@ -299,6 +299,9 @@ static int scene_init_billboard_shader(Scene* scene)
 	    scene->pbr_billboard_shader, "u_ProbeGridDim");
 	scene->billboard_uniforms.gi_mode = shader_get_uniform_location(
 	    scene->pbr_billboard_shader, "u_GIMode");
+	scene->billboard_uniforms.grid_to_idx_scale =
+	    shader_get_uniform_location(scene->pbr_billboard_shader,
+	                                "u_GridToIdxScale");
 
 	/* Set Billboard SH Sampler Indices (units 8-14) */
 	{


### PR DESCRIPTION
* Degré de certitude : 100% (C'est mathématiquement une égalité parfaite (ISO), basée sur l'associativité de la multiplication Ax(B×C)=(A×B)×C).
* CPU : Le piège de la complexité $O(N \times M)$ dans compute_probe_sh
* CPU : L'élimination des sqrtf() (Early Depth Test)
* GPU : Extraire les "invariants par pixel" (sh_probe.glsl)

```
C'est une optimisation "gratuite" classique dans les moteurs AAA.
Actuellement, pour chaque pixel à l'écran, votre shader fait le calcul suivant pour reconstruire l'irradiance :
Couleur = Coefficient_Sonde * (Constante_Harmonique * Constante_Cosinus * Polynome_Spatial)

Puisque les sondes ne bougent pas (ou sont calculées asynchronement), on peut multiplier le Coefficient_Sonde par la Constante_Harmonique et la Constante_Cosinus une seule fois sur le CPU.

Le shader n'aura plus qu'à faire :
Couleur = Coefficient_Cuit * Polynome_Spatial
```