### PR TITLE
feat: introduce RHI abstraction for multi-backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(SOURCES
     src/ui.c
     src/utils.c
     src/window.c
+    src/rhi.c
     src/renderer.c
     src/effects/fx_auto_exposure.c
     src/effects/fx_bloom.c
@@ -338,11 +339,13 @@ endif()
 
 # Link avec la version statique de cJSON
 find_package(Threads REQUIRED)
+find_package(Vulkan REQUIRED)
 target_link_libraries(app PRIVATE
     cglm
     glad
     cjson  # Ceci link automatiquement la version statique grâce aux options ci-dessus
     ${GLFW3_LIBRARIES}
+    Vulkan::Vulkan
     m
     dl
     Threads::Threads

--- a/include/app.h
+++ b/include/app.h
@@ -16,6 +16,7 @@
 #include "scene.h"
 #include "tracy_manager.h"
 #include "ui.h"
+#include "rhi.h"
 #include <cglm/cglm.h>
 
 #ifdef USE_SSBO_RENDERING
@@ -88,6 +89,8 @@ typedef struct App {
 	float current_exposure; /**< Integrated GPU exposure value. */
 
 	AsyncLoader* async_loader; /**< Background asset loader context. */
+
+	RHIContext rhi;
 } App;
 
 /* --- Core Control Flow --- */
@@ -95,7 +98,7 @@ typedef struct App {
 /**
  * @brief Fully initializes the application state, window, and OpenGL context.
  */
-int app_init(App* app, int width, int height, const char* title);
+int app_init(App* app, int width, int height, const char* title, GraphicsAPI api);
 
 /**
  * @brief Safely releases all GPU and CPU resources held by the application.

--- a/include/app.h
+++ b/include/app.h
@@ -13,10 +13,10 @@
 #include "gpu_profiler_ui.h"
 #include "perf_mode.h"
 #include "postprocess.h"
+#include "rhi.h"
 #include "scene.h"
 #include "tracy_manager.h"
 #include "ui.h"
-#include "rhi.h"
 #include <cglm/cglm.h>
 
 #ifdef USE_SSBO_RENDERING
@@ -98,7 +98,8 @@ typedef struct App {
 /**
  * @brief Fully initializes the application state, window, and OpenGL context.
  */
-int app_init(App* app, int width, int height, const char* title, GraphicsAPI api);
+int app_init(App* app, int width, int height, const char* title,
+             GraphicsAPI api);
 
 /**
  * @brief Safely releases all GPU and CPU resources held by the application.

--- a/include/cli.h
+++ b/include/cli.h
@@ -6,6 +6,8 @@
 #ifndef CLI_H
 #define CLI_H
 
+#include "rhi.h"
+
 /**
  * @enum CliAction
  * @brief Directive for the application after parsing arguments.
@@ -19,6 +21,15 @@ typedef enum {
 } CliAction;
 
 /**
+ * @struct CliResult
+ * @brief The result of parsing command-line arguments.
+ */
+typedef struct {
+	CliAction action;
+	GraphicsAPI api;
+} CliResult;
+
+/**
  * @brief Parses command-line arguments and determines the next action.
  *
  * @param argc Number of arguments.
@@ -27,6 +38,6 @@ typedef enum {
  *
  * @see main.c
  */
-CliAction cli_handle_args(int argc, char* argv[]);
+CliResult cli_handle_args(int argc, char* argv[]);
 
 #endif /* CLI_H */

--- a/include/rhi.h
+++ b/include/rhi.h
@@ -1,0 +1,20 @@
+#ifndef RHI_H
+#define RHI_H
+
+#include <vulkan/vulkan.h>
+
+typedef struct GLFWwindow GLFWwindow;
+
+typedef enum { API_OPENGL, API_VULKAN } GraphicsAPI;
+
+typedef struct {
+	GraphicsAPI api;
+	VkInstance instance;
+	VkPhysicalDevice physical_device;
+	VkDevice device;
+} RHIContext;
+
+int rhi_init(RHIContext* ctx, GraphicsAPI api, GLFWwindow* window);
+void rhi_cleanup(RHIContext* ctx);
+
+#endif /* RHI_H */

--- a/include/window.h
+++ b/include/window.h
@@ -15,8 +15,8 @@ typedef struct GLFWwindow GLFWwindow;
  * @param api The graphics API (OpenGL or Vulkan)
  * @return Pointer to the created window, or NULL on failure.
  */
-GLFWwindow* window_create(int width, int height, const char* title,
-                          int samples, GraphicsAPI api);
+GLFWwindow* window_create(int width, int height, const char* title, int samples,
+                          GraphicsAPI api);
 
 /**
  * Destroys the window and terminates GLFW.

--- a/include/window.h
+++ b/include/window.h
@@ -1,20 +1,22 @@
 #ifndef WINDOW_H
 #define WINDOW_H
 
+#include "rhi.h"
+
 typedef struct GLFWwindow GLFWwindow;
 
 /**
- * Creates a GLFW window with an OpenGL context initialized.
- * Handles GLFW initialization, Window creation, and GLAD loading.
+ * Creates a GLFW window. For OpenGL, it also initializes context and GLAD.
  *
  * @param width Window width
  * @param height Window height
  * @param title Window title
  * @param samples MSAA samples (0 or 1 to disable)
+ * @param api The graphics API (OpenGL or Vulkan)
  * @return Pointer to the created window, or NULL on failure.
  */
 GLFWwindow* window_create(int width, int height, const char* title,
-                          int samples);
+                          int samples, GraphicsAPI api);
 
 /**
  * Destroys the window and terminates GLFW.

--- a/src/app.c
+++ b/src/app.c
@@ -33,7 +33,7 @@
 
 static const char* const DEFAULT_ENV_FILENAME = "env.hdr";
 
-int app_init(App* app, int width, int height, const char* title)
+int app_init(App* app, int width, int height, const char* title, GraphicsAPI api)
 {
 	app->width = width;
 	app->height = height;
@@ -49,8 +49,14 @@ int app_init(App* app, int width, int height, const char* title)
 	camera_init(&app->camera, DEFAULT_CAMERA_DISTANCE, DEFAULT_CAMERA_YAW,
 	            DEFAULT_CAMERA_PITCH);
 
-	app->window = window_create(width, height, title, DEFAULT_SAMPLES);
+	app->window = window_create(width, height, title, DEFAULT_SAMPLES, api);
 	if (!app->window) {
+		return 0;
+	}
+
+	if (!rhi_init(&app->rhi, api, app->window)) {
+		LOG_ERROR("suckless-ogl.app", "Failed to initialize RHI");
+		window_destroy(app->window);
 		return 0;
 	}
 
@@ -173,6 +179,8 @@ void app_cleanup(App* app)
 	if (!app) {
 		return;
 	}
+
+	rhi_cleanup(&app->rhi);
 
 	/* 1. High-level systems first (may depend on textures/shaders) */
 	ui_destroy(&app->ui);

--- a/src/app.c
+++ b/src/app.c
@@ -33,7 +33,8 @@
 
 static const char* const DEFAULT_ENV_FILENAME = "env.hdr";
 
-int app_init(App* app, int width, int height, const char* title, GraphicsAPI api)
+int app_init(App* app, int width, int height, const char* title,
+             GraphicsAPI api)
 {
 	app->width = width;
 	app->height = height;

--- a/src/cli.c
+++ b/src/cli.c
@@ -7,7 +7,8 @@ static void print_help(const char* prog_name)
 {
 	(void)printf("Usage: %s [options]\n\n", prog_name);
 	(void)printf("Options:\n");
-	(void)printf("  -h, --help      Show this help message and exit\n\n");
+	(void)printf("  -h, --help      Show this help message and exit\n");
+	(void)printf("  --api <name>    Choose graphics API (opengl, vulkan)\n\n");
 	(void)printf("Environment Variables:\n");
 	(void)printf("  OGL_LOG_LEVEL   Set the logging level\n");
 	(void)printf(
@@ -15,26 +16,53 @@ static void print_help(const char* prog_name)
 	(void)printf("                  Default: INFO\n");
 }
 
-CliAction cli_handle_args(int argc, char* argv[])
+CliResult cli_handle_args(int argc, char* argv[])
 {
+	CliResult result = {CLI_ACTION_CONTINUE, API_OPENGL};
+
 	if (argc <= 1) {
-		return CLI_ACTION_CONTINUE;
+		return result;
 	}
 
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "-h") == 0 ||
 		    strcmp(argv[i], "--help") == 0) {
 			print_help(argv[0]);
-			return CLI_ACTION_EXIT_SUCCESS;
+			result.action = CLI_ACTION_EXIT_SUCCESS;
+			return result;
+		} else if (strcmp(argv[i], "--api") == 0) {
+			if (i + 1 < argc) {
+				const char* api_name = argv[i + 1];
+				if (strcmp(api_name, "opengl") == 0) {
+					result.api = API_OPENGL;
+				} else if (strcmp(api_name, "vulkan") == 0) {
+					result.api = API_VULKAN;
+				} else {
+					(void)fprintf(stderr,
+					              "Error: Unknown API '%s'\n\n",
+					              api_name);
+					print_help(argv[0]);
+					result.action = CLI_ACTION_EXIT_FAILURE;
+					return result;
+				}
+				i++; /* Skip next argument */
+			} else {
+				(void)fputs("Error: Missing argument for --api\n\n",
+				            stderr);
+				print_help(argv[0]);
+				result.action = CLI_ACTION_EXIT_FAILURE;
+				return result;
+			}
+		} else {
+			/* Unrecognized option */
+			(void)fputs("Error: Unknown option '", stderr);
+			(void)fputs(argv[i], stderr);
+			(void)fputs("'\n\n", stderr);
+			print_help(argv[0]);
+			result.action = CLI_ACTION_EXIT_FAILURE;
+			return result;
 		}
-
-		/* Unrecognized option */
-		(void)fputs("Error: Unknown option '", stderr);
-		(void)fputs(argv[i], stderr);
-		(void)fputs("'\n\n", stderr);
-		print_help(argv[0]);
-		return CLI_ACTION_EXIT_FAILURE;
 	}
 
-	return CLI_ACTION_CONTINUE;
+	return result;
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -31,7 +31,9 @@ CliResult cli_handle_args(int argc, char* argv[])
 			print_help(argv[0]);
 			result.action = CLI_ACTION_EXIT_SUCCESS;
 			return result;
-		} else if (strcmp(argv[i], "--api") == 0) {
+		}
+
+		if (strcmp(argv[i], "--api") == 0) {
 			if (i + 1 < argc) {
 				const char* api_name = argv[i + 1];
 				if (strcmp(api_name, "opengl") == 0) {
@@ -39,10 +41,10 @@ CliResult cli_handle_args(int argc, char* argv[])
 				} else if (strcmp(api_name, "vulkan") == 0) {
 					result.api = API_VULKAN;
 				} else {
-					(void)fprintf(
-					    stderr,
-					    "Error: Unknown API '%s'\n\n",
-					    api_name);
+					(void)fputs("Error: Unknown API '",
+					            stderr);
+					(void)fputs(api_name, stderr);
+					(void)fputs("'\n\n", stderr);
 					print_help(argv[0]);
 					result.action = CLI_ACTION_EXIT_FAILURE;
 					return result;
@@ -56,15 +58,16 @@ CliResult cli_handle_args(int argc, char* argv[])
 				result.action = CLI_ACTION_EXIT_FAILURE;
 				return result;
 			}
-		} else {
-			/* Unrecognized option */
-			(void)fputs("Error: Unknown option '", stderr);
-			(void)fputs(argv[i], stderr);
-			(void)fputs("'\n\n", stderr);
-			print_help(argv[0]);
-			result.action = CLI_ACTION_EXIT_FAILURE;
-			return result;
+			continue;
 		}
+
+		/* Unrecognized option */
+		(void)fputs("Error: Unknown option '", stderr);
+		(void)fputs(argv[i], stderr);
+		(void)fputs("'\n\n", stderr);
+		print_help(argv[0]);
+		result.action = CLI_ACTION_EXIT_FAILURE;
+		return result;
 	}
 
 	return result;

--- a/src/cli.c
+++ b/src/cli.c
@@ -8,7 +8,8 @@ static void print_help(const char* prog_name)
 	(void)printf("Usage: %s [options]\n\n", prog_name);
 	(void)printf("Options:\n");
 	(void)printf("  -h, --help      Show this help message and exit\n");
-	(void)printf("  --api <name>    Choose graphics API (opengl, vulkan)\n\n");
+	(void)printf(
+	    "  --api <name>    Choose graphics API (opengl, vulkan)\n\n");
 	(void)printf("Environment Variables:\n");
 	(void)printf("  OGL_LOG_LEVEL   Set the logging level\n");
 	(void)printf(
@@ -38,17 +39,19 @@ CliResult cli_handle_args(int argc, char* argv[])
 				} else if (strcmp(api_name, "vulkan") == 0) {
 					result.api = API_VULKAN;
 				} else {
-					(void)fprintf(stderr,
-					              "Error: Unknown API '%s'\n\n",
-					              api_name);
+					(void)fprintf(
+					    stderr,
+					    "Error: Unknown API '%s'\n\n",
+					    api_name);
 					print_help(argv[0]);
 					result.action = CLI_ACTION_EXIT_FAILURE;
 					return result;
 				}
 				i++; /* Skip next argument */
 			} else {
-				(void)fputs("Error: Missing argument for --api\n\n",
-				            stderr);
+				(void)fputs(
+				    "Error: Missing argument for --api\n\n",
+				    stderr);
 				print_help(argv[0]);
 				result.action = CLI_ACTION_EXIT_FAILURE;
 				return result;

--- a/src/main.c
+++ b/src/main.c
@@ -14,11 +14,11 @@ int main(int argc, char* argv[])
 {
 	tracy_manager_init_global();
 
-	CliAction action = cli_handle_args(argc, argv);
-	if (action == CLI_ACTION_EXIT_SUCCESS) {
+	CliResult cli_result = cli_handle_args(argc, argv);
+	if (cli_result.action == CLI_ACTION_EXIT_SUCCESS) {
 		return EXIT_SUCCESS;
 	}
-	if (action == CLI_ACTION_EXIT_FAILURE) {
+	if (cli_result.action == CLI_ACTION_EXIT_FAILURE) {
 		return EXIT_FAILURE;
 	}
 
@@ -30,7 +30,7 @@ int main(int argc, char* argv[])
 	}
 	*app = (App){0};
 
-	if (!app_init(app, WINDOW_WIDTH, WINDOW_HEIGHT, "Icosphere Phong")) {
+	if (!app_init(app, WINDOW_WIDTH, WINDOW_HEIGHT, "Icosphere Phong", cli_result.api)) {
 		LOG_ERROR("suckless-ogl.main",
 		          "Failed to initialize application");
 		app_cleanup(app);

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,8 @@ int main(int argc, char* argv[])
 	}
 	*app = (App){0};
 
-	if (!app_init(app, WINDOW_WIDTH, WINDOW_HEIGHT, "Icosphere Phong", cli_result.api)) {
+	if (!app_init(app, WINDOW_WIDTH, WINDOW_HEIGHT, "Icosphere Phong",
+	              cli_result.api)) {
 		LOG_ERROR("suckless-ogl.main",
 		          "Failed to initialize application");
 		app_cleanup(app);

--- a/src/rhi.c
+++ b/src/rhi.c
@@ -1,0 +1,129 @@
+#include "rhi.h"
+
+#include "log.h"
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+#include <string.h>
+
+int rhi_init(RHIContext* ctx, GraphicsAPI api, GLFWwindow* window)
+{
+	(void)window;
+	if (ctx != NULL) {
+		ctx->api = api;
+		ctx->instance = VK_NULL_HANDLE;
+		ctx->physical_device = VK_NULL_HANDLE;
+		ctx->device = VK_NULL_HANDLE;
+	}
+
+	if (api == API_OPENGL) {
+		LOG_INFO("suckless-ogl.rhi",
+		         "Initializing OpenGL context wrapper.");
+		return 1;
+	}
+
+	if (api == API_VULKAN) {
+		LOG_INFO("suckless-ogl.rhi", "Initializing Vulkan RHI.");
+		VkApplicationInfo app_info = {
+		    .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+		    .pApplicationName = "Suckless-OGL",
+		    .applicationVersion = VK_MAKE_VERSION(1, 0, 0),
+		    .pEngineName = "No Engine",
+		    .engineVersion = VK_MAKE_VERSION(1, 0, 0),
+		    .apiVersion = VK_API_VERSION_1_0};
+
+		uint32_t glfw_extension_count = 0;
+		const char** glfw_extensions = NULL;
+		glfw_extensions =
+		    glfwGetRequiredInstanceExtensions(&glfw_extension_count);
+
+		VkInstanceCreateInfo create_info = {
+		    .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+		    .pApplicationInfo = &app_info,
+		    .enabledExtensionCount = glfw_extension_count,
+		    .ppEnabledExtensionNames = glfw_extensions};
+
+		/* Request validation layers for debug */
+		const char* validation_layers[] = {
+		    "VK_LAYER_KHRONOS_validation"};
+		create_info.enabledLayerCount = 1;
+		create_info.ppEnabledLayerNames = validation_layers;
+
+		if (ctx != NULL) {
+			if (vkCreateInstance(&create_info, NULL,
+			                     &ctx->instance) != VK_SUCCESS) {
+				LOG_ERROR("suckless-ogl.rhi",
+				          "Failed to create Vulkan instance.");
+				return 0;
+			}
+		} else {
+			return 0;
+		}
+
+		uint32_t device_count = 0;
+		vkEnumeratePhysicalDevices(ctx->instance, &device_count, NULL);
+		if (device_count == 0) {
+			LOG_ERROR("suckless-ogl.rhi",
+			          "Failed to find GPUs with Vulkan support.");
+			return 0;
+		}
+
+		enum { MAX_DEVICES = 8 };
+		VkPhysicalDevice devices[MAX_DEVICES] = {VK_NULL_HANDLE};
+		if (device_count > MAX_DEVICES) {
+			device_count = MAX_DEVICES;
+		}
+		vkEnumeratePhysicalDevices(ctx->instance, &device_count,
+		                           devices);
+		if (ctx != NULL) {
+			ctx->physical_device =
+			    devices[0]; /* Pick first for now */
+		}
+
+		float queue_priority = 1.0F;
+		VkDeviceQueueCreateInfo queue_create_info = {
+		    .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+		    .queueFamilyIndex =
+		        0, /* Assuming 0 supports graphics for now */
+		    .queueCount = 1,
+		    .pQueuePriorities = &queue_priority};
+
+		VkPhysicalDeviceFeatures device_features = {0};
+
+		VkDeviceCreateInfo device_create_info = {
+		    .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+		    .pQueueCreateInfos = &queue_create_info,
+		    .queueCreateInfoCount = 1,
+		    .pEnabledFeatures = &device_features,
+		    .enabledExtensionCount = 0,
+		    .ppEnabledExtensionNames = NULL};
+
+		if (vkCreateDevice(ctx->physical_device, &device_create_info,
+		                   NULL, &ctx->device) != VK_SUCCESS) {
+			LOG_ERROR("suckless-ogl.rhi",
+			          "Failed to create Vulkan logical device.");
+			return 0;
+		}
+
+		return 1;
+	}
+
+	return 0;
+}
+
+void rhi_cleanup(RHIContext* ctx)
+{
+	if (!ctx) {
+		return;
+	}
+
+	if (ctx->api == API_VULKAN) {
+		if (ctx->device != VK_NULL_HANDLE) {
+			vkDestroyDevice(ctx->device, NULL);
+			ctx->device = VK_NULL_HANDLE;
+		}
+		if (ctx->instance != VK_NULL_HANDLE) {
+			vkDestroyInstance(ctx->instance, NULL);
+			ctx->instance = VK_NULL_HANDLE;
+		}
+	}
+}

--- a/src/window.c
+++ b/src/window.c
@@ -7,7 +7,7 @@
 #include <GLFW/glfw3.h>
 #include <stdio.h>
 
-GLFWwindow* window_create(int width, int height, const char* title, int samples)
+GLFWwindow* window_create(int width, int height, const char* title, int samples, GraphicsAPI api)
 {
 	/* Initialize GLFW */
 	if (!glfwInit()) {
@@ -15,15 +15,19 @@ GLFWwindow* window_create(int width, int height, const char* title, int samples)
 		return NULL;
 	}
 
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
-	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
+	if (api == API_OPENGL) {
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
+		glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+		glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
 #ifdef __APPLE__
-	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+		glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif
-	if (samples > 1) {
-		glfwWindowHint(GLFW_SAMPLES, samples);
+		if (samples > 1) {
+			glfwWindowHint(GLFW_SAMPLES, samples);
+		}
+	} else if (api == API_VULKAN) {
+		glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 	}
 
 	GLFWwindow* window = glfwCreateWindow(width, height, title, NULL, NULL);
@@ -33,26 +37,30 @@ GLFWwindow* window_create(int width, int height, const char* title, int samples)
 		return NULL;
 	}
 
-	glfwMakeContextCurrent(window);
+	if (api == API_OPENGL) {
+		glfwMakeContextCurrent(window);
 
-	/* Initialize GLAD */
-	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
-		LOG_ERROR("suckless-ogl.window", "Failed to initialize GLAD");
-		glfwDestroyWindow(window);
-		glfwTerminate();
-		return NULL;
+		/* Initialize GLAD */
+		if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+			LOG_ERROR("suckless-ogl.window", "Failed to initialize GLAD");
+			glfwDestroyWindow(window);
+			glfwTerminate();
+			return NULL;
+		}
+
+		/* Initialize OpenGL Debug */
+		setup_opengl_debug();
+
+		/* Log Context Info */
+		int major = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
+		int minor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);
+		LOG_INFO("suckless-ogl.window", "Context Version: %d.%d", major, minor);
+		GPUInfo gpu_info = render_utils_get_gpu_info();
+		LOG_INFO("suckless-ogl.window", "Renderer: %s", gpu_info.renderer);
+		LOG_INFO("suckless-ogl.window", "Version: %s", gpu_info.version);
+	} else if (api == API_VULKAN) {
+		LOG_INFO("suckless-ogl.window", "Created window for Vulkan");
 	}
-
-	/* Initialize OpenGL Debug */
-	setup_opengl_debug();
-
-	/* Log Context Info */
-	int major = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
-	int minor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);
-	LOG_INFO("suckless-ogl.window", "Context Version: %d.%d", major, minor);
-	GPUInfo gpu_info = render_utils_get_gpu_info();
-	LOG_INFO("suckless-ogl.window", "Renderer: %s", gpu_info.renderer);
-	LOG_INFO("suckless-ogl.window", "Version: %s", gpu_info.version);
 
 	return window;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -7,7 +7,8 @@
 #include <GLFW/glfw3.h>
 #include <stdio.h>
 
-GLFWwindow* window_create(int width, int height, const char* title, int samples, GraphicsAPI api)
+GLFWwindow* window_create(int width, int height, const char* title, int samples,
+                          GraphicsAPI api)
 {
 	/* Initialize GLFW */
 	if (!glfwInit()) {
@@ -42,7 +43,8 @@ GLFWwindow* window_create(int width, int height, const char* title, int samples,
 
 		/* Initialize GLAD */
 		if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
-			LOG_ERROR("suckless-ogl.window", "Failed to initialize GLAD");
+			LOG_ERROR("suckless-ogl.window",
+			          "Failed to initialize GLAD");
 			glfwDestroyWindow(window);
 			glfwTerminate();
 			return NULL;
@@ -52,12 +54,17 @@ GLFWwindow* window_create(int width, int height, const char* title, int samples,
 		setup_opengl_debug();
 
 		/* Log Context Info */
-		int major = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
-		int minor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);
-		LOG_INFO("suckless-ogl.window", "Context Version: %d.%d", major, minor);
+		int major =
+		    glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
+		int minor =
+		    glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);
+		LOG_INFO("suckless-ogl.window", "Context Version: %d.%d", major,
+		         minor);
 		GPUInfo gpu_info = render_utils_get_gpu_info();
-		LOG_INFO("suckless-ogl.window", "Renderer: %s", gpu_info.renderer);
-		LOG_INFO("suckless-ogl.window", "Version: %s", gpu_info.version);
+		LOG_INFO("suckless-ogl.window", "Renderer: %s",
+		         gpu_info.renderer);
+		LOG_INFO("suckless-ogl.window", "Version: %s",
+		         gpu_info.version);
 	} else if (api == API_VULKAN) {
 		LOG_INFO("suckless-ogl.window", "Created window for Vulkan");
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,8 @@
 # CONFIGURATION COMMUNE
 # =============================================================================
 
-set(TEST_COMMON_LIBS unity cglm glad cjson ${GLFW3_LIBRARIES} m dl)
+find_package(Vulkan REQUIRED)
+set(TEST_COMMON_LIBS unity cglm glad cjson ${GLFW3_LIBRARIES} Vulkan::Vulkan m dl)
 set(TEST_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/include ${stb_SOURCE_DIR} ${cjson_SOURCE_DIR})
 
 if(ENABLE_TRACY)

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -66,7 +66,7 @@ void setUp(void)
 	// Initialiser une seule fois pour tous les tests
 	if (!g_app_initialized) {
 		int result = app_init(&g_test_app, WINDOW_WIDTH, WINDOW_HEIGHT,
-		                      "Integration Test");
+		                      "Integration Test", API_OPENGL);
 		TEST_ASSERT_EQUAL_INT(1, result);
 		g_app_initialized = true;
 

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -17,31 +17,52 @@ void tearDown(void)
 void test_cli_no_args(void)
 {
 	char* argv[] = {"app"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_CONTINUE, cli_handle_args(1, argv));
+	TEST_ASSERT_EQUAL(CLI_ACTION_CONTINUE, cli_handle_args(1, argv).action);
 }
 
 void test_cli_help_short(void)
 {
 	char* argv[] = {"app", "-h"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS, cli_handle_args(2, argv));
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS, cli_handle_args(2, argv).action);
 }
 
 void test_cli_help_long(void)
 {
 	char* argv[] = {"app", "--help"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS, cli_handle_args(2, argv));
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS, cli_handle_args(2, argv).action);
 }
 
 void test_cli_unknown_arg(void)
 {
 	char* argv[] = {"app", "--unknown"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv));
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv).action);
 }
 
 void test_cli_partial_match(void)
 {
 	char* argv[] = {"app", "--h"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv));
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv).action);
+}
+
+void test_cli_api_arg(void)
+{
+	char* argv_gl[] = {"app", "--api", "opengl"};
+	CliResult result1 = cli_handle_args(3, argv_gl);
+	TEST_ASSERT_EQUAL(CLI_ACTION_CONTINUE, result1.action);
+	TEST_ASSERT_EQUAL(API_OPENGL, result1.api);
+
+	char* argv_vk[] = {"app", "--api", "vulkan"};
+	CliResult result2 = cli_handle_args(3, argv_vk);
+	TEST_ASSERT_EQUAL(CLI_ACTION_CONTINUE, result2.action);
+	TEST_ASSERT_EQUAL(API_VULKAN, result2.api);
+
+	char* argv_unknown_api[] = {"app", "--api", "dx12"};
+	CliResult result3 = cli_handle_args(3, argv_unknown_api);
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, result3.action);
+
+	char* argv_missing_api[] = {"app", "--api"};
+	CliResult result4 = cli_handle_args(2, argv_missing_api);
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, result4.action);
 }
 
 void test_cli_very_long_arg(void)
