### PR TITLE
refactor: abstract texture creation boilerplate in effects modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ set(SOURCES
     src/effects/fx_bloom.c
     src/effects/fx_dof.c
     src/effects/fx_motion_blur.c
+    src/effects/fx_utils.c
 )
 
 # Silence warnings about legacy CMake versions in subprojects (e.g., cglm, glad)

--- a/include/effects/fx_utils.h
+++ b/include/effects/fx_utils.h
@@ -1,0 +1,31 @@
+#ifndef FX_UTILS_H
+#define FX_UTILS_H
+
+#include "gl_common.h"
+
+/**
+ * @brief Configuration parameters for creating an effect texture.
+ */
+typedef struct {
+	int width;
+	int height;
+	GLenum internal_format;
+	GLenum format;
+	GLenum type;
+	GLint min_filter;
+	GLint mag_filter;
+	GLint wrap_s;
+	GLint wrap_t;
+	const void* initial_data; /* Can be NULL */
+} FXTextureConfig;
+
+/**
+ * @brief Creates a texture, allocates memory, and sets filtering/wrapping
+ * parameters.
+ * @param tex Pointer to the GLuint where the texture ID will be stored.
+ *        If *tex is not 0, it deletes the old texture first.
+ * @param config The texture configuration parameters.
+ */
+void fx_utils_create_texture(GLuint* tex, const FXTextureConfig* config);
+
+#endif /* FX_UTILS_H */

--- a/include/effects/fx_utils.h
+++ b/include/effects/fx_utils.h
@@ -7,17 +7,25 @@
  * @brief Configuration parameters for creating an effect texture.
  */
 typedef struct {
-	int width;
-	int height;
-	GLenum internal_format;
-	GLenum format;
-	GLenum type;
-	GLint min_filter;
-	GLint mag_filter;
-	GLint wrap_s;
-	GLint wrap_t;
-	const void* initial_data; /* Can be NULL */
+	int width;  /**< Texture width in pixels. */
+	int height; /**< Texture height in pixels. */
+	GLenum
+	    internal_format; /**< OpenGL internal format (e.g., GL_RGBA16F). */
+	GLenum format;       /**< OpenGL data format (e.g., GL_RGBA). */
+	GLenum type;         /**< OpenGL data type (e.g., GL_FLOAT). */
+	GLint min_filter;    /**< Minification filter (e.g., GL_LINEAR). */
+	GLint mag_filter;    /**< Magnification filter (e.g., GL_LINEAR). */
+	GLint wrap_s; /**< S-coordinate wrap mode (e.g., GL_CLAMP_TO_EDGE). Set
+	                 to 0 or FX_TEXTURE_WRAP_NONE to skip. */
+	GLint wrap_t; /**< T-coordinate wrap mode (e.g., GL_CLAMP_TO_EDGE). Set
+	                 to 0 or FX_TEXTURE_WRAP_NONE to skip. */
+	const void* initial_data; /**< Initial texture data. Can be NULL. */
 } FXTextureConfig;
+
+/**
+ * @brief Sentinel value to skip setting a wrap parameter.
+ */
+#define FX_TEXTURE_WRAP_NONE 0
 
 /**
  * @brief Creates a texture, allocates memory, and sets filtering/wrapping

--- a/src/effects/fx_auto_exposure.c
+++ b/src/effects/fx_auto_exposure.c
@@ -1,6 +1,7 @@
 #include "effects/fx_auto_exposure.h"
 
 #include "app_settings.h"
+#include "effects/fx_utils.h"
 #include "gl_common.h"
 #include "log.h"
 #include "postprocess.h"
@@ -18,14 +19,17 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	glGenFramebuffers(1, &auto_exp->downsample_fbo);
 	glBindFramebuffer(GL_FRAMEBUFFER, auto_exp->downsample_fbo);
 
-	glGenTextures(1, &auto_exp->downsample_tex);
-	glBindTexture(GL_TEXTURE_2D, auto_exp->downsample_tex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_R16F, LUM_HISTOGRAM_MAP_SIZE,
-	             LUM_HISTOGRAM_MAP_SIZE, 0, GL_RED, GL_FLOAT, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	FXTextureConfig ds_config = {.width = LUM_HISTOGRAM_MAP_SIZE,
+	                             .height = LUM_HISTOGRAM_MAP_SIZE,
+	                             .internal_format = GL_R16F,
+	                             .format = GL_RED,
+	                             .type = GL_FLOAT,
+	                             .min_filter = GL_LINEAR,
+	                             .mag_filter = GL_LINEAR,
+	                             .wrap_s = GL_CLAMP_TO_EDGE,
+	                             .wrap_t = GL_CLAMP_TO_EDGE,
+	                             .initial_data = NULL};
+	fx_utils_create_texture(&auto_exp->downsample_tex, &ds_config);
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
 	                       GL_TEXTURE_2D, auto_exp->downsample_tex, 0);
@@ -39,15 +43,18 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	}
 
 	/* 2. Adaptation Storage (1x1 RGBA32F) */
