### PR TITLE
Refactor: decouple exposure and histogram readback buffers from App state

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -72,12 +72,10 @@ typedef struct App {
 	TracyManager tracy_mgr; /**< Tracy instrumentation manager. */
 
 	/* --- Global Configuration Uniforms --- */
-	float u_metallic;       /**< Override metallic for all objects. */
-	float u_roughness;      /**< Override roughness for all objects. */
-	float u_ao;             /**< Override AO for all objects. */
-	float u_exposure;       /**< Manual exposure compensation. */
-	float auto_threshold;   /**< Dynamic exposure target. */
-	float current_exposure; /**< Integrated GPU exposure value. */
+	float u_metallic;  /**< Override metallic for all objects. */
+	float u_roughness; /**< Override roughness for all objects. */
+	float u_ao;        /**< Override AO for all objects. */
+	float u_exposure;  /**< Manual exposure compensation. */
 
 	AsyncLoader* async_loader; /**< Background asset loader context. */
 	AsyncCoordinator

--- a/include/app.h
+++ b/include/app.h
@@ -68,16 +68,8 @@ typedef struct App {
 	int log_gpu_metrics; /**< Toggle console logging of GPU stats. */
 
 	/* --- Global GPU Resources --- */
-	GLuint
-	    exposure_pbo[2]; /**< Pixel Buffer Object for mean luma readback. */
-	GLuint histogram_pbo[2];  /**< Pixel Buffer Object for luminance
-	                             histogram  readback. */
-	GLsync exposure_sync[2];  /**< Sync objects to avoid CPU stalls on
-	                             exposure  readback. */
-	GLsync histogram_sync[2]; /**< Sync objects to avoid CPU stalls on
-	                             histogram readback. */
-	GLuint lum_ssbo[2];       /**< Double-buffered storage for luminance. */
-	TracyManager tracy_mgr;   /**< Tracy instrumentation manager. */
+	GLuint lum_ssbo[2];     /**< Double-buffered storage for luminance. */
+	TracyManager tracy_mgr; /**< Tracy instrumentation manager. */
 
 	/* --- Global Configuration Uniforms --- */
 	float u_metallic;       /**< Override metallic for all objects. */

--- a/include/env_manager.h
+++ b/include/env_manager.h
@@ -80,8 +80,8 @@ int env_manager_trigger_transition(EnvManager* mgr, AsyncLoader* loader,
  * @param height Current window height (for snapshot).
  */
 void env_manager_update_ibl(EnvManager* mgr, Scene* scene,
-                            PostProcess* postproc, float* auto_threshold,
-                            uint64_t frame_count, int width, int height);
+                            PostProcess* postproc, uint64_t frame_count,
+                            int width, int height);
 
 /**
  * @brief Updates the environment transition animation.
@@ -93,8 +93,8 @@ void env_manager_update_ibl(EnvManager* mgr, Scene* scene,
  * @param frame_count Current frame count.
  */
 void env_manager_update_transition(EnvManager* mgr, Scene* scene,
-                                   PostProcess* postproc, float* auto_threshold,
-                                   double delta_time, uint64_t frame_count);
+                                   PostProcess* postproc, double delta_time,
+                                   uint64_t frame_count);
 
 /**
  * @brief Renders the transition overlay (fade/crossfade).

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -377,6 +377,9 @@ typedef struct PostProcess {
 	GLsync histogram_sync[2]; /**< Sync objects to avoid CPU stalls on
 	                             histogram readback. */
 
+	float current_exposure; /**< Cached exposure from GPU readback. */
+	float auto_threshold;   /**< Dynamic exposure target. */
+	uint64_t frame_count; /**< Internal frame counter for readback sync. */
 } PostProcess;
 
 /* --- Lifecycle --- */
@@ -538,5 +541,27 @@ void postprocess_set_exposure_sync(PostProcess* post_processing, int index,
                                    GLsync sync);
 void postprocess_set_histogram_sync(PostProcess* post_processing, int index,
                                     GLsync sync);
+
+/**
+ * @brief Updates all async GPU readbacks (Exposure, Histogram).
+ * Handles PBO mapping and Sync management internally to avoid CPU stalls.
+ */
+void postprocess_update_readbacks(PostProcess* post_processing,
+                                  uint64_t frame_count);
+
+/**
+ * @brief Updates the target exposure threshold for AE.
+ */
+void postprocess_set_exposure_target(PostProcess* post_processing,
+                                     float threshold);
+
+/**
+ * @brief Computes the luminance histogram from the GPU readback.
+ * @return 1 if buckets were updated, 0 otherwise.
+ */
+int postprocess_compute_luminance_histogram(PostProcess* post_processing,
+                                            uint64_t frame_count, int* buckets,
+                                            int size, float* min_lum,
+                                            float* max_lum);
 
 #endif /* POSTPROCESS_H */

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -366,6 +366,17 @@ typedef struct PostProcess {
 
 	GPUProfiler* gpu_profiler;
 	int banding_preset_idx; /**< Internal index for preset cycling. */
+
+	/* --- Exposure Readback --- */
+	GLuint
+	    exposure_pbo[2]; /**< Pixel Buffer Object for mean luma readback. */
+	GLuint histogram_pbo[2];  /**< Pixel Buffer Object for luminance
+	                             histogram  readback. */
+	GLsync exposure_sync[2];  /**< Sync objects to avoid CPU stalls on
+	                             exposure  readback. */
+	GLsync histogram_sync[2]; /**< Sync objects to avoid CPU stalls on
+	                             histogram readback. */
+
 } PostProcess;
 
 /* --- Lifecycle --- */
@@ -518,5 +529,14 @@ void postprocess_end(PostProcess* post_processing);
  * @param delta_time SECONDS elapsed since last frame.
  */
 void postprocess_update_time(PostProcess* post_processing, float delta_time);
+
+GLuint postprocess_get_exposure_pbo(PostProcess* post_processing, int index);
+GLuint postprocess_get_histogram_pbo(PostProcess* post_processing, int index);
+GLsync postprocess_get_exposure_sync(PostProcess* post_processing, int index);
+GLsync postprocess_get_histogram_sync(PostProcess* post_processing, int index);
+void postprocess_set_exposure_sync(PostProcess* post_processing, int index,
+                                   GLsync sync);
+void postprocess_set_histogram_sync(PostProcess* post_processing, int index,
+                                    GLsync sync);
 
 #endif /* POSTPROCESS_H */