@@ -56,7 +77,7 @@ void test_cli_very_long_arg(void)
 
 	char* argv[] = {"app", long_arg};
 	/* Should fail gracefully (exit failure) without crashing */
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv));
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv).action);
 	free(long_arg);
 }
 
@@ -68,6 +89,7 @@ int main(void)
 	RUN_TEST(test_cli_help_long);
 	RUN_TEST(test_cli_unknown_arg);
 	RUN_TEST(test_cli_partial_match);
+	RUN_TEST(test_cli_api_arg);
 	RUN_TEST(test_cli_very_long_arg);
 	return UNITY_END();
 }

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -23,25 +23,29 @@ void test_cli_no_args(void)
 void test_cli_help_short(void)
 {
 	char* argv[] = {"app", "-h"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS, cli_handle_args(2, argv).action);
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS,
+	                  cli_handle_args(2, argv).action);
 }
 
 void test_cli_help_long(void)
 {
 	char* argv[] = {"app", "--help"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS, cli_handle_args(2, argv).action);
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_SUCCESS,
+	                  cli_handle_args(2, argv).action);
 }
 
 void test_cli_unknown_arg(void)
 {
 	char* argv[] = {"app", "--unknown"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv).action);
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE,
+	                  cli_handle_args(2, argv).action);
 }
 
 void test_cli_partial_match(void)
 {
 	char* argv[] = {"app", "--h"};
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv).action);
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE,
+	                  cli_handle_args(2, argv).action);
 }
 
 void test_cli_api_arg(void)
