### PR TITLE
Refactor: remove NOLINT directives from public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,7 +403,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
         target_compile_options(app PRIVATE -fno-omit-frame-pointer)
     endif()
 
-    target_compile_definitions(app PRIVATE _GNU_SOURCE)
+    target_compile_definitions(app PRIVATE _GNU_SOURCE _POSIX_C_SOURCE=200809L)
 endif()
 
 if(ENABLE_SHADER_OPTIMIZATION)

--- a/include/gl_common.h
+++ b/include/gl_common.h
@@ -17,11 +17,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/** @brief Macro to offset a pointer by a byte amount (useful for EBO/VBO
- * offsets). */
-#define BUFFER_OFFSET(offset) \
-	((void*)(uintptr_t)(offset))  // NOLINT(performance-no-int-to-ptr)
-
 /** @brief Minimum number of vertex attributes guaranteed by OpenGL 3.3+. */
 enum { MAX_VERTEX_ATTRIBS_BASELINE = 16 };
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -8,9 +8,19 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/**
+ * @brief Helper to securely cast an integer offset to a pointer, often used for
+ * VBO/EBO byte offsets.
+ * @param offset The byte offset to cast.
+ * @return A void pointer representing the offset.
+ */
+void* utils_buffer_offset(size_t offset);
 
 /**
  * @brief Safe wrapper around vsnprintf to format strings with bounds checking.

--- a/src/async_loader.c
+++ b/src/async_loader.c
@@ -1,11 +1,11 @@
-#include "utils.h"
-#define _POSIX_C_SOURCE 200809L  // NOLINT(cert-dcl37-c,cert-dcl51-cpp)
 #include "async_loader.h"
+
 #include "log.h"
 #include "perf_timer.h"
 #include "simd_utils.h"
 #include "texture.h"
 #include "tracy_manager.h"
+#include "utils.h"
 #include <pthread.h>
 #include <stb_image.h>
 #include <stdbool.h>

--- a/src/render_utils.c
+++ b/src/render_utils.c
@@ -153,9 +153,7 @@ void render_utils_create_fullscreen_quad(GLuint* vao, GLuint* vbo)
 
 	/* TexCoords */
 	glEnableVertexAttribArray(1);
-	/* clang-format off */
-	const void* tex_offset = (const void*)(uintptr_t)TEX_COORD_OFFSET; /* NOLINT(performance-no-int-to-ptr) */
-	/* clang-format on */
+	const void* tex_offset = utils_buffer_offset(TEX_COORD_OFFSET);
 	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
 	                      tex_offset);
 	glVertexAttribDivisor(1, 0);
@@ -282,9 +280,8 @@ void render_utils_setup_sphere_instance_attributes(GLsizei stride,
 
 	/* mat4 model (Locations 2, 3, 4, 5) */
 	for (int i = 0; i < 4; i++) {
-		/* clang-format off */
-		const void* m_offset = (const void*)(uintptr_t)(i * 4 * sizeof(float)); /* NOLINT(performance-no-int-to-ptr) */
-		/* clang-format on */
+		const void* m_offset =
+		    utils_buffer_offset(i * 4 * sizeof(float));
 		glEnableVertexAttribArray(index_vattrib);
 		glVertexAttribPointer(index_vattrib, 4, GL_FLOAT, GL_FALSE,
 		                      stride, m_offset);
@@ -294,9 +291,7 @@ void render_utils_setup_sphere_instance_attributes(GLsizei stride,
 
 	/* Albedo (6) */
 	glEnableVertexAttribArray(index_vattrib);
-	/* clang-format off */
-	const void* a_offset = (const void*)(uintptr_t)offset_albedo; /* NOLINT(performance-no-int-to-ptr) */
-	/* clang-format on */
+	const void* a_offset = utils_buffer_offset(offset_albedo);
 	glVertexAttribPointer(index_vattrib, 3, GL_FLOAT, GL_FALSE, stride,
 	                      a_offset);
 	glVertexAttribDivisor(index_vattrib, 1);
@@ -305,7 +300,7 @@ void render_utils_setup_sphere_instance_attributes(GLsizei stride,
 	/* PBR (7) */
 	glEnableVertexAttribArray(index_vattrib);
 	glVertexAttribPointer(index_vattrib, 3, GL_FLOAT, GL_FALSE, stride,
-	                      BUFFER_OFFSET(offset_metallic));
+	                      utils_buffer_offset(offset_metallic));
 	glVertexAttribDivisor(index_vattrib, 1);
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -147,6 +147,11 @@ bool is_safe_relative_path(const char* path)
 	return true;
 }
 
+void* utils_buffer_offset(size_t offset)
+{
+	return (void*)(uintptr_t)offset;  // NOLINT(performance-no-int-to-ptr)
+}
+
 #ifdef __clang_analyzer__
 void raii_satisfy_analyzer_file(FILE* file_ptr)
 {


### PR DESCRIPTION
This pull request refactors the codebase to adhere to the strict rule of prohibiting `// NOLINT` directives in public header files.

### Changes:
- **`gl_common.h` / `utils.h` / `utils.c`**: The `BUFFER_OFFSET` macro, which previously contained a `NOLINT` to suppress an int-to-pointer cast warning, has been removed from `gl_common.h`. It is replaced by a safe `utils_buffer_offset` function implemented in `src/utils.c`, where the warning can be managed safely inside the implementation file.
- **`render_utils.c`**: Replaced direct macro usage and explicit pointer casts with `utils_buffer_offset()`, effectively clearing out all the `/* NOLINT(performance-no-int-to-ptr) */` comments.
- **`async_loader.c` & `CMakeLists.txt`**: Moved the `#define _POSIX_C_SOURCE 200809L` out of `src/async_loader.c` and into the build system (`CMakeLists.txt`) using `target_compile_definitions`. This resolves the `cert-dcl37-c` and `cert-dcl51-cpp` warnings without the need for inline suppressions.
- **`perf_mode.c`**: Restored the valid `// NOLINT(misc-include-cleaner)` inside the `.c` implementation file for the `sched_param` system struct, strictly keeping to the rule that implementation files can handle third-party/system struct quirks.

All tests compile and run properly. Local formatting was enforced successfully (`make format`). We will rely on the GitHub Actions CI pipeline to perform the final linting and ASan/Valgrind memory checks.

---
*PR created automatically by Jules for task [3146122466483544794](https://jules.google.com/task/3146122466483544794) started by @yoyonel*