### PR TITLE
Refactor: Extract AsyncCoordinator and fix ASan crash in postprocess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SOURCES
     src/app_metrics.c
     src/app_ui.c
     src/async_loader.c
+    src/async_coordinator.c
     src/billboard_rendering.c
     src/camera.c
     src/camera_input.c

--- a/include/app.h
+++ b/include/app.h
@@ -3,6 +3,7 @@
 
 #include "action_notifier.h"
 #include "adaptive_sampler.h"
+#include "async/async_coordinator.h"
 #include "async_loader.h"
 #include "camera.h"
 #include "effect_benchmark.h"
@@ -67,12 +68,6 @@ typedef struct App {
 	int log_gpu_metrics; /**< Toggle console logging of GPU stats. */
 
 	/* --- Global GPU Resources --- */
-	GLuint upload_pbo[2];
-	int upload_pbo_idx;
-	GLsizeiptr upload_pbo_size[2];
-	int pending_prealloc_w; /**< Deferred pre-alloc width (0=none). */
-	int pending_prealloc_h; /**< Deferred pre-alloc height. */
-
 	GLuint exposure_pbo; /**< Pixel Buffer Object for mean luma readback. */
 	GLuint histogram_pbo;   /**< Pixel Buffer Object for luminance histogram
 	                           readback. */
@@ -88,6 +83,8 @@ typedef struct App {
 	float current_exposure; /**< Integrated GPU exposure value. */
 
 	AsyncLoader* async_loader; /**< Background asset loader context. */
+	AsyncCoordinator
+	    async_coord; /**< Manages PBO allocation & async synchronization. */
 } App;
 
 /* --- Core Control Flow --- */

--- a/include/async/async_coordinator.h
+++ b/include/async/async_coordinator.h
@@ -1,0 +1,25 @@
+#ifndef ASYNC_COORDINATOR_H
+#define ASYNC_COORDINATOR_H
+
+#include "async_loader.h"
+
+typedef struct AsyncCoordinator {
+	GLuint upload_pbo[2];
+	int upload_pbo_idx;
+	GLsizeiptr upload_pbo_size[2];
+	int pending_prealloc_w;
+	int pending_prealloc_h;
+} AsyncCoordinator;
+
+void async_coordinator_init(AsyncCoordinator* coord);
+void async_coordinator_cleanup(AsyncCoordinator* coord);
+
+/**
+ * Handles communication between the AsyncLoader (background thread) and the
+ * main thread for tasks like mapping PBOs. Returns true if an async request
+ * is fully ready to be consumed by the application.
+ */
+bool async_coordinator_update(AsyncCoordinator* coord, AsyncLoader* loader,
+                              AsyncRequest* out_req);
+
+#endif /* ASYNC_COORDINATOR_H */

--- a/scripts/lint_incremental.py
+++ b/scripts/lint_incremental.py
@@ -24,6 +24,33 @@ CACHE_DIR = os.path.join(src_root, f".lint_cache_{build_dir_name}")
 COMPILE_COMMANDS = os.path.join(BUILD_DIR, "compile_commands.json")
 CLANG_TIDY_CONFIG = os.path.join(src_root, ".clang-tidy")
 
+def find_clang_tidy():
+    """Detect available clang-tidy binary."""
+    # 1. Check environment variable
+    env_bin = os.environ.get("CLANG_TIDY")
+    if env_bin:
+        return env_bin
+
+    # 2. Check standard command
+    try:
+        subprocess.run(["clang-tidy", "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        return "clang-tidy"
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    # 3. Check versioned binaries (descending order)
+    for version in range(22, 13, -1):
+        binary = f"clang-tidy-{version}"
+        try:
+            subprocess.run([binary, "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+            return binary
+        except (subprocess.CalledProcessError, OSError):
+            continue
+
+    return "clang-tidy" # Fallback
+
+CLANG_TIDY_BIN = find_clang_tidy()
+
 def detect_path_prefix():
     """Detect path prefix mismatch between filesystem and compile_commands.json.
 
@@ -89,7 +116,7 @@ def run_clang_tidy(file_path):
     """Runs clang-tidy on a single file."""
     # Normalize path to match compile_commands.json (handles /var/home vs /home)
     normalized_path = normalize_path_for_clang_tidy(file_path)
-    cmd = ["clang-tidy-17", "-p", BUILD_DIR, "-quiet", normalized_path]
+    cmd = [CLANG_TIDY_BIN, "-p", BUILD_DIR, "-quiet", normalized_path]
 
     try:
         # Capture output.

--- a/scripts/lint_incremental.py
+++ b/scripts/lint_incremental.py
@@ -89,7 +89,7 @@ def run_clang_tidy(file_path):
     """Runs clang-tidy on a single file."""
     # Normalize path to match compile_commands.json (handles /var/home vs /home)
     normalized_path = normalize_path_for_clang_tidy(file_path)
-    cmd = ["run-clang-tidy", "-p", BUILD_DIR, "-quiet", normalized_path]
+    cmd = ["clang-tidy-17", "-p", BUILD_DIR, "-quiet", normalized_path]
 
     try:
         # Capture output.

--- a/src/app.c
+++ b/src/app.c
@@ -93,10 +93,7 @@ int app_init(App* app, int width, int height, const char* title)
 
 	app->current_exposure = 1.0F;
 
-	glGenBuffers(2, app->upload_pbo);
-	app->upload_pbo_idx = 0;
-	app->upload_pbo_size[0] = 0;
-	app->upload_pbo_size[1] = 0;
+	async_coordinator_init(&app->async_coord);
 
 	app->lum_histogram_buffer =
 	    malloc((size_t)(LUM_HISTOGRAM_MAP_SIZE * LUM_HISTOGRAM_MAP_SIZE) *
@@ -189,7 +186,8 @@ void app_cleanup(App* app)
 	/* 3. Common low-level resources */
 	GL_SAFE_DELETE_BUFFER(app->exposure_pbo);
 	GL_SAFE_DELETE_BUFFER(app->histogram_pbo);
-	GL_SAFE_DELETE_BUFFERS(2, app->upload_pbo);
+
+	async_coordinator_cleanup(&app->async_coord);
 
 	adaptive_sampler_cleanup(&app->fps_sampler);
 
@@ -337,58 +335,21 @@ void app_update(App* app)
 	 * PBO setup, so glTexImage2D doesn't pile up on the same
 	 * frame as PBO Setup & Map.
 	 */
-	if (app->pending_prealloc_w > 0) {
-		app->scene.recycled_hdr_tex = texture_preallocate_hdr(
-		    app->pending_prealloc_w, app->pending_prealloc_h,
-		    app->scene.recycled_hdr_tex);
-		app->pending_prealloc_w = 0;
-		app->pending_prealloc_h = 0;
+	if (app->async_coord.pending_prealloc_w > 0) {
+		app->scene.recycled_hdr_tex =
+		    texture_preallocate_hdr(app->async_coord.pending_prealloc_w,
+		                            app->async_coord.pending_prealloc_h,
+		                            app->scene.recycled_hdr_tex);
+		app->async_coord.pending_prealloc_w = 0;
+		app->async_coord.pending_prealloc_h = 0;
 	}
 
-	AsyncRequest req;
-	if (async_loader_poll(app->async_loader, &req)) {
-		if (req.state == ASYNC_WAITING_FOR_PBO) {
-			/* Step 1: Main thread provides mapped PBO */
-			/* Use ping-pong index to avoid stalling on previous
-			 * frame's upload */
-			int pbo_idx = app->upload_pbo_idx;
-			size_t size = (size_t)req.width * (size_t)req.height *
-			              4 * sizeof(uint16_t);
-#ifdef TRACY_ENABLE
-			TracyCZoneN(pbo_ctx, "PBO Setup & Map", 1);
-#endif
-			texture_ensure_pbo(&app->upload_pbo[pbo_idx],
-			                   &app->upload_pbo_size[pbo_idx],
-			                   (GLsizeiptr)size);
-			void* ptr =
-			    texture_map_pbo(app->upload_pbo[pbo_idx], size);
-#ifdef TRACY_ENABLE
-			TracyCZoneEnd(pbo_ctx);
-#endif
-			if (ptr) {
-				async_loader_provide_pbo(
-				    app->async_loader, ptr,
-				    app->upload_pbo[pbo_idx]);
-				/* Advance index for next request */
-				app->upload_pbo_idx =
-				    (app->upload_pbo_idx + 1) % 2;
-
-				/* Schedule deferred pre-allocation for
-				 * NEXT frame. This spreads glTexStorage2D
-				 * cost away from PBO setup.
-				 */
-				app->pending_prealloc_w = req.width;
-				app->pending_prealloc_h = req.height;
-			} else {
-				LOG_ERROR("suckless-ogl.app",
-				          "Failed to map PBO for async upload");
-				async_loader_cancel(app->async_loader);
-			}
-		} else if (req.state == ASYNC_READY) {
-			/* Step 2: Begin multi-frame finalize process */
-			app->env_mgr.current_env_req = req;
-			app->env_mgr.env_map_loading_step = 1;
-		}
+	AsyncRequest ready_req;
+	if (async_coordinator_update(&app->async_coord, app->async_loader,
+	                             &ready_req)) {
+		/* Step 2: Begin multi-frame finalize process */
+		app->env_mgr.current_env_req = ready_req;
+		app->env_mgr.env_map_loading_step = 1;
 	}
 
 	if (app->env_mgr.env_map_loading_step > 0) {

--- a/src/async_coordinator.c
+++ b/src/async_coordinator.c
@@ -1,0 +1,84 @@
+#include "async/async_coordinator.h"
+
+#include "gl_common.h"
+#include "log.h"
+#include "texture.h"
+
+#ifdef TRACY_ENABLE
+#include "../deps/tracy/public/tracy/TracyC.h"
+#endif
+
+void async_coordinator_init(AsyncCoordinator* coord)
+{
+	if (!coord) {
+		return;
+	}
+	glGenBuffers(2, coord->upload_pbo);
+	coord->upload_pbo_idx = 0;
+	coord->upload_pbo_size[0] = 0;
+	coord->upload_pbo_size[1] = 0;
+	coord->pending_prealloc_w = 0;
+	coord->pending_prealloc_h = 0;
+}
+
+void async_coordinator_cleanup(AsyncCoordinator* coord)
+{
+	if (!coord) {
+		return;
+	}
+	GL_SAFE_DELETE_BUFFERS(2, coord->upload_pbo);
+}
+
+bool async_coordinator_update(AsyncCoordinator* coord, AsyncLoader* loader,
+                              AsyncRequest* out_req)
+{
+	if (!coord || !loader || !out_req) {
+		return false;
+	}
+
+	bool result = false;
+	AsyncRequest req;
+	if (async_loader_poll(loader, &req)) {
+		if (req.state == ASYNC_WAITING_FOR_PBO) {
+			/* Step 1: Main thread provides mapped PBO */
+			/* Use ping-pong index to avoid stalling on previous
+			 * frame's upload */
+			int pbo_idx = coord->upload_pbo_idx;
+			size_t size = (size_t)req.width * (size_t)req.height *
+			              4 * sizeof(uint16_t);
+#ifdef TRACY_ENABLE
+			TracyCZoneN(pbo_ctx, "PBO Setup & Map", 1);
+#endif
+			texture_ensure_pbo(&coord->upload_pbo[pbo_idx],
+			                   &coord->upload_pbo_size[pbo_idx],
+			                   (GLsizeiptr)size);
+			void* ptr =
+			    texture_map_pbo(coord->upload_pbo[pbo_idx], size);
+#ifdef TRACY_ENABLE
+			TracyCZoneEnd(pbo_ctx);
+#endif
+			if (ptr) {
+				async_loader_provide_pbo(
+				    loader, ptr, coord->upload_pbo[pbo_idx]);
+				/* Advance index for next request */
+				coord->upload_pbo_idx =
+				    (coord->upload_pbo_idx + 1) % 2;
+
+				/* Let caller know that we expect a
+				 * pre-allocation cost in the near future */
+				coord->pending_prealloc_w = req.width;
+				coord->pending_prealloc_h = req.height;
+			} else {
+				LOG_ERROR("suckless-ogl.async",
+				          "Failed to map PBO for async upload");
+				async_loader_cancel(loader);
+			}
+		} else if (req.state == ASYNC_READY) {
+			/* Request is fully ready to be processed */
+			*out_req = req;
+			result = true;
+		}
+	}
+
+	return result;
+}

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -211,8 +211,10 @@ static void destroy_framebuffer(PostProcess* post_processing)
 	/* Bridge Unit 0 with dummy to avoid invalid state warnings during
 	 * resize
 	 */
-	render_utils_bind_texture_safe(GL_TEXTURE0, 0,
-	                               post_processing->dummy_black_tex);
+	if (post_processing->dummy_black_tex) {
+		render_utils_bind_texture_safe(
+		    GL_TEXTURE0, 0, post_processing->dummy_black_tex);
+	}
 }
 
 static void destroy_screen_quad(PostProcess* post_processing)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_sphere_sorting\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_benchmark_sphere_sorting_perf\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_sh_precision\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_sh_integration\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_coordinator\\.c$")
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
 set(OPENGL_TESTS
@@ -501,3 +502,21 @@ target_include_directories(test_sh_integration PRIVATE
 )
 target_link_libraries(test_sh_integration PRIVATE cglm m pthread)
 add_test(NAME test_sh_integration COMMAND test_sh_integration)
+
+# =============================================================================
+# ASYNC COORDINATOR TEST (MOCKED)
+# =============================================================================
+add_executable(test_async_coordinator
+    test_async_coordinator.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/src/async_coordinator.c
+)
+target_include_directories(test_async_coordinator PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${unity_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/_deps/glad-build/include
+)
+target_link_libraries(test_async_coordinator PRIVATE cglm m)
+add_test(NAME test_async_coordinator COMMAND test_async_coordinator)

--- a/tests/test_async_coordinator.c
+++ b/tests/test_async_coordinator.c
@@ -1,0 +1,204 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Include GLAD and Log headers from the project */
+#include "async/async_coordinator.h"
+#include "glad/glad.h"
+#include "log.h"
+#include "unity.h"
+
+/* --- Mock GLAD Function Pointers --- */
+/* src/async_coordinator.c uses glGenBuffers and glDeleteBuffers.
+   GLAD defines these as macros: #define glGenBuffers glad_glGenBuffers
+   So we need to provide the actual glad_... function pointers.
+*/
+
+static void mock_glGenBuffers(GLsizei n, GLuint* buffers)
+{
+	(void)n;
+	if (buffers)
+		*buffers = 100; /* Default mock ID */
+}
+
+static void mock_glDeleteBuffers(GLsizei n, const GLuint* buffers)
+{
+	(void)n;
+	(void)buffers;
+}
+
+/* Define the glad pointers that the linker is looking for */
+PFNGLGENBUFFERSPROC glad_glGenBuffers = mock_glGenBuffers;
+PFNGLDELETESYNCPROC glad_glDeleteSync =
+    NULL; /* Not used in coordinator yet but might be in headers */
+PFNGLDELETEBUFFERSPROC glad_glDeleteBuffers = mock_glDeleteBuffers;
+
+/* --- Mock Log --- */
+void log_message(LogLevel level, const char* tag, const char* format, ...)
+{
+	(void)level;
+	(void)tag;
+	(void)format;
+}
+
+/* --- Mock AsyncLoader --- */
+typedef struct AsyncLoader {
+	AsyncRequest current_req;
+	bool has_req;
+	bool pbo_provided;
+	void* provided_ptr;
+	GLuint provided_pbo;
+	bool cancelled;
+} AsyncLoader;
+
+AsyncLoader* async_loader_create(struct TracyManager* mgr)
+{
+	(void)mgr;
+	AsyncLoader* loader = calloc(1, sizeof(AsyncLoader));
+	return loader;
+}
+
+void async_loader_destroy(AsyncLoader* loader)
+{
+	free(loader);
+}
+
+bool async_loader_poll(AsyncLoader* loader, AsyncRequest* out_req)
+{
+	if (loader->has_req) {
+		*out_req = loader->current_req;
+		loader->has_req = false;
+		return true;
+	}
+	return false;
+}
+
+void async_loader_provide_pbo(AsyncLoader* loader, void* mapped_ptr,
+                              GLuint pbo_id)
+{
+	loader->pbo_provided = true;
+	loader->provided_ptr = mapped_ptr;
+	loader->provided_pbo = pbo_id;
+}
+
+void async_loader_cancel(AsyncLoader* loader)
+{
+	loader->cancelled = true;
+}
+
+/* --- Mock Texture Utils --- */
+void texture_ensure_pbo(GLuint* pbo, GLsizeiptr* current_size,
+                        GLsizeiptr required_size)
+{
+	(void)pbo;
+	*current_size = required_size;
+}
+
+void* texture_map_pbo(GLuint pbo, size_t size)
+{
+	(void)pbo;
+	(void)size;
+	static char dummy_buffer[1024];
+	if (pbo == 666)
+		return NULL; /* Simulate failure */
+	return dummy_buffer;
+}
+
+/* --- Unity Tests --- */
+void setUp(void)
+{
+}
+void tearDown(void)
+{
+}
+
+void test_AsyncCoordinator_Init_ShouldSetDefaults(void)
+{
+	AsyncCoordinator coord;
+	async_coordinator_init(&coord);
+
+	TEST_ASSERT_EQUAL_INT(0, coord.upload_pbo_idx);
+	TEST_ASSERT_EQUAL_INT(0, coord.pending_prealloc_w);
+	/* mock_glGenBuffers returns 100 */
+	TEST_ASSERT_EQUAL_UINT(100, coord.upload_pbo[0]);
+}
+
+void test_AsyncCoordinator_Update_ShouldHandlePBORequest(void)
+{
+	AsyncCoordinator coord = {0};
+	AsyncLoader* loader = async_loader_create(NULL);
+	AsyncRequest out_req = {0};
+
+	coord.upload_pbo[0] = 101;
+	coord.upload_pbo[1] = 102;
+	coord.upload_pbo_idx = 0;
+
+	loader->has_req = true;
+	loader->current_req.state = ASYNC_WAITING_FOR_PBO;
+	loader->current_req.width = 128;
+	loader->current_req.height = 128;
+
+	bool ready = async_coordinator_update(&coord, loader, &out_req);
+
+	TEST_ASSERT_FALSE(ready);
+	TEST_ASSERT_TRUE(loader->pbo_provided);
+	TEST_ASSERT_EQUAL_UINT(101, loader->provided_pbo);
+	TEST_ASSERT_EQUAL_INT(128, coord.pending_prealloc_w);
+	TEST_ASSERT_EQUAL_INT(1, coord.upload_pbo_idx);
+
+	async_loader_destroy(loader);
+}
+
+void test_AsyncCoordinator_Update_ShouldHandleReadyRequest(void)
+{
+	AsyncCoordinator coord = {0};
+	AsyncLoader* loader = async_loader_create(NULL);
+	AsyncRequest out_req = {0};
+
+	loader->has_req = true;
+	loader->current_req.state = ASYNC_READY;
+	loader->current_req.width = 256;
+	strcpy(loader->current_req.path, "test.hdr");
+
+	bool ready = async_coordinator_update(&coord, loader, &out_req);
+
+	TEST_ASSERT_TRUE(ready);
+	TEST_ASSERT_EQUAL_INT(256, out_req.width);
+	TEST_ASSERT_EQUAL_STRING("test.hdr", out_req.path);
+
+	async_loader_destroy(loader);
+}
+
+void test_AsyncCoordinator_Update_ShouldHandleMapFailure(void)
+{
+	AsyncCoordinator coord = {0};
+	AsyncLoader* loader = async_loader_create(NULL);
+	AsyncRequest out_req = {0};
+
+	coord.upload_pbo[0] = 666; /* Magic ID to trigger mock failure */
+	coord.upload_pbo_idx = 0;
+
+	loader->has_req = true;
+	loader->current_req.state = ASYNC_WAITING_FOR_PBO;
+
+	bool ready = async_coordinator_update(&coord, loader, &out_req);
+
+	TEST_ASSERT_FALSE(ready);
+	TEST_ASSERT_FALSE(loader->pbo_provided);
+	TEST_ASSERT_TRUE(loader->cancelled);
+
+	async_loader_destroy(loader);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_AsyncCoordinator_Init_ShouldSetDefaults);
+	RUN_TEST(test_AsyncCoordinator_Update_ShouldHandlePBORequest);
+	RUN_TEST(test_AsyncCoordinator_Update_ShouldHandleReadyRequest);
+	RUN_TEST(test_AsyncCoordinator_Update_ShouldHandleMapFailure);
+	return UNITY_END();
+}

--- a/tests/test_benchmark_sphere_sorting_perf.c
+++ b/tests/test_benchmark_sphere_sorting_perf.c
@@ -98,10 +98,15 @@ int main(void)
 	SphereInstance* instances_baseline = NULL;
 	SphereInstance* instances_optimized = NULL;
 
-	posix_memalign((void**)&instances_baseline, SIMD_ALIGNMENT,
-	               COUNT * sizeof(SphereInstance));
-	posix_memalign((void**)&instances_optimized, SIMD_ALIGNMENT,
-	               COUNT * sizeof(SphereInstance));
+	if (posix_memalign((void**)&instances_baseline, SIMD_ALIGNMENT,
+	                   COUNT * sizeof(SphereInstance)) != 0) {
+		return 1;
+	}
+	if (posix_memalign((void**)&instances_optimized, SIMD_ALIGNMENT,
+	                   COUNT * sizeof(SphereInstance)) != 0) {
+		free(instances_baseline);
+		return 1;
+	}
 
 	/* Initialize data */
 	for (int i = 0; i < COUNT; ++i) {


### PR DESCRIPTION
## Changes Made

1. **ASan Crash Fix**: `src/postprocess.c` previously crashed during shutdown in `destroy_framebuffer` because it tried to bind `post_processing->dummy_black_tex` even if it was `0`, resulting in an invalid internal state. A null-check resolves this, and `make test-integration-asan` passes natively.
2. **Decoupling `App`**: `src/app.c` had extensive knowledge of internal `AsyncLoader` state machines (like `ASYNC_WAITING_FOR_PBO`) and directly managed dual PBOs for `EnvManager`. I extracted this logic into `AsyncCoordinator` (`src/async_coordinator.c`). It handles PBO mappings internally and returns a clean `AsyncRequest` flag back to `app_update()` to pass on to the environment state machine.
3. **Environment Fixes**: Suppressed linter warnings breaking due to `clang-tidy-18` segfaults by running `clang-tidy-17` locally, matching typical CI results, and fixed unused return values for standard `posix_memalign` usage in benchmarking. 

This continues the trend of eroding the `App` God Object.

---
*PR created automatically by Jules for task [8194892164801983735](https://jules.google.com/task/8194892164801983735) started by @yoyonel*