--- a/include/postprocess_input.h
+++ b/include/postprocess_input.h
@@ -17,8 +17,7 @@ typedef struct {
 	PostProcess* postprocess; /**< The post-processing pipeline state. */
 	ActionNotifier* notifier; /**< System for user feedback messages. */
 	EffectBenchmark* effect_bench; /**< Benchmarking tool state. */
-	float auto_threshold; /**< Current auto-exposure target value. */
-	GLFWwindow* window;   /**< Window handle for modifier checks. */
+	GLFWwindow* window; /**< Window handle for modifier checks. */
 } PostProcessInputContext;
 
 /**

--- a/src/app.c
+++ b/src/app.c
@@ -77,8 +77,6 @@ int app_init(App* app, int width, int height, const char* title)
 	app->env_mgr.env_transition_mode = DEFAULT_ENV_TRANSITION_MODE;
 	app->env_mgr.is_first_load = 1;
 
-	app->current_exposure = 1.0F;
-
 	async_coordinator_init(&app->async_coord);
 
 	app->lum_histogram_buffer =
@@ -132,7 +130,8 @@ int app_init(App* app, int width, int height, const char* title)
 	}
 	postprocess_set_dummy_textures(&app->postprocess,
 	                               app->scene.dummy_black_tex);
-	postprocess_set_exposure(&app->postprocess, app->auto_threshold);
+	postprocess_set_exposure(&app->postprocess,
+	                         app->postprocess.auto_threshold);
 	postprocess_enable(&app->postprocess, POSTFX_FXAA);
 
 #ifdef ENABLE_SHADER_OPTIMIZATION
@@ -318,9 +317,8 @@ void app_update(App* app)
 	}
 
 	env_manager_update_ibl(&app->env_mgr, &app->scene, &app->postprocess,
-	                       &app->auto_threshold, app->frame_count,
-	                       app->width, app->height);
+	                       app->frame_count, app->width, app->height);
 	env_manager_update_transition(&app->env_mgr, &app->scene,
-	                              &app->postprocess, &app->auto_threshold,
-	                              app->delta_time, app->frame_count);
+	                              &app->postprocess, app->delta_time,
+	                              app->frame_count);
 }

--- a/src/app.c
+++ b/src/app.c
@@ -65,25 +65,6 @@ int app_init(App* app, int width, int height, const char* title)
 		                 GLFW_CURSOR_DISABLED);
 	}
 
-	/* Initialize Exposure PBOs */
-	glGenBuffers(2, app->exposure_pbo);
-	for (int i = 0; i < 2; i++) {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, app->exposure_pbo[i]);
-		glBufferData(GL_PIXEL_PACK_BUFFER, sizeof(float), NULL,
-		             GL_STREAM_READ);
-		app->exposure_sync[i] = NULL;
-	}
-
-	/* Initialize Histogram PBOs (64x64 floats) */
-	glGenBuffers(2, app->histogram_pbo);
-	for (int i = 0; i < 2; i++) {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, app->histogram_pbo[i]);
-		glBufferData(GL_PIXEL_PACK_BUFFER,
-		             (GLsizeiptr)(LUM_HISTOGRAM_SIZE * sizeof(float)),
-		             NULL, GL_STREAM_READ);
-		app->histogram_sync[i] = NULL;
-	}
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 	/* Initialize Tracy Manager */
 	tracy_manager_init(&app->tracy_mgr, width, height);
 
@@ -189,18 +170,6 @@ void app_cleanup(App* app)
 	scene_cleanup(&app->scene);
 
 	/* 3. Common low-level resources */
-	for (int i = 0; i < 2; i++) {
-		GL_SAFE_DELETE_BUFFER(app->exposure_pbo[i]);
-		GL_SAFE_DELETE_BUFFER(app->histogram_pbo[i]);
-		if (app->exposure_sync[i]) {
-			glDeleteSync(app->exposure_sync[i]);
-			app->exposure_sync[i] = NULL;
-		}
-		if (app->histogram_sync[i]) {
-			glDeleteSync(app->histogram_sync[i]);
-			app->histogram_sync[i] = NULL;
-		}
-	}
 
 	async_coordinator_cleanup(&app->async_coord);
 

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -472,7 +472,6 @@ void handle_app_input(App* app, int key, int mods)
 	PostProcessInputContext pp_ctx = {.postprocess = &app->postprocess,
 	                                  .notifier = &app->notifier,
 	                                  .effect_bench = &app->effect_bench,
-	                                  .auto_threshold = app->auto_threshold,
 	                                  .window = app->window};
 	postprocess_input_handle_key(&pp_ctx, key, mods);
 }

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -6,29 +6,15 @@
 #include "app_settings.h"
 #include "glad/glad.h"
 #include "postprocess.h"
-#include "profiler.h"
-#include "render_utils.h"
 #include "ui.h"
 #include "utils.h"
 #include <GLFW/glfw3.h>
-#include <cglm/types.h>
-#include <cglm/vec3.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 /* --- Forward Declarations (Internal) --- */
-static void draw_exposure_debug_text(App* app);
-static void process_histogram_data(int* buckets, int size, float* min_lum,
-                                   float* max_lum, const float* lum_data);
-static int handle_histogram_readback(App* app, int* buckets, int size,
-                                     float* min_lum, float* max_lum);
-static void draw_luminance_histogram_graph(App* app, const int* buckets,
-                                           int size, float min_lum,
-                                           float max_lum);
 static void draw_main_info_overlay(App* app, UILayout* layout);
-static void handle_exposure_readback(App* app);
-static void trigger_exposure_readback(App* app);
 static void draw_exposure_overlay(App* app, UILayout* layout);
 static void draw_loading_indicator(App* app);
 
@@ -126,13 +112,7 @@ void app_draw_help_overlay(App* app)
 
 static void draw_exposure_debug_text(App* app)
 {
-	float exposure_val = 0.0F;
-	PROFILE_ZONE(ctx, "AE Sync Readback (glGetTexImage)");
-	glBindTexture(GL_TEXTURE_2D,
-	              app->postprocess.auto_exposure_fx.exposure_tex);
-	glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, &exposure_val);
-	glBindTexture(GL_TEXTURE_2D, 0);
-	PROFILE_ZONE_END(ctx);
+	float exposure_val = postprocess_get_exposure(&app->postprocess);
 
 	char debug_text[DEBUG_TEXT_BUFFER_SIZE];
 	float luminance =
@@ -147,100 +127,7 @@ static void draw_exposure_debug_text(App* app)
 	             (float*)DEBUG_ORANGE_COLOR, app->width, app->height);
 }
 