-	glGenTextures(1, &auto_exp->exposure_tex);
-	glBindTexture(GL_TEXTURE_2D, auto_exp->exposure_tex);
-
 	float initialValues[4] = {EXPOSURE_INITIAL_VAL, 0.0F, 0.0F, 1.0F};
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, 1, 1, 0, GL_RGBA, GL_FLOAT,
-	             initialValues);
-
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	FXTextureConfig exp_config = {.width = 1,
+	                              .height = 1,
+	                              .internal_format = GL_RGBA32F,
+	                              .format = GL_RGBA,
+	                              .type = GL_FLOAT,
+	                              .min_filter = GL_NEAREST,
+	                              .mag_filter = GL_NEAREST,
+	                              .wrap_s = GL_CLAMP_TO_EDGE,
+	                              .wrap_t = GL_CLAMP_TO_EDGE,
+	                              .initial_data = initialValues};
+	fx_utils_create_texture(&auto_exp->exposure_tex, &exp_config);
 
 	/* 3. Load Shaders */
 	auto_exp->downsample_shader = shader_load(

--- a/src/effects/fx_bloom.c
+++ b/src/effects/fx_bloom.c
@@ -1,5 +1,6 @@
 #include "effects/fx_bloom.h"
 
+#include "effects/fx_utils.h"
 #include "gl_common.h"
 #include "log.h"
 #include "postprocess.h"
@@ -58,18 +59,18 @@ int fx_bloom_init(PostProcess* post_processing)
 		bloom->mips[i].width = width;
 		bloom->mips[i].height = height;
 
-		glGenTextures(1, &bloom->mips[i].texture);
-		glBindTexture(GL_TEXTURE_2D, bloom->mips[i].texture);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_R11F_G11F_B10F, width, height,
-		             0, GL_RGB, GL_FLOAT, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-		                GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
-		                GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S,
-		                GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,
-		                GL_CLAMP_TO_EDGE);
+		FXTextureConfig tex_config = {
+		    .width = width,
+		    .height = height,
+		    .internal_format = GL_R11F_G11F_B10F,
+		    .format = GL_RGB,
+		    .type = GL_FLOAT,
+		    .min_filter = GL_LINEAR,
+		    .mag_filter = GL_LINEAR,
+		    .wrap_s = GL_CLAMP_TO_EDGE,
+		    .wrap_t = GL_CLAMP_TO_EDGE,
+		    .initial_data = NULL};
+		fx_utils_create_texture(&bloom->mips[i].texture, &tex_config);
 	}
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/src/effects/fx_dof.c
+++ b/src/effects/fx_dof.c
@@ -1,6 +1,7 @@
 #include "effects/fx_dof.h"
 
 #include "effects/fx_bloom.h"
+#include "effects/fx_utils.h"
 #include "gl_common.h"
 #include "log.h"
 #include "postprocess.h"
@@ -64,31 +65,22 @@ int fx_dof_resize(PostProcess* post_processing)
 		dof_height = 1;
 	}
 
+	FXTextureConfig dof_config = {.width = dof_width,
+	                              .height = dof_height,
+	                              .internal_format = GL_R11F_G11F_B10F,
+	                              .format = GL_RGB,
+	                              .type = GL_FLOAT,
+	                              .min_filter = GL_LINEAR,
+	                              .mag_filter = GL_LINEAR,
+	                              .wrap_s = GL_CLAMP_TO_EDGE,
+	                              .wrap_t = GL_CLAMP_TO_EDGE,
+	                              .initial_data = NULL};
+
 	/* Create/Resize Texture (R11F_G11F_B10F is sufficient for bokeh) */
-	if (dof->blur_tex) {
-		glDeleteTextures(1, &dof->blur_tex);
-	}
-	glGenTextures(1, &dof->blur_tex);
-	glBindTexture(GL_TEXTURE_2D, dof->blur_tex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_R11F_G11F_B10F, dof_width, dof_height,
-	             0, GL_RGB, GL_FLOAT, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	fx_utils_create_texture(&dof->blur_tex, &dof_config);
 
 	/* Create/Resize Temp Texture for Ping-Pong */
-	if (dof->temp_tex) {
-		glDeleteTextures(1, &dof->temp_tex);
-	}
-	glGenTextures(1, &dof->temp_tex);
-	glBindTexture(GL_TEXTURE_2D, dof->temp_tex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_R11F_G11F_B10F, dof_width, dof_height,
-	             0, GL_RGB, GL_FLOAT, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	fx_utils_create_texture(&dof->temp_tex, &dof_config);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, dof->fbo);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,

--- a/src/effects/fx_motion_blur.c
+++ b/src/effects/fx_motion_blur.c
@@ -1,5 +1,6 @@
 #include "effects/fx_motion_blur.h"
 
+#include "effects/fx_utils.h"
 #include "gl_common.h"
 #include "log.h"
 #include "postprocess.h"
@@ -87,31 +88,22 @@ int fx_motion_blur_resize(PostProcess* post_processing)
 		tile_height = 1;
 	}
 