@@ -77,7 +81,8 @@ void test_cli_very_long_arg(void)
 
 	char* argv[] = {"app", long_arg};
 	/* Should fail gracefully (exit failure) without crashing */
-	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE, cli_handle_args(2, argv).action);
+	TEST_ASSERT_EQUAL(CLI_ACTION_EXIT_FAILURE,
+	                  cli_handle_args(2, argv).action);
 	free(long_arg);
 }
 

--- a/tests/test_stencil_masking.c
+++ b/tests/test_stencil_masking.c
@@ -30,7 +30,7 @@ void setUp(void)
 {
 	if (!g_app_initialized) {
 		int result = app_init(&g_test_app, TEST_WIDTH, TEST_HEIGHT,
-		                      "Stencil Test");
+		                      "Stencil Test", API_OPENGL);
 		TEST_ASSERT_EQUAL_INT(1, result);
 		g_app_initialized = true;
 	}


### PR DESCRIPTION
This pull request implements the first phase of the Render Hardware Interface (RHI) abstraction required for multi-backend (OpenGL/Vulkan) support.

### Motivation
The codebase was tightly coupled to OpenGL, making it difficult to introduce Vulkan without breaking existing logic or increasing cognitive load. This refactoring extracts the context initialization and window management into a decoupled module (`rhi.c` and `rhi.h`). This reduces the cognitive load for developers by centralizing API-specific setup logic. A human operator can now easily see, isolate, and extend backend initialization logic without hunting through monolithic app files.

### Changes
- **CLI Parsing:** Introduced `--api` flag in `cli.c` to select between OpenGL and Vulkan.
- **Window Management:** Updated `window_create` to accept a `GraphicsAPI` enum, properly setting up context hints (e.g. `GLFW_NO_API` for Vulkan, context logic for OpenGL).
- **RHI Abstraction:** Created `include/rhi.h` and `src/rhi.c` managing a unified `RHIContext`. For Vulkan, it instantiates the `VkInstance` and a logical `VkDevice`.
- **App Teardown:** Centralized RHI resource destruction within `app_cleanup`.
- **Testing:** Extended integration tests to invoke the legacy `API_OPENGL` path and added specific `test_cli` validation.

All formatting, linting, tests, and memory sanitization criteria are met without warning suppressions (`NOLINT`).

---
*PR created automatically by Jules for task [13785568320578119264](https://jules.google.com/task/13785568320578119264) started by @yoyonel*