-static void process_histogram_data(int* buckets, int size, float* min_lum,
-                                   float* max_lum, const float* lum_data)
-{
-	for (int i = 0; i < LUM_HISTOGRAM_SIZE; i++) {
-		float val = lum_data[i];
-		if (val < *min_lum) {
-			*min_lum = val;
-		}
-		if (val > *max_lum) {
-			*max_lum = val;
-		}
-
-		static const float RANGE_OFFSET = 5.0F;
-		static const float RANGE_SCALE = 10.0F;
-		float norm = (val + RANGE_OFFSET) / RANGE_SCALE;
-		int idx = (int)(norm * (float)size);
-		if (idx < 0) {
-			idx = 0;
-		}
-		if (idx >= size) {
-			idx = size - 1;
-		}
-
-		buckets[idx]++;
-	}
-}
-
-static int handle_histogram_readback(App* app, int* buckets, int size,
-                                     float* min_lum, float* max_lum)
-{
-	int read_idx = (int)(app->frame_count % 2);
-	GLsync current_sync =
-	    postprocess_get_histogram_sync(&app->postprocess, read_idx);
-	if (!current_sync) {
-		return 0;
-	}
-
-	GLenum res = glClientWaitSync(current_sync, 0, 0);
-	if (res != GL_ALREADY_SIGNALED && res != GL_CONDITION_SATISFIED) {
-		return 0;
-	}
-
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_histogram_pbo(
-	                                       &app->postprocess, read_idx));
-	float* lum_data =
-	    (float*)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
-
-	int processed = 0;
-	if (lum_data) {
-		PROFILE_ZONE(ctx, "Histogram Process");
-		process_histogram_data(buckets, size, min_lum, max_lum,
-		                       lum_data);
-		glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
-		PROFILE_ZONE_END(ctx);
-		processed = 1;
-	}
-
-	glDeleteSync(current_sync);
-	postprocess_set_histogram_sync(&app->postprocess, read_idx, NULL);
-	return processed;
-}
-
-int compute_luminance_histogram(App* app, int* buckets, int size,
-                                float* min_lum, float* max_lum)
-{
-	/* Initialize buckets */
-	for (int i = 0; i < size; i++) {
-		buckets[i] = 0;
-	}
-
-	static const float HISTO_MIN_INIT = 1000.0F;
-	static const float HISTO_MAX_INIT = -1000.0F;
-	*min_lum = HISTO_MIN_INIT;
-	*max_lum = HISTO_MAX_INIT;
-
-	int processed =
-	    handle_histogram_readback(app, buckets, size, min_lum, max_lum);
-
-	/* Trigger Async Transfer (For Next Frame) */
-	int write_idx = (int)((app->frame_count + 1) % 2);
-	glBindTexture(GL_TEXTURE_2D,
-	              app->postprocess.auto_exposure_fx.downsample_tex);
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_histogram_pbo(
-	                                       &app->postprocess, write_idx));
-	glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
-	postprocess_set_histogram_sync(
-	    &app->postprocess, write_idx,
-	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0));
-
-	glBindTexture(GL_TEXTURE_2D, 0);
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
-
-	return processed;
-}
+/* All histogram logic moved to PostProcess */
 
 static void draw_luminance_histogram_graph(App* app, const int* buckets,
                                            int size, float min_lum,
@@ -308,8 +195,9 @@ void app_draw_debug_overlay(App* app)
 		float min_lum = 0.0F;
 		float max_lum = 0.0F;
 
-		if (compute_luminance_histogram(app, buckets, HISTO_SIZE,
-		                                &min_lum, &max_lum) != 0) {
+		if (postprocess_compute_luminance_histogram(
+		        &app->postprocess, app->frame_count, buckets,
+		        HISTO_SIZE, &min_lum, &max_lum) != 0) {
 			draw_luminance_histogram_graph(app, buckets, HISTO_SIZE,
 			                               min_lum, max_lum);
 		}
@@ -366,47 +254,7 @@ static void draw_main_info_overlay(App* app, UILayout* layout)
 	}
 }
 
-static void handle_exposure_readback(App* app)
-{
-	int read_idx = (int)(app->frame_count % 2);
-	GLsync current_sync =
-	    postprocess_get_exposure_sync(&app->postprocess, read_idx);
-	if (!current_sync) {
-		return;
-	}
-
-	GLenum res = glClientWaitSync(current_sync, 0, 0);
-	if (res == GL_ALREADY_SIGNALED || res == GL_CONDITION_SATISFIED) {
-		glBindBuffer(
-		    GL_PIXEL_PACK_BUFFER,
-		    postprocess_get_exposure_pbo(&app->postprocess, read_idx));
-		float* ptr =
-		    (float*)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
-		if (ptr) {
-			app->current_exposure = *ptr;
-			glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
-		}
-		glDeleteSync(current_sync);
-		postprocess_set_exposure_sync(&app->postprocess, read_idx,
-		                              NULL);
-	}
-}
-
-static void trigger_exposure_readback(App* app)
-{
-	int write_idx = (int)((app->frame_count + 1) % 2);
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_exposure_pbo(
-	                                       &app->postprocess, write_idx));
-	glBindTexture(GL_TEXTURE_2D,
-	              app->postprocess.auto_exposure_fx.exposure_tex);
-	glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
-	postprocess_set_exposure_sync(
-	    &app->postprocess, write_idx,
-	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0));
-
-	glBindTexture(GL_TEXTURE_2D, 0);
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
-}
+/* Readbacks now handled in PostProcess */
 
 static void draw_exposure_overlay(App* app, UILayout* layout)
 {
@@ -414,14 +262,7 @@ static void draw_exposure_overlay(App* app, UILayout* layout)
 		return;
 	}
 
-	float exposure_val = 0.0F;
-	if (postprocess_is_enabled(&app->postprocess, POSTFX_AUTO_EXPOSURE)) {
-		handle_exposure_readback(app);
-		trigger_exposure_readback(app);
-		exposure_val = app->current_exposure;
-	} else {
-		exposure_val = app->postprocess.exposure.exposure;
-	}
+	float exposure_val = postprocess_get_exposure(&app->postprocess);
 
 	char exposure_text[EXPOSURE_TEXT_BUFFER_SIZE];
 	(void)safe_snprintf(exposure_text, sizeof(exposure_text),

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -178,16 +178,19 @@ static int handle_histogram_readback(App* app, int* buckets, int size,
                                      float* min_lum, float* max_lum)
 {
 	int read_idx = (int)(app->frame_count % 2);
-	if (!app->histogram_sync[read_idx]) {
+	GLsync current_sync =
+	    postprocess_get_histogram_sync(&app->postprocess, read_idx);
+	if (!current_sync) {
 		return 0;
 	}
 
-	GLenum res = glClientWaitSync(app->histogram_sync[read_idx], 0, 0);
+	GLenum res = glClientWaitSync(current_sync, 0, 0);
 	if (res != GL_ALREADY_SIGNALED && res != GL_CONDITION_SATISFIED) {
 		return 0;
 	}
 
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, app->histogram_pbo[read_idx]);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_histogram_pbo(
+	                                       &app->postprocess, read_idx));
 	float* lum_data =
 	    (float*)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
 
@@ -201,8 +204,8 @@ static int handle_histogram_readback(App* app, int* buckets, int size,
 		processed = 1;
 	}
 
-	glDeleteSync(app->histogram_sync[read_idx]);
-	app->histogram_sync[read_idx] = NULL;
+	glDeleteSync(current_sync);
+	postprocess_set_histogram_sync(&app->postprocess, read_idx, NULL);
 	return processed;
 }
 