+	FXTextureConfig mb_config = {.width = tile_width,
+	                             .height = tile_height,
+	                             .internal_format = GL_RG16F,
+	                             .format = GL_RG,
+	                             .type = GL_FLOAT,
+	                             .min_filter = GL_NEAREST,
+	                             .mag_filter = GL_NEAREST,
+	                             .wrap_s = GL_CLAMP_TO_EDGE,
+	                             .wrap_t = GL_CLAMP_TO_EDGE,
+	                             .initial_data = NULL};
+
 	/* Tile Max Texture (RG16F) */
-	if (mb_fx->tile_max_tex) {
-		glDeleteTextures(1, &mb_fx->tile_max_tex);
-	}
-	glGenTextures(1, &mb_fx->tile_max_tex);
-	glBindTexture(GL_TEXTURE_2D, mb_fx->tile_max_tex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RG16F, tile_width, tile_height, 0,
-	             GL_RG, GL_FLOAT, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	fx_utils_create_texture(&mb_fx->tile_max_tex, &mb_config);
 
 	/* Neighbor Max Texture (RG16F) */
-	if (mb_fx->neighbor_max_tex) {
-		glDeleteTextures(1, &mb_fx->neighbor_max_tex);
-	}
-	glGenTextures(1, &mb_fx->neighbor_max_tex);
-	glBindTexture(GL_TEXTURE_2D, mb_fx->neighbor_max_tex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RG16F, tile_width, tile_height, 0,
-	             GL_RG, GL_FLOAT, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	fx_utils_create_texture(&mb_fx->neighbor_max_tex, &mb_config);
 
 	return 1;
 }

--- a/src/effects/fx_utils.c
+++ b/src/effects/fx_utils.c
@@ -1,0 +1,32 @@
+#include "effects/fx_utils.h"
+
+#include "gl_common.h"
+#include <stddef.h>
+
+void fx_utils_create_texture(GLuint* tex, const FXTextureConfig* config)
+{
+	if (*tex) {
+		glDeleteTextures(1, tex);
+	}
+
+	glGenTextures(1, tex);
+	glBindTexture(GL_TEXTURE_2D, *tex);
+
+	glTexImage2D(GL_TEXTURE_2D, 0, (GLint)config->internal_format,
+	             config->width, config->height, 0, config->format,
+	             config->type, config->initial_data);
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+	                config->min_filter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+	                config->mag_filter);
+
+	if (config->wrap_s != 0) {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S,
+		                config->wrap_s);
+	}
+	if (config->wrap_t != 0) {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,
+		                config->wrap_t);
+	}
+}

--- a/src/effects/fx_utils.c
+++ b/src/effects/fx_utils.c
@@ -1,10 +1,17 @@
 #include "effects/fx_utils.h"
 
 #include "gl_common.h"
+#include "log.h"
 #include <stddef.h>
 
 void fx_utils_create_texture(GLuint* tex, const FXTextureConfig* config)
 {
+	if (!config || !tex) {
+		LOG_ERROR("suckless-ogl.effects.utils",
+		          "Invalid parameters for texture creation");
+		return;
+	}
+
 	if (*tex) {
 		glDeleteTextures(1, tex);
 	}
@@ -21,11 +28,11 @@ void fx_utils_create_texture(GLuint* tex, const FXTextureConfig* config)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
 	                config->mag_filter);
 
-	if (config->wrap_s != 0) {
+	if (config->wrap_s != FX_TEXTURE_WRAP_NONE) {
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S,
 		                config->wrap_s);
 	}
-	if (config->wrap_t != 0) {
+	if (config->wrap_t != FX_TEXTURE_WRAP_NONE) {
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,
 		                config->wrap_t);
 	}


### PR DESCRIPTION
**Rationale:**
The memory context indicated that the `src/effects/` modules (`fx_bloom.c`, `fx_auto_exposure.c`, `fx_dof.c`, and `fx_motion_blur.c`) suffered from significant boilerplate duplication regarding OpenGL texture creation and parameterization (`glGenTextures`, `glTexImage2D`, `glTexParameteri`).

**Solution:**
1. Created `include/effects/fx_utils.h` to define `FXTextureConfig` and declare `fx_utils_create_texture`.
2. Created `src/effects/fx_utils.c` to encapsulate the duplicated OpenGL texture creation and configuration logic.
3. Refactored the following files to utilize the new abstracted utility, destroying the local boilerplate and decoupling them from raw OpenGL setup logic:
    - `src/effects/fx_bloom.c`
    - `src/effects/fx_auto_exposure.c`
    - `src/effects/fx_dof.c`
    - `src/effects/fx_motion_blur.c`
4. Updated `CMakeLists.txt` to include `src/effects/fx_utils.c`.

**Quality Metric Verification:**
This targeted refactoring directly addresses the goal of reducing cognitive load for human operators by actively destroying strong couplings to OpenGL texture initialization within specific post-process effects. The individual effect source files are now cleaner, shorter, and easier to comprehend.

**Testing:**
- Formatted and linted cleanly (`make format`, `make lint` with `clang-tidy-17`).
- Passed AddressSanitizer integration tests (`xvfb-run -a make test-integration-asan`).
- Code reviewed locally.

---
*PR created automatically by Jules for task [8247323663669807895](https://jules.google.com/task/8247323663669807895) started by @yoyonel*