@@ -226,10 +229,12 @@ int compute_luminance_histogram(App* app, int* buckets, int size,
 	int write_idx = (int)((app->frame_count + 1) % 2);
 	glBindTexture(GL_TEXTURE_2D,
 	              app->postprocess.auto_exposure_fx.downsample_tex);
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, app->histogram_pbo[write_idx]);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_histogram_pbo(
+	                                       &app->postprocess, write_idx));
 	glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
-	app->histogram_sync[write_idx] =
-	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	postprocess_set_histogram_sync(
+	    &app->postprocess, write_idx,
+	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0));
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
@@ -364,33 +369,40 @@ static void draw_main_info_overlay(App* app, UILayout* layout)
 static void handle_exposure_readback(App* app)
 {
 	int read_idx = (int)(app->frame_count % 2);
-	if (!app->exposure_sync[read_idx]) {
+	GLsync current_sync =
+	    postprocess_get_exposure_sync(&app->postprocess, read_idx);
+	if (!current_sync) {
 		return;
 	}
 
-	GLenum res = glClientWaitSync(app->exposure_sync[read_idx], 0, 0);
+	GLenum res = glClientWaitSync(current_sync, 0, 0);
 	if (res == GL_ALREADY_SIGNALED || res == GL_CONDITION_SATISFIED) {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, app->exposure_pbo[read_idx]);
+		glBindBuffer(
+		    GL_PIXEL_PACK_BUFFER,
+		    postprocess_get_exposure_pbo(&app->postprocess, read_idx));
 		float* ptr =
 		    (float*)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
 		if (ptr) {
 			app->current_exposure = *ptr;
 			glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
 		}
-		glDeleteSync(app->exposure_sync[read_idx]);
-		app->exposure_sync[read_idx] = NULL;
+		glDeleteSync(current_sync);
+		postprocess_set_exposure_sync(&app->postprocess, read_idx,
+		                              NULL);
 	}
 }
 
 static void trigger_exposure_readback(App* app)
 {
 	int write_idx = (int)((app->frame_count + 1) % 2);
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, app->exposure_pbo[write_idx]);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_exposure_pbo(
+	                                       &app->postprocess, write_idx));
 	glBindTexture(GL_TEXTURE_2D,
 	              app->postprocess.auto_exposure_fx.exposure_tex);
 	glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
-	app->exposure_sync[write_idx] =
-	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	postprocess_set_exposure_sync(
+	    &app->postprocess, write_idx,
+	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0));
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -146,12 +146,10 @@ static void capture_snapshot(Scene* scene, int width, int height)
 }
 
 static void finalize_ibl_swap(Scene* scene, PostProcess* postproc,
-                              float* auto_threshold, GLuint hdr_tex,
-                              GLuint spec_tex, GLuint irr_tex, float threshold,
-                              uint64_t frame_count)
+                              GLuint hdr_tex, GLuint spec_tex, GLuint irr_tex,
+                              float threshold, uint64_t frame_count)
 {
-	postprocess_set_exposure(postproc, threshold);
-	*auto_threshold = threshold;
+	postprocess_set_exposure_target(postproc, threshold);
 
 	/* Recycle the old HDR texture instead of deleting it */
 	if (scene->hdr_texture) {
@@ -181,7 +179,6 @@ static void finalize_ibl_swap(Scene* scene, PostProcess* postproc,
 
 static void handle_ibl_done_wait_state(EnvManager* mgr, Scene* scene,
                                        PostProcess* postproc,
-                                       float* auto_threshold,
                                        uint64_t frame_count)
 {
 	GLuint hdr_tex = 0;
@@ -191,8 +188,8 @@ static void handle_ibl_done_wait_state(EnvManager* mgr, Scene* scene,
 
 	if (ibl_coordinator_get_results(&scene->ibl_coord, &hdr_tex, &spec_tex,
 	                                &irr_tex, &threshold)) {
-		finalize_ibl_swap(scene, postproc, auto_threshold, hdr_tex,
-		                  spec_tex, irr_tex, threshold, frame_count);
+		finalize_ibl_swap(scene, postproc, hdr_tex, spec_tex, irr_tex,
+		                  threshold, frame_count);
 		mgr->transition_state = TRANSITION_FADE_IN;
 		mgr->transition_alpha = 1.0F;
 	}
@@ -200,7 +197,6 @@ static void handle_ibl_done_wait_state(EnvManager* mgr, Scene* scene,
 
 static void handle_ibl_done_loading_state(EnvManager* mgr, Scene* scene,
                                           PostProcess* postproc,
-                                          float* auto_threshold,
                                           uint64_t frame_count, int width,
                                           int height)
 {
@@ -220,9 +216,8 @@ static void handle_ibl_done_loading_state(EnvManager* mgr, Scene* scene,
 		                                &spec_tex, &irr_tex,
 		                                &threshold)) {
 			capture_snapshot(scene, width, height);
-			finalize_ibl_swap(scene, postproc, auto_threshold,
-			                  hdr_tex, spec_tex, irr_tex, threshold,
-			                  frame_count);
+			finalize_ibl_swap(scene, postproc, hdr_tex, spec_tex,
+			                  irr_tex, threshold, frame_count);
 			mgr->transition_state = TRANSITION_FADE_IN;
 			mgr->transition_alpha = 1.0F;
 		}
@@ -230,26 +225,25 @@ static void handle_ibl_done_loading_state(EnvManager* mgr, Scene* scene,
 }
 
 void env_manager_update_ibl(EnvManager* mgr, Scene* scene,
-                            PostProcess* postproc, float* auto_threshold,
-                            uint64_t frame_count, int width, int height)
+                            PostProcess* postproc, uint64_t frame_count,
+                            int width, int height)
 {
 	IBLState state = ibl_coordinator_update(&scene->ibl_coord, frame_count);
 
 	if (state == IBL_STATE_DONE) {
 		if (mgr->transition_state == TRANSITION_WAIT_IBL) {
 			handle_ibl_done_wait_state(mgr, scene, postproc,
-			                           auto_threshold, frame_count);
+			                           frame_count);
 		} else if (mgr->transition_state == TRANSITION_LOADING) {
 			handle_ibl_done_loading_state(
-			    mgr, scene, postproc, auto_threshold, frame_count,
-			    width, height);
+			    mgr, scene, postproc, frame_count, width, height);
 		}
 	}
 }
 
 void env_manager_update_transition(EnvManager* mgr, Scene* scene,
-                                   PostProcess* postproc, float* auto_threshold,
-                                   double delta_time, uint64_t frame_count)
+                                   PostProcess* postproc, double delta_time,
+                                   uint64_t frame_count)
 {
 	switch (mgr->transition_state) {
 		case TRANSITION_IDLE:
@@ -273,9 +267,9 @@ void env_manager_update_transition(EnvManager* mgr, Scene* scene,
 			if (ibl_coordinator_get_results(&scene->ibl_coord,
 			                                &hdr_tex, &spec_tex,
 			                                &irr_tex, &threshold)) {
-				finalize_ibl_swap(
-				    scene, postproc, auto_threshold, hdr_tex,
-				    spec_tex, irr_tex, threshold, frame_count);
+				finalize_ibl_swap(scene, postproc, hdr_tex,
+				                  spec_tex, irr_tex, threshold,
+				                  frame_count);
 				mgr->transition_state = TRANSITION_FADE_IN;
 			}
 			break;

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -114,6 +114,28 @@ int postprocess_init(PostProcess* post_processing,
 	post_processing->fxaa.edge_threshold_min =
 	    DEFAULT_FXAA_EDGE_THRESHOLD_MIN;
 
+	/* Initialize Exposure PBOs */
+	glGenBuffers(2, post_processing->exposure_pbo);
+	for (int i = 0; i < 2; i++) {
+		glBindBuffer(GL_PIXEL_PACK_BUFFER,
+		             post_processing->exposure_pbo[i]);
+		glBufferData(GL_PIXEL_PACK_BUFFER, sizeof(float), NULL,
+		             GL_STREAM_READ);
+		post_processing->exposure_sync[i] = NULL;
+	}
+
+	/* Initialize Histogram PBOs (64x64 floats) */
+	glGenBuffers(2, post_processing->histogram_pbo);
+	for (int i = 0; i < 2; i++) {
+		glBindBuffer(GL_PIXEL_PACK_BUFFER,
+		             post_processing->histogram_pbo[i]);
+		glBufferData(GL_PIXEL_PACK_BUFFER,
+		             (GLsizeiptr)(LUM_HISTOGRAM_SIZE * sizeof(float)),
+		             NULL, GL_STREAM_READ);
+		post_processing->histogram_sync[i] = NULL;
+	}
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
 	/* Initialisation Banding */
 	post_processing->banding.mode = BANDING_MODE_LINEAR;
 	post_processing->banding.levels = DEFAULT_BANDING_LEVELS;
@@ -221,12 +243,43 @@ static void destroy_screen_quad(PostProcess* post_processing)
 	GL_SAFE_DELETE_BUFFER(post_processing->screen_quad_vbo);
 }
 
+static void destroy_readback_buffers(PostProcess* post_processing)
+{
+	for (int i = 0; i < 2; i++) {
+		GL_SAFE_DELETE_BUFFER(post_processing->exposure_pbo[i]);
+		GL_SAFE_DELETE_BUFFER(post_processing->histogram_pbo[i]);
+		if (post_processing->exposure_sync[i]) {
+			glDeleteSync(post_processing->exposure_sync[i]);
+			post_processing->exposure_sync[i] = NULL;
+		}
+		if (post_processing->histogram_sync[i]) {
+			glDeleteSync(post_processing->histogram_sync[i]);
+			post_processing->histogram_sync[i] = NULL;
+		}
+	}
+}
+
+static void destroy_cached_shaders(PostProcess* post_processing)
+{
+	/* Destroy cached shaders */
+	for (int i = 0; i < post_processing->shader_cache_count; i++) {
+		if (post_processing->shader_cache[i].shader) {
+			/* SHADER_SAFE_DESTROY will handle internal program +
+			 * struct free */
+			SHADER_SAFE_DESTROY(
+			    post_processing->shader_cache[i].shader);
+		}
+	}
+	post_processing->shader_cache_count = 0;
+}
+
 void postprocess_cleanup(PostProcess* post_processing)
 {
 	if (!post_processing) {
 		return;
 	}
 
+	destroy_readback_buffers(post_processing);
 	destroy_framebuffer(post_processing);
 	destroy_screen_quad(post_processing);
 
@@ -239,16 +292,7 @@ void postprocess_cleanup(PostProcess* post_processing)
 		post_processing->postprocess_shader = NULL;
 	}
 
-	/* Destroy cached shaders */
-	for (int i = 0; i < post_processing->shader_cache_count; i++) {
-		if (post_processing->shader_cache[i].shader) {
-			/* SHADER_SAFE_DESTROY will handle internal program +
-			 * struct free */
-			SHADER_SAFE_DESTROY(
-			    post_processing->shader_cache[i].shader);
-		}
-	}
-	post_processing->shader_cache_count = 0;
+	destroy_cached_shaders(post_processing);
 
 	/* Destroy postprocess_shader if it wasn't in the cache */
 	SHADER_SAFE_DESTROY(post_processing->postprocess_shader);
@@ -779,6 +823,38 @@ void postprocess_update_time(PostProcess* post_processing, float delta_time)
 	post_processing->time += delta_time;
 	post_processing->delta_time =
 	    delta_time; /* Save dt for compute shader */
+}
+
+GLuint postprocess_get_exposure_pbo(PostProcess* post_processing, int index)
+{
+	return post_processing->exposure_pbo[index];
+}
+
+GLuint postprocess_get_histogram_pbo(PostProcess* post_processing, int index)
+{
+	return post_processing->histogram_pbo[index];
+}
+
+GLsync postprocess_get_exposure_sync(PostProcess* post_processing, int index)
+{
+	return post_processing->exposure_sync[index];
+}
+
+GLsync postprocess_get_histogram_sync(PostProcess* post_processing, int index)
+{
+	return post_processing->histogram_sync[index];
+}
+
+void postprocess_set_exposure_sync(PostProcess* post_processing, int index,
+                                   GLsync sync)
+{
+	post_processing->exposure_sync[index] = sync;
+}
+
+void postprocess_set_histogram_sync(PostProcess* post_processing, int index,
+                                    GLsync sync)
+{
+	post_processing->histogram_sync[index] = sync;
 }
 
 void postprocess_update_matrices(PostProcess* post_processing, mat4 view_proj)

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -100,6 +100,8 @@ int postprocess_init(PostProcess* post_processing,
 	post_processing->auto_exposure.speed_up = EXPOSURE_SPEED_UP;
 	post_processing->auto_exposure.speed_down = EXPOSURE_SPEED_DOWN;
 	post_processing->auto_exposure.key_value = EXPOSURE_DEFAULT_KEY_VALUE;
+	post_processing->current_exposure = 1.0F;
+	post_processing->auto_threshold = 1.0F;
 
 	/* Initialisation Motion Blur */
 	if (!fx_motion_blur_init(post_processing)) {
@@ -472,7 +474,12 @@ void postprocess_set_dof(PostProcess* post_processing, float focal_distance,
 
 float postprocess_get_exposure(PostProcess* post_processing)
 {
-	return fx_auto_exposure_get_current_exposure(post_processing);
+	/* Return the cached value from the last async readback to avoid
+	 * synchronous GPU stalls. If AE is disabled, return manual exposure. */
+	if (postprocess_is_enabled(post_processing, POSTFX_AUTO_EXPOSURE)) {
+		return post_processing->current_exposure;
+	}
+	return post_processing->exposure.exposure;
 }
 
 void postprocess_set_auto_exposure(PostProcess* post_processing,
@@ -618,6 +625,20 @@ void postprocess_end(PostProcess* post_processing)
 		                   "Auto Exposure",
 		                   GPU_PROFILER_AUTO_EXPOSURE_COLOR);
 		fx_auto_exposure_render(post_processing);
+
+		/* Trigger Async Readback for current frame (will be ready in
+		 * next frames) */
+		int write_idx = (int)((post_processing->frame_count + 1) % 2);
+		glBindBuffer(GL_PIXEL_PACK_BUFFER,
+		             post_processing->exposure_pbo[write_idx]);
+		glBindTexture(GL_TEXTURE_2D,
+		              post_processing->auto_exposure_fx.exposure_tex);
+		glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
+		post_processing->exposure_sync[write_idx] =
+		    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+
+		glBindTexture(GL_TEXTURE_2D, 0);
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 	}
 
 	/* Motion Blur Pre-Pass (Compute) - Also needed for debug modes */
@@ -855,6 +876,133 @@ void postprocess_set_histogram_sync(PostProcess* post_processing, int index,
                                     GLsync sync)
 {
 	post_processing->histogram_sync[index] = sync;
+}
+
+void postprocess_update_readbacks(PostProcess* post_processing,
+                                  uint64_t frame_count)
+{
+	post_processing->frame_count = frame_count;
+
+	if (!postprocess_is_enabled(post_processing, POSTFX_AUTO_EXPOSURE)) {
+		return;
+	}
+
+	int read_idx = (int)(frame_count % 2);
+	GLsync current_sync = post_processing->exposure_sync[read_idx];
+
+	if (current_sync) {
+		GLenum res = glClientWaitSync(current_sync, 0, 0);
+		if (res == GL_ALREADY_SIGNALED ||
+		    res == GL_CONDITION_SATISFIED) {
+			glBindBuffer(GL_PIXEL_PACK_BUFFER,
+			             post_processing->exposure_pbo[read_idx]);
+			float* ptr = (float*)glMapBuffer(GL_PIXEL_PACK_BUFFER,
+			                                 GL_READ_ONLY);
+			if (ptr) {
+				post_processing->current_exposure = *ptr;
+				glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+			}
+			glDeleteSync(current_sync);
+			post_processing->exposure_sync[read_idx] = NULL;
+		}
+	}
+}
+
+void postprocess_set_exposure_target(PostProcess* post_processing,
+                                     float threshold)
+{
+	post_processing->auto_threshold = threshold;
+	postprocess_set_exposure(post_processing, threshold);
+}
+
+static void fill_histogram_buckets(const float* lum_data, int* buckets,
+                                   int size, float* min_lum, float* max_lum)
+{
+	for (int i = 0; i < LUM_HISTOGRAM_SIZE; i++) {
+		float val = lum_data[i];
+		if (val < *min_lum) {
+			*min_lum = val;
+		}
+		if (val > *max_lum) {
+			*max_lum = val;
+		}
+
+		static const float RANGE_OFFSET = 5.0F;
+		static const float RANGE_SCALE = 10.0F;
+		float norm = (val + RANGE_OFFSET) / RANGE_SCALE;
+		int idx = (int)(norm * (float)size);
+		if (idx < 0) {
+			idx = 0;
+		}
+		if (idx >= size) {
+			idx = size - 1;
+		}
+		buckets[idx]++;
+	}
+}
+
+static void trigger_histogram_readback(PostProcess* post_processing,
+                                       int write_idx)
+{
+	glBindTexture(GL_TEXTURE_2D,
+	              post_processing->auto_exposure_fx.downsample_tex);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER,
+	             post_processing->histogram_pbo[write_idx]);
+	glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
+	post_processing->histogram_sync[write_idx] =
+	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+}
+
+int postprocess_compute_luminance_histogram(PostProcess* post_processing,
+                                            uint64_t frame_count, int* buckets,
+                                            int size, float* min_lum,
+                                            float* max_lum)
+{
+	/* Initialize buckets */
+	for (int i = 0; i < size; i++) {
+		buckets[i] = 0;
+	}
+
+	static const float HISTO_MIN_INIT = 1000.0F;
+	static const float HISTO_MAX_INIT = -1000.0F;
+	*min_lum = HISTO_MIN_INIT;
+	*max_lum = HISTO_MAX_INIT;
+
+	int read_idx = (int)(frame_count % 2);
+	GLsync current_sync = post_processing->histogram_sync[read_idx];
+
+	int processed = 0;
+	if (current_sync) {
+		GLenum res = glClientWaitSync(current_sync, 0, 0);
+		if (res == GL_ALREADY_SIGNALED ||
+		    res == GL_CONDITION_SATISFIED) {
+			glBindBuffer(GL_PIXEL_PACK_BUFFER,
+			             post_processing->histogram_pbo[read_idx]);
+			float* lum_data = (float*)glMapBuffer(
+			    GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+
+			if (lum_data) {
+				fill_histogram_buckets(lum_data, buckets, size,
+				                       min_lum, max_lum);
+				glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+				processed = 1;
+			}
+
+			glDeleteSync(current_sync);
+			post_processing->histogram_sync[read_idx] = NULL;
+		}
+	}
+
+	/* Trigger Async Transfer for Next Slot if not already pending */
+	int write_idx = (int)((frame_count + 1) % 2);
+	if (!post_processing->histogram_sync[write_idx]) {
+		trigger_histogram_readback(post_processing, write_idx);
+	}
+
+	return processed;
 }
 
 void postprocess_update_matrices(PostProcess* post_processing, mat4 view_proj)

--- a/src/postprocess_input.c
+++ b/src/postprocess_input.c
@@ -62,11 +62,11 @@ static void handle_preset_input(const PostProcessInputContext* ctx, int key)
 		case GLFW_KEY_1: /* Preset: Aucun */
 			postprocess_apply_preset(ctx->postprocess,
 			                         &PRESET_DEFAULT);
-			postprocess_set_exposure(ctx->postprocess,
-			                         ctx->auto_threshold);
+			postprocess_set_exposure(
+			    ctx->postprocess, ctx->postprocess->auto_threshold);
 			LOG_INFO("suckless-ogl.postprocess",
 			         "Style: Aucun (rendu pur) - Exposure: %.2f",
-			         ctx->auto_threshold);
+			         ctx->postprocess->auto_threshold);
 			action_notifier_push(ctx->notifier,
 			                     "Style: Pure Render",
 			                     NOTIF_DUR_LONG);
@@ -174,8 +174,8 @@ static void handle_preset_input(const PostProcessInputContext* ctx, int key)
 		case GLFW_KEY_KP_0:
 			postprocess_apply_preset(ctx->postprocess,
 			                         &PRESET_DEFAULT);
-			postprocess_set_exposure(ctx->postprocess,
-			                         ctx->auto_threshold);
+			postprocess_set_exposure(
+			    ctx->postprocess, ctx->postprocess->auto_threshold);
 			LOG_INFO("suckless-ogl.postprocess",
 			         "Color Grading: Reset to Defaults");
 			action_notifier_push(ctx->notifier,

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -20,6 +20,7 @@ void renderer_draw_frame(struct App* app_ref, Scene* scene,
 	     effect_benchmark_is_running(effect_bench)) != 0;
 	gpu_profiler_set_enabled(profiler, profiling_enabled);
 	gpu_profiler_begin_frame(profiler, frame_count);
+	postprocess_update_readbacks(postprocess, frame_count);
 
 	PROFILE_FRAME_MARK;
 

--- a/tests/test_benchmark_histogram.c
+++ b/tests/test_benchmark_histogram.c
@@ -87,7 +87,9 @@ void test_benchmark_histogram(void)
 	// Initialize PBOs for the test
 	glGenBuffers(2, app.postprocess.histogram_pbo);
 	for (int i = 0; i < 2; i++) {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_histogram_pbo(&app.postprocess, i));
+		glBindBuffer(
+		    GL_PIXEL_PACK_BUFFER,
+		    postprocess_get_histogram_pbo(&app.postprocess, i));
 		glBufferData(GL_PIXEL_PACK_BUFFER,
 		             MAP_SIZE * MAP_SIZE * (GLsizeiptr)sizeof(float),
 		             NULL, GL_STREAM_READ);
@@ -120,10 +122,11 @@ void test_benchmark_histogram(void)
 
 	// Final blocking wait to ensure we have data for verification
 	int last_idx = (int)((ITERATIONS) % 2);
-	GLsync last_sync = postprocess_get_histogram_sync(&app.postprocess, last_idx);
+	GLsync last_sync =
+	    postprocess_get_histogram_sync(&app.postprocess, last_idx);
 	if (last_sync) {
-		glClientWaitSync(last_sync,
-		                 GL_SYNC_FLUSH_COMMANDS_BIT, 1000000000);  // 1s
+		glClientWaitSync(last_sync, GL_SYNC_FLUSH_COMMANDS_BIT,
+		                 1000000000);  // 1s
 	}
 	app.frame_count = (uint64_t)ITERATIONS;
 	compute_luminance_histogram(&app, buckets, HISTO_SIZE, &min_lum,
@@ -140,7 +143,8 @@ void test_benchmark_histogram(void)
 	glDeleteTextures(1, &tex);
 	glDeleteBuffers(2, app.postprocess.histogram_pbo);
 	for (int i = 0; i < 2; i++) {
-		GLsync current_sync = postprocess_get_histogram_sync(&app.postprocess, i);
+		GLsync current_sync =
+		    postprocess_get_histogram_sync(&app.postprocess, i);
 		if (current_sync) {
 			glDeleteSync(current_sync);
 		}

--- a/tests/test_benchmark_histogram.c
+++ b/tests/test_benchmark_histogram.c
@@ -85,13 +85,13 @@ void test_benchmark_histogram(void)
 	app.postprocess.auto_exposure_fx.downsample_tex = tex;
 
 	// Initialize PBOs for the test
-	glGenBuffers(2, app.histogram_pbo);
+	glGenBuffers(2, app.postprocess.histogram_pbo);
 	for (int i = 0; i < 2; i++) {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, app.histogram_pbo[i]);
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, postprocess_get_histogram_pbo(&app.postprocess, i));
 		glBufferData(GL_PIXEL_PACK_BUFFER,
 		             MAP_SIZE * MAP_SIZE * (GLsizeiptr)sizeof(float),
 		             NULL, GL_STREAM_READ);
-		app.histogram_sync[i] = NULL;
+		postprocess_set_histogram_sync(&app.postprocess, i, NULL);
 	}
 	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
@@ -120,8 +120,9 @@ void test_benchmark_histogram(void)
 
 	// Final blocking wait to ensure we have data for verification
 	int last_idx = (int)((ITERATIONS) % 2);
-	if (app.histogram_sync[last_idx]) {
-		glClientWaitSync(app.histogram_sync[last_idx],
+	GLsync last_sync = postprocess_get_histogram_sync(&app.postprocess, last_idx);
+	if (last_sync) {
+		glClientWaitSync(last_sync,
 		                 GL_SYNC_FLUSH_COMMANDS_BIT, 1000000000);  // 1s
 	}
 	app.frame_count = (uint64_t)ITERATIONS;
@@ -137,10 +138,11 @@ void test_benchmark_histogram(void)
 
 	// Cleanup
 	glDeleteTextures(1, &tex);
-	glDeleteBuffers(2, app.histogram_pbo);
+	glDeleteBuffers(2, app.postprocess.histogram_pbo);
 	for (int i = 0; i < 2; i++) {
-		if (app.histogram_sync[i]) {
-			glDeleteSync(app.histogram_sync[i]);
+		GLsync current_sync = postprocess_get_histogram_sync(&app.postprocess, i);
+		if (current_sync) {
+			glDeleteSync(current_sync);
 		}
 	}
 }

--- a/tests/test_benchmark_histogram.c
+++ b/tests/test_benchmark_histogram.c
@@ -103,15 +103,17 @@ void test_benchmark_histogram(void)
 	float max_lum = 0.0F;
 
 	// Warmup
-	compute_luminance_histogram(&app, buckets, HISTO_SIZE, &min_lum,
-	                            &max_lum);
+	postprocess_compute_luminance_histogram(&app.postprocess,
+	                                        app.frame_count, buckets,
+	                                        HISTO_SIZE, &min_lum, &max_lum);
 
 	// Benchmark
 	clock_t start = clock();
 	for (int i = 0; i < ITERATIONS; i++) {
 		app.frame_count = (uint64_t)i;
-		compute_luminance_histogram(&app, buckets, HISTO_SIZE, &min_lum,
-		                            &max_lum);
+		postprocess_compute_luminance_histogram(
+		    &app.postprocess, app.frame_count, buckets, HISTO_SIZE,
+		    &min_lum, &max_lum);
 	}
 	clock_t end = clock();
 	double cpu_time_used =
@@ -129,8 +131,9 @@ void test_benchmark_histogram(void)
 		                 1000000000);  // 1s
 	}
 	app.frame_count = (uint64_t)ITERATIONS;
-	compute_luminance_histogram(&app, buckets, HISTO_SIZE, &min_lum,
-	                            &max_lum);
+	postprocess_compute_luminance_histogram(&app.postprocess,
+	                                        app.frame_count, buckets,
+	                                        HISTO_SIZE, &min_lum, &max_lum);
 
 	// Verify
 	int total_buckets = 0;

--- a/tests/test_env_transition.c
+++ b/tests/test_env_transition.c
@@ -66,8 +66,7 @@ void test_transition_initial_state(void)
 	/* Simulate state machine processing */
 	env_manager_update_ibl(
 	    &g_test_app->env_mgr, &g_test_app->scene, &g_test_app->postprocess,
-	    &g_test_app->auto_threshold, g_test_app->frame_count,
-	    g_test_app->width, g_test_app->height);
+	    g_test_app->frame_count, g_test_app->width, g_test_app->height);
 
 	/* Should move to FADE_IN */
 	TEST_ASSERT_EQUAL(TRANSITION_FADE_IN,
@@ -86,8 +85,7 @@ void test_transition_crossfade_flow(void)
 	/* Simulate state machine processing */
 	env_manager_update_ibl(
 	    &g_test_app->env_mgr, &g_test_app->scene, &g_test_app->postprocess,
-	    &g_test_app->auto_threshold, g_test_app->frame_count,
-	    g_test_app->width, g_test_app->height);
+	    g_test_app->frame_count, g_test_app->width, g_test_app->height);
 
 	/* In Crossfade, Done -> FADE_IN immediately */
 	TEST_ASSERT_EQUAL(TRANSITION_FADE_IN,
@@ -110,8 +108,7 @@ void test_transition_black_screen_flow(void)
 	/* Simulate state machine processing */
 	env_manager_update_ibl(
 	    &g_test_app->env_mgr, &g_test_app->scene, &g_test_app->postprocess,
-	    &g_test_app->auto_threshold, g_test_app->frame_count,
-	    g_test_app->width, g_test_app->height);
+	    g_test_app->frame_count, g_test_app->width, g_test_app->height);
 
 	/* In Black Screen, Done -> FADE_OUT */
 	TEST_ASSERT_EQUAL(TRANSITION_FADE_OUT,
@@ -122,9 +119,9 @@ void test_transition_black_screen_flow(void)
 	static const double FADE_OUT_DURATION_FACTOR = 2.0;
 	g_test_app->delta_time =
 	    (double)TRANSITION_DURATION * FADE_OUT_DURATION_FACTOR;
-	env_manager_update_transition(
-	    &g_test_app->env_mgr, &g_test_app->scene, &g_test_app->postprocess,
-	    &g_test_app->auto_threshold, g_test_app->delta_time, 0);
+	env_manager_update_transition(&g_test_app->env_mgr, &g_test_app->scene,
+	                              &g_test_app->postprocess,
+	                              g_test_app->delta_time, 0);
 
 	/* Should move to FADE_IN after swap */
 	TEST_ASSERT_EQUAL(TRANSITION_FADE_IN,


### PR DESCRIPTION
Extracted [exposure_pbo](src/postprocess.c:848:0-851:1), [histogram_pbo](src/postprocess.c:853:0-856:1), [exposure_sync](src/postprocess.c:858:0-861:1), and [histogram_sync](src/postprocess.c:863:0-866:1) from the monolithic `App` structure into the correctly scoped `PostProcess` module. This significantly reduces the cognitive load of the central struct and localizes GPU readback management.

**Key Improvements:**
- **Centralized Exposure State**: Moved `current_exposure` and `auto_threshold` into `PostProcess`. Application logic and UI now access cached exposure values via [postprocess_get_exposure()](src/postprocess.c:474:0-482:1), eliminating synchronous GPU stalls and micro-stuttering.
- **Decoupled logic**: Refactored [src/app_ui.c](src/app_ui.c:0:0-0:0) and [src/app_input.c](src/app_input.c:0:0-0:0) to interact solely with the high-level `PostProcess` API, removing all low-level OpenGL synchronization and PBO mapping from the UI and input layers.
- **Robust Async Readback Pump**: Reorganized the histogram and exposure readback logic to ensure the asynchronous GPU-to-CPU transfer "pump" is self-sustaining and correctly handled even during initial frames or state transitions.
- **Linter Compliance & Cognitive Complexity**: To respect the strict clean-code policy without `NOLINT` pragmas, complex functions were divided into smaller, specialized helpers:
    - [postprocess_cleanup](src/postprocess.c:277:0-307:1) -> [destroy_readback_buffers](src/postprocess.c:247:0-261:1) and [destroy_cached_shaders](src/postprocess.c:263:0-275:1).
    - [postprocess_compute_luminance_histogram](src/postprocess.c:958:0-1005:1) -> [fill_histogram_buckets](src/postprocess.c:917:0-941:1) and [trigger_histogram_readback](src/postprocess.c:943:0-956:1).

All UI components, environment management (`EnvManager`), and unit tests have been updated. `just lint`, `make test`, and [test_benchmark_histogram](tests/test_benchmark_histogram.c:52:0-154:1) are 100% passing.

---
*PR updated by Antigravity for task [10013263637674115171](https://jules.google.com/task/10013263637674115171) started by @yoyonel*
