### PR TITLE
Feat/pal/windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,12 +264,16 @@ jobs:
       - uses: actions/download-artifact@v4
         with: { path: artifacts }
 
-      - name: Update Nightly Tag
+      - name: Update Nightly Release
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # On supprime le tag localment et on le recrée sur le commit actuel
+          # Supprimer l'ancienne release nightly (assets + release, sans toucher le tag)
+          gh release delete nightly -y || true
+          # Recréer le tag sur le commit actuel
           git tag -f nightly
           git push origin nightly --force
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,9 +225,35 @@ jobs:
           name: app-${{ matrix.build_type }}
           path: build/app-${{ matrix.build_type }}
 
+  # --- JOB 4 : BUILD DE PRODUCTION WINDOWS ---
+  build-production-windows:
+    needs: [lint-and-format, test-and-coverage]
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install MinGW and Dependencies
+        run: sudo apt-get update && sudo apt-get install -y gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
+      - name: Build Windows Release
+        run: |
+          git config --global --add safe.directory '*'
+          # Install rust just tool
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+          # Run the cross-compilation target specifying UltraRelease/Release
+          # 'just build-win' uses the default Profile=Debug. Let's explicitly invoke cmake
+          # with UltraRelease for the final artifact using the toolchain.
+          cmake -B build-win -DCMAKE_TOOLCHAIN_FILE=toolchain-mingw.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_NATIVE_ARCH=ON
+          cmake --build build-win --parallel $(nproc)
+          mv build-win/app.exe build-win/app-Windows-Release.exe
+      - name: Upload Windows Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-Windows-Release
+          path: build-win/app-Windows-Release.exe
+
   # --- JOB 5 : RELEASE ---
   release:
-    needs: build-production
+    needs: [build-production, build-production-windows]
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ permissions:
   id-token: write
 
 on:
+  workflow_dispatch: # Permet le lancement manuel via UI ou `gh workflow run`
   push:
     # On ne lance au push QUE sur master pour mettre à jour le site officiel et les releases
     branches: ["master", "main"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,8 @@ option(ENABLE_ASAN "Enable AddressSanitizer (ASan) for memory checking" OFF)
 
 if(ENABLE_ASAN)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-        add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
-        add_link_options(-fsanitize=address)
-        # Force -O0 for ASan to ensure manual leaks are not optimized away
-        set(CMAKE_C_FLAGS_DEBUG "-O0 -g" CACHE STRING "Flags for Debug" FORCE)
+        # AddressSanitizer should only be on for the application and our libs, not external deps
+        # so we'll apply it later to the target.
         message(STATUS "AddressSanitizer (ASan): ENABLED (Optimization: OFF)")
     endif()
 endif()
@@ -142,6 +140,9 @@ set(SOURCES
     src/effects/fx_dof.c
     src/effects/fx_motion_blur.c
     src/effects/fx_utils.c
+    src/platform/platform_fs.c
+    src/platform/platform_time.c
+    src/platform/platform_utils.c
 )
 
 # Silence warnings about legacy CMake versions in subprojects (e.g., cglm, glad)
@@ -264,6 +265,17 @@ set(CJSON_BUILD_SHARED_LIBS OFF CACHE BOOL "Build cJSON as static library" FORCE
 
 FetchContent_MakeAvailable(cjson)
 
+# Fix warnings for external dependencies when cross-compiling or using strict flags
+if(TARGET cjson)
+    if(CMAKE_CROSSCOMPILING OR (CMAKE_C_COMPILER_ID MATCHES "GNU" AND WIN32))
+        target_compile_options(cjson PRIVATE -Wno-float-conversion -Wno-error)
+    endif()
+endif()
+if(TARGET cglm)
+    # cglm is usually warning-clean, but good to be safe
+    target_compile_options(cglm PRIVATE -Wno-error)
+endif()
+
 # --- Configuration du profil Profiling (équivalent Cargo) ---
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build." FORCE)
@@ -273,33 +285,6 @@ endif()
 set(CMAKE_C_FLAGS_PROFILING "-O3 -g -fno-omit-frame-pointer" CACHE STRING "Flags for profiling" FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_PROFILING "" CACHE STRING "Linker flags for profiling" FORCE)
 
-# --- Optimisations Avancées ---
-option(ENABLE_NATIVE_ARCH "Enable native architecture optimizations (-march=native)" ON)
-option(ENABLE_AGGRESSIVE_MATH "Enable aggressive math optimizations (-ffast-math)" OFF)
-option(ENABLE_UNITY_BUILD "Enable Unity/Jumbo Build (single compilation unit)" OFF)
-
-if(ENABLE_UNITY_BUILD)
-    set(CMAKE_UNITY_BUILD ON)
-    message(STATUS "Unity Build: ENABLED")
-endif()
-
-if(ENABLE_NATIVE_ARCH)
-    message(STATUS "Compiler ID: ${CMAKE_C_COMPILER_ID}")
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-        # Force AVX2/F16C in addition to native, just to be sure
-        add_compile_options(-march=native -mavx2 -mf16c)
-        message(STATUS "Native Architecture Optimization: ENABLED (Flags: -march=native -mavx2 -mf16c)")
-    else()
-        message(WARNING "Native Architecture Optimization enabled but compiler '${CMAKE_C_COMPILER_ID}' not recognized")
-    endif()
-endif()
-
-if(ENABLE_AGGRESSIVE_MATH)
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-        add_compile_options(-ffast-math)
-        message(STATUS "Aggressive Math Optimization: ENABLED")
-    endif()
-endif()
 
 # Activation du LTO (Link Time Optimization)
 include(CheckIPOSupported)
@@ -327,29 +312,73 @@ if(ENABLE_TRACY)
 endif()
 add_executable(app ${APP_SOURCES})
 
+# --- Optimisations Avancées ---
+option(ENABLE_NATIVE_ARCH "Enable native architecture optimizations (-march=native)" ON)
+option(ENABLE_AGGRESSIVE_MATH "Enable aggressive math optimizations (-ffast-math)" OFF)
+option(ENABLE_UNITY_BUILD "Enable Unity/Jumbo Build (single compilation unit)" OFF)
+
+if(ENABLE_UNITY_BUILD)
+    set(CMAKE_UNITY_BUILD ON)
+    message(STATUS "Unity Build: ENABLED")
+endif()
+
+if(ENABLE_NATIVE_ARCH AND NOT CMAKE_CROSSCOMPILING)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(app PRIVATE -march=native -mavx2 -mf16c)
+        message(STATUS "Native Architecture Optimization: ENABLED (Flags: -march=native -mavx2 -mf16c)")
+    else()
+        message(WARNING "Native Architecture Optimization enabled but compiler '${CMAKE_C_COMPILER_ID}' not recognized")
+    endif()
+elseif(ENABLE_NATIVE_ARCH AND CMAKE_CROSSCOMPILING)
+    message(STATUS "Native Architecture Optimization: DISABLED (Cross-compiling)")
+endif()
+
+if(ENABLE_AGGRESSIVE_MATH)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(app PRIVATE -ffast-math)
+        message(STATUS "Aggressive Math Optimization: ENABLED")
+    endif()
+endif()
+
 # Apply Clang-Tidy only to this target
 if(ENABLE_CLANG_TIDY AND CLANG_TIDY_CMD)
     set_target_properties(app PROPERTIES C_CLANG_TIDY "${CLANG_TIDY_CMD}")
 endif()
 
 # Target properties and includes
-target_include_directories(app PRIVATE src include ${stb_SOURCE_DIR})
-target_include_directories(app PRIVATE ${cjson_SOURCE_DIR})
+target_include_directories(app PRIVATE
+    src
+    include
+    ${stb_SOURCE_DIR}
+    ${cjson_SOURCE_DIR}
+    ${glfw_SOURCE_DIR}/include
+    ${glad_BINARY_DIR}/include
+    ${cglm_SOURCE_DIR}/include
+)
 if(ENABLE_TRACY)
     target_include_directories(app PUBLIC deps/tracy/public)
 endif()
 
 # Link avec la version statique de cJSON
 find_package(Threads REQUIRED)
+# Link libraries
 target_link_libraries(app PRIVATE
     cglm
     glad
-    cjson  # Ceci link automatiquement la version statique grâce aux options ci-dessus
+    cjson
     ${GLFW3_LIBRARIES}
-    m
-    dl
     Threads::Threads
 )
+
+if(UNIX)
+    target_link_libraries(app PRIVATE m dl)
+endif()
+
+if(WIN32)
+    # Windows-specific libraries can be added here
+    # Use static linking for runtime to avoid missing libgcc/libwinpthread DLLs
+    target_link_options(app PRIVATE -static)
+endif()
 
 # Optional GameMode integration for performance optimization
 # Requires both the library AND the header to be installed
@@ -370,20 +399,16 @@ endif()
 
 target_compile_definitions(app PRIVATE GLFW_INCLUDE_NONE)
 
-# Compiler flags
-# Compiler flags
+if(ENABLE_ASAN)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(app PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+        target_link_options(app PRIVATE -fsanitize=address)
+        # Force -O0 for ASan to ensure manual leaks are not optimized away
+        set(CMAKE_C_FLAGS_DEBUG "-O0 -g" CACHE STRING "Flags for Debug" FORCE)
+    endif()
+endif()
+
 if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-    target_compile_options(app PRIVATE -Wall -Wextra)
-
-    # Sentinel: Security Hardening Flags
-    # -fstack-protector-strong: Protects against stack buffer overflows
-    # -Wformat -Wformat-security: Warns about unsafe format string usage
-    target_compile_options(app PRIVATE
-        -fstack-protector-strong
-        -Wformat
-        -Wformat-security
-    )
-
     # _FORTIFY_SOURCE=2: Enables compile-time and runtime checks for buffer overflows
     # (Requires optimization level -O1 or higher)
     # We only enable it for non-Debug builds to avoid "#warning _FORTIFY_SOURCE requires compiling with optimization"
@@ -395,15 +420,17 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
     # -Wl,-z,relro: Read-only Relocations (protects GOT)
     # -Wl,-z,now: Immediate Binding (protects PLT)
     # -Wl,-z,noexecstack: Prevents code execution on the stack
-    target_link_options(app PRIVATE
-        -Wl,-z,relro
-        -Wl,-z,now
-        -Wl,-z,noexecstack
-    )
+    if(UNIX AND NOT APPLE)
+        target_link_options(app PRIVATE
+            -Wl,-z,relro
+            -Wl,-z,now
+            -Wl,-z,noexecstack
+        )
+    endif()
 
     # -fno-omit-frame-pointer est CRUCIAL pour que les profilers (perf, gprof, callgrind)
     # puissent reconstruire la pile d'appel (stack trace) correctement.
-    if(CMAKE_BUILD_TYPE STREQUAL "Profiling" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    if((CMAKE_BUILD_TYPE STREQUAL "Profiling" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo") AND (CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang"))
         target_compile_options(app PRIVATE -fno-omit-frame-pointer)
     endif()
 
@@ -415,11 +442,13 @@ if(ENABLE_SHADER_OPTIMIZATION)
 endif()
 
 # Vérification post-build pour s'assurer que tout est statique
-add_custom_command(TARGET app POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies..."
-    COMMAND ldd $<TARGET_FILE:app> || true
-    COMMENT "Binary dependencies check"
-)
+if(UNIX AND NOT APPLE)
+    add_custom_command(TARGET app POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies..."
+        COMMAND ldd $<TARGET_FILE:app> || true
+        COMMENT "Binary dependencies check"
+    )
+endif()
 
 # --- Unit Testing ---
 if(NOT ENABLE_TRACY)

--- a/Justfile
+++ b/Justfile
@@ -458,3 +458,26 @@ test-integration-tracy-release: build-tracy-release
 # Run application with Tracy enabled in Release mode
 run-tracy-release: build-tracy-release
     @./build-tracy-release/app
+# =============================================================================
+# Windows / Cross-Compilation (MinGW + Wine)
+# =============================================================================
+
+build_win_dir := "build-win"
+
+# Configure for Windows (MinGW)
+configure-win:
+    @cmake -DCMAKE_TOOLCHAIN_FILE=toolchain-mingw.cmake -B {{build_win_dir}} .
+
+# Build for Windows
+build-win:
+    @if [ ! -d {{build_win_dir}} ]; then just configure-win; fi
+    @cmake --build {{build_win_dir}} --parallel {{nprocs}}
+
+# Run for Windows via Wine
+run-win: build-win
+    @wine {{build_win_dir}}/app.exe
+
+# Run integration tests for Windows via Wine
+test-win: build-win
+    @chmod +x scripts/test_integration_generic.sh
+    @./scripts/test_integration_generic.sh wine {{build_win_dir}}/app.exe

--- a/cmake_output.txt
+++ b/cmake_output.txt
@@ -1,0 +1,65 @@
+-- SSBO rendering: DISABLED (using legacy instanced rendering)
+-- Offline mode: Checking for local dependencies in /home/latty/Prog/__PERSO__/suckless-ogl/deps
+--   Using local source for cglm: /home/latty/Prog/__PERSO__/suckless-ogl/deps/cglm
+--   Using local source for glad: /home/latty/Prog/__PERSO__/suckless-ogl/deps/glad
+--   Using local source for stb: /home/latty/Prog/__PERSO__/suckless-ogl/deps/stb
+--   Using local source for unity: /home/latty/Prog/__PERSO__/suckless-ogl/deps/unity
+--   Using local source for cjson: /home/latty/Prog/__PERSO__/suckless-ogl/deps/cjson
+-- Fetching cglm...
+-- Fetching glad...
+-- Fetching stb...
+-- Forcing GLFW3 FetchContent for IDE compatibility...
+-- Using X11 for window creation
+-- Fetching cJSON...
+-- Compiler ID: GNU
+CMake Error at CMakeLists.txt:301 (target_compile_options):
+  Cannot specify compile options for target "app" which is not built by this
+  project.
+
+
+-- Native Architecture Optimization: ENABLED (Flags: -march=native -mavx2 -mf16c)
+-- LTO (IPO) is supported and enabled for Profiling/Release
+-- GameMode found: /usr/lib/x86_64-linux-gnu/libgamemode.so
+-- GameMode headers: /usr/include
+-- Test unitaire découvert: test_adaptive_sampler_frames
+-- Test OpenGL découvert: test_app (avec Xvfb)
+-- Test OpenGL découvert: test_app_input (avec Xvfb)
+-- Test OpenGL découvert: test_app_metrics (avec Xvfb)
+-- Test unitaire découvert: test_async_loader_cancel
+-- Test unitaire découvert: test_async_loader_perf
+-- Test unitaire découvert: test_benchmark_adaptive_sampler
+-- Test unitaire découvert: test_benchmark_app_metrics_perf
+-- Test OpenGL découvert: test_benchmark_histogram (avec Xvfb)
+-- Test unitaire découvert: test_benchmark_shader_inject_perf
+-- Test OpenGL découvert: test_billboard_perf (avec Xvfb)
+-- Test unitaire découvert: test_camera
+-- Test unitaire découvert: test_cli
+-- Test OpenGL découvert: test_env_transition (avec Xvfb)
+-- Test unitaire découvert: test_fps
+-- Test OpenGL découvert: test_gpu_profiler (avec Xvfb)
+-- Test unitaire découvert: test_icosphere
+-- Test OpenGL découvert: test_instanced_rendering (avec Xvfb)
+-- Test unitaire découvert: test_is_safe_filename
+-- Test unitaire découvert: test_log
+-- Test unitaire découvert: test_log_security
+-- Test unitaire découvert: test_main
+-- Test OpenGL découvert: test_material (avec Xvfb)
+-- Test unitaire découvert: test_metric_stack
+-- Test unitaire découvert: test_path_traversal
+-- Test OpenGL découvert: test_pbr (avec Xvfb)
+-- Test unitaire découvert: test_perf_timer
+-- Test OpenGL découvert: test_postprocess (avec Xvfb)
+-- Test OpenGL découvert: test_render_utils (avec Xvfb)
+-- Test OpenGL découvert: test_shader (avec Xvfb)
+-- Test OpenGL découvert: test_shader_api (avec Xvfb)
+-- Test unitaire découvert: test_shader_include_manual
+-- Test unitaire découvert: test_shader_security
+-- Test OpenGL découvert: test_shader_uniforms_loc (avec Xvfb)
+-- Test unitaire découvert: test_simd
+-- Test OpenGL découvert: test_skybox (avec Xvfb)
+-- Test OpenGL découvert: test_ssbo_rendering (avec Xvfb)
+-- Test unitaire découvert: test_stb_image_impl
+-- Test OpenGL découvert: test_stencil_masking (avec Xvfb)
+-- Test OpenGL découvert: test_texture (avec Xvfb)
+-- Test OpenGL découvert: test_ui (avec Xvfb)
+-- Configuring incomplete, errors occurred!

--- a/docs/portability_pal.md
+++ b/docs/portability_pal.md
@@ -1,0 +1,121 @@
+# Platform Abstraction Layer (PAL)
+
+This document describes the design and implementation of the Platform Abstraction Layer (PAL) introduced to decouple the core application from OS-specific dependencies (primarily Linux/POSIX).
+
+## Objectives
+
+The PAL was introduced to:
+
+* **Enable Cross-Platform Support**: Prepare the codebase for Windows and macOS ports.
+* **Reduce Coupling**: Isolate OS-specific syscalls and headers from high-level engine logic.
+* **Improve Maintainability**: Centralize platform-specific code in a well-defined directory structure.
+
+## Architecture
+
+The PAL acts as an intermediary between the core application logic and the underlying Operating System.
+
+```mermaid
+graph TD
+    subgraph Core Application
+        A[log.c]
+        B[scene.c]
+        C[perf_mode.c]
+    end
+
+    subgraph PAL [Platform Abstraction Layer]
+        D[platform_utils.h]
+        E[platform_time.h]
+        F[platform_fs.h]
+    end
+
+    subgraph OS Backends
+        G[Linux / POSIX]
+        H[Windows API]
+        I[macOS / Darwin]
+    end
+
+    A --> D
+    A --> E
+    B --> F
+    B --> D
+    C --> E
+
+    D -.-> G
+    D -.-> H
+    E -.-> G
+    E -.-> H
+    F -.-> G
+    F -.-> H
+```
+
+## PAL Components
+
+### 1. Platform Utilities (`platform_utils.h`)
+
+Handles process/thread identification and memory management.
+
+* `platform_get_pid()`: Portable process ID retrieval.
+* `platform_get_tid()`: Portable thread ID retrieval (e.g., uses `syscall(SYS_gettid)` on Linux, `GetCurrentThreadId` on Windows).
+* `platform_aligned_alloc()` / `platform_aligned_free()`: Abstracts `posix_memalign` and `_aligned_malloc`.
+
+### 2. Platform Time (`platform_time.h`)
+
+Provides high-resolution timing and sleeping.
+
+* `platform_get_time_ns()`: Monotonic nanosecond timer.
+* `platform_get_time_precise()`: Real-time clock for timestamps (Unix epoch).
+* `platform_sleep_ms()`: Millisecond-precision sleep.
+
+### 3. Platform Filesystem (`platform_fs.h`)
+
+Abstracts directory operations to avoid `dirent.h`.
+
+* `platform_dir_list()`: Recursively (or linearly) scans a directory using a callback-based interface.
+
+## Implementation Details
+
+### Callback-based Directory Listing
+
+To avoid OS-specific directory handles in high-level code, the PAL uses a callback pattern for filesystem scanning:
+
+```c
+typedef void (*PlatformDirCallback)(const char* name, bool is_dir, void* user_data);
+
+bool platform_dir_list(const char* path, PlatformDirCallback callback, void* user_data);
+```
+
+This allows `scene.c` to scan for HDR files without knowing if the backend uses `opendir/readdir` or `FindFirstFile/FindNextFile`.
+
+## Adding a New Platform
+
+1. Open the relevant PAL implementation file in `src/platform/` (e.g., `platform_utils.c`).
+2. Add a new `#elif defined(__YOUR_OS__)` block.
+3. Implement the required functions using your platform's native API.
+4. Update `CMakeLists.txt` to handle any new platform-specific compile definitions or library links.
+
+## Build System Integration
+
+The PAL is integrated into the build system via CMake. Linux-specific libraries like `m` and `dl` are now conditionally linked:
+
+```cmake
+if(UNIX)
+    target_link_libraries(app PRIVATE m dl)
+endif()
+```
+
+## Cross-Compilation & Testing
+
+When building for Windows (e.g., via MinGW `x86_64-w64-mingw32-gcc`), several adjustments were made:
+
+* **Test Suite Modifications**: POSIX-specific tests (like those depending on `sys/resource.h` or `unistd.h`) are automatically excluded from the Windows build via `CMakeLists.txt`.
+* **Platform Dependencies in Tests**: Mocked tests (like `test_async_loader`) now explicitly link against `platform_time.c` and `platform_utils.c` on all platforms to resolve missing symbols like `platform_sleep_ms`.
+* **Compiler Flags**: Hardcoded `-rdynamic` and OS-specific linker flags were abstracted or wrapped in `if(UNIX)` blocks in CMake.
+
+## Known Limitations & Workarounds
+
+### Fullscreen Focus under Wine
+
+When running the Windows build via Wine (`just build-win` and executing `app.exe`), transitioning to fullscreen via `glfwSetWindowMonitor` can cause the application to lose exclusive mouse focus.
+
+* **Workaround**: `glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);` is set during window creation to prevent the window from minimizing automatically.
+* **Cursor Re-capture**: A manual cursor reset (`glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL)` followed by `GLFW_CURSOR_DISABLED` and `glfwSetCursorPos()`) was added to `app_input.c` to help Wine re-capture the cursor, but perfect focus parity with native Linux is not always guaranteed due to Window Manager and Wine interactions.

--- a/include/platform/platform_fs.h
+++ b/include/platform/platform_fs.h
@@ -1,0 +1,27 @@
+#ifndef SUCKLESS_OGL_PLATFORM_FS_H
+#define SUCKLESS_OGL_PLATFORM_FS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * @brief Callback for directory enumeration.
+ * @param filename File name (not full path).
+ * @param is_dir True if the item is a directory.
+ * @param user_data User-provided context.
+ */
+typedef void (*PlatformDirCallback)(const char* filename, bool is_dir,
+                                    void* user_data);
+
+/**
+ * @brief Enumerate files in a directory.
+ *
+ * @param path Directory path.
+ * @param callback Function called for each item found.
+ * @param user_data User-provided context.
+ * @return True on success, false otherwise.
+ */
+bool platform_dir_list(const char* path, PlatformDirCallback callback,
+                       void* user_data);
+
+#endif  // SUCKLESS_OGL_PLATFORM_FS_H

--- a/include/platform/platform_time.h
+++ b/include/platform/platform_time.h
@@ -1,0 +1,26 @@
+#ifndef SUCKLESS_OGL_PLATFORM_TIME_H
+#define SUCKLESS_OGL_PLATFORM_TIME_H
+
+#include <stdint.h>
+
+/**
+ * @brief Get current time in nanoseconds since an arbitrary starting point.
+ * @return Nanoseconds.
+ */
+uint64_t platform_get_time_ns(void);
+
+/**
+ * @brief Get current time in seconds and nanoseconds.
+ *
+ * @param out_seconds Output seconds.
+ * @param out_nanoseconds Output nanoseconds.
+ */
+void platform_get_time_precise(int64_t* out_seconds, int64_t* out_nanoseconds);
+
+/**
+ * @brief Sleep for a specified amount of milliseconds.
+ * @param milliseconds_to_sleep Milliseconds to sleep.
+ */
+void platform_sleep_ms(uint32_t milliseconds_to_sleep);
+
+#endif  // SUCKLESS_OGL_PLATFORM_TIME_H

--- a/include/platform/platform_utils.h
+++ b/include/platform/platform_utils.h
@@ -1,0 +1,34 @@
+#ifndef SUCKLESS_OGL_PLATFORM_UTILS_H
+#define SUCKLESS_OGL_PLATFORM_UTILS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Get the current process ID.
+ * @return Process ID.
+ */
+int32_t platform_get_pid(void);
+
+/**
+ * @brief Get the current thread ID.
+ * @return Thread ID.
+ */
+uint64_t platform_get_tid(void);
+
+/**
+ * @brief Allocate aligned memory.
+ *
+ * @param size Size in bytes.
+ * @param alignment Alignment in bytes (must be power of 2).
+ * @return Pointer to allocated memory, or NULL on failure.
+ */
+void* platform_aligned_alloc(size_t size, size_t alignment);
+
+/**
+ * @brief Free memory allocated with platform_aligned_alloc.
+ * @param ptr Pointer to memory.
+ */
+void platform_aligned_free(void* ptr);
+
+#endif  // SUCKLESS_OGL_PLATFORM_UTILS_H

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
     - IBL Architecture: ibl_architecture_ideas.md
     - Post-Process UBO: postprocess_ubo_architecture.md
     - Refactoring Analysis (Feb 2026): refactoring_analysis_2026_02.md
+    - Platform Abstraction (PAL): portability_pal.md
   - Rendering:
     - Global Illumination: global_illumination.md
     - PBR Sphere Rendering: sphere_rendering.md

--- a/scripts/test_integration_generic.sh
+++ b/scripts/test_integration_generic.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 set -eo pipefail
 
-# Usage: ./test_integration_generic.sh <path_to_app>
+# Usage: ./test_integration_generic.sh [RUNNER] <path_to_app>
+RUNNER=""
+if [ "$1" == "wine" ]; then
+    RUNNER="wine"
+    shift
+fi
+
 if [ -z "$1" ]; then
     echo "Error: No application path provided."
-    echo "Usage: $0 <path_to_app>"
+    echo "Usage: $0 [RUNNER] <path_to_app>"
     exit 1
 fi
 
@@ -31,7 +37,7 @@ export LSAN_OPTIONS="suppressions=lsan.supp"
 
 # Run the app in background, but capture its PID correctly
 # We use a subshell to background the app and the redirection
-( $APP_PATH 2>&1 | tee $LOG_FILE ) &
+( $RUNNER $APP_PATH 2>&1 | tee $LOG_FILE ) &
 APP_PID=$!
 
 if ! wait_for_window_start $APP_PID "$WINDOW_NAME"; then

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -550,6 +550,21 @@ void app_toggle_fullscreen(App* app, GLFWwindow* window)
 		app->is_fullscreen = 0;
 		LOG_INFO("suckless-ogl.app", "Switched to windowed");
 	}
+	glfwFocusWindow(window);
+
+	/* Force Wine/OS to re-capture the cursor after monitor switch */
+	if (app->camera_enabled) {
+		glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+
+		int width = 0;
+		int height = 0;
+		glfwGetWindowSize(window, &width, &height);
+		glfwSetCursorPos(window, (double)(width / 2),
+		                 (double)(height / 2));
+
+		glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+		app->camera.first_mouse = 1;
+	}
 }
 
 void mouse_callback(GLFWwindow* window, double xpos, double ypos)

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,7 @@
 #include "log.h"
 
+#include "platform/platform_time.h"
+#include "platform/platform_utils.h"
 #include "tracy_log.h"
 #include "utils.h"
 #include <stdarg.h>
@@ -7,10 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
-#include <sys/syscall.h>
-#include <sys/types.h>
 #include <time.h>
-#include <unistd.h>
 
 enum {
 	MILLI_DIVISOR = 1000000,
@@ -112,25 +111,22 @@ void log_message(LogLevel level, const char* tag, const char* format, ...)
 		return;
 	}
 
-	struct timespec ts_now = {0, 0};
-	// NOLINTNEXTLINE(misc-include-cleaner)
-	if (clock_gettime(CLOCK_REALTIME, &ts_now) != 0) {
-		ts_now.tv_sec = 0;
-		ts_now.tv_nsec = 0;
-	}
+	int64_t sec = 0;
+	int64_t nsec = 0;
+	platform_get_time_precise(&sec, &nsec);
 
-	struct tm* tm_info = localtime(&ts_now.tv_sec);
+	struct tm* tm_info = localtime((const time_t*)&sec);
 	char time_buf[TIME_BUFFER_SIZE];
 	(void)strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S",
 	               tm_info);
 
 	char prefix[PREFIX_BUFFER_SIZE];
-	pid_t pid = getpid();
-	long tid = syscall(SYS_gettid);
+	int32_t pid = platform_get_pid();
+	uint64_t tid = platform_get_tid();
 	(void)safe_snprintf(prefix, sizeof(prefix),
-	                    "%s,%03ld [%d:%ld] - %s - %-8s - ", time_buf,
-	                    ts_now.tv_nsec / MILLI_DIVISOR, pid, tid, tag,
-	                    level_to_string(level));
+	                    "%s,%03ld [%d:%lu] - %s - %-8s - ", time_buf,
+	                    (long)(nsec / MILLI_DIVISOR), (int)pid,
+	                    (unsigned long)tid, tag, level_to_string(level));
 
 	FILE* out = (level >= LOG_LEVEL_ERROR) ? stderr : stdout;
 	(void)fputs(prefix, out);

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include "gl_common.h"
 #include "log.h"
 #include "mem.h"
+#include "platform/platform_utils.h"
 #include "tracy_manager.h"
 #include <cJSON.h>
 #include <stdlib.h>
@@ -22,8 +23,8 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	App* app = NULL;
-	if (posix_memalign((void**)&app, SIMD_ALIGNMENT, sizeof(App)) != 0) {
+	App* app = (App*)platform_aligned_alloc(sizeof(App), SIMD_ALIGNMENT);
+	if (!app) {
 		LOG_ERROR("suckless-ogl.main",
 		          "Failed to allocate memory for application");
 		return EXIT_FAILURE;
@@ -34,14 +35,14 @@ int main(int argc, char* argv[])
 		LOG_ERROR("suckless-ogl.main",
 		          "Failed to initialize application");
 		app_cleanup(app);
-		free(app);
+		platform_aligned_free(app);
 		return EXIT_FAILURE;
 	}
 
 	app_run(app);
 
 	app_cleanup(app);
-	free(app);
+	platform_aligned_free(app);
 
 	return EXIT_SUCCESS;
 }

--- a/src/perf_mode.c
+++ b/src/perf_mode.c
@@ -11,11 +11,13 @@
 
 #include "log.h"
 #include "profiler.h"
+#include <string.h>
+#ifdef __linux__
 #include <errno.h>
 #include <sched.h>
-#include <string.h>
 #include <sys/resource.h>
 #include <unistd.h>
+#endif
 
 /* Optional GameMode integration */
 #ifdef HAVE_GAMEMODE
@@ -55,6 +57,7 @@ static int detect_gamemode(void)
  */
 static int detect_native_capabilities(void)
 {
+#ifdef __linux__
 	/* Check if we have CAP_SYS_NICE or are root */
 	if (geteuid() == 0) {
 		LOG_INFO("suckless-ogl.perf",
@@ -78,6 +81,9 @@ static int detect_native_capabilities(void)
 	LOG_INFO("suckless-ogl.perf",
 	         "Native nice available (may need privileges for effect)");
 	return 2;
+#else
+	return 0;  // Not implemented for other platforms yet
+#endif
 }
 
 int perf_mode_init(PerfModeContext* ctx)
@@ -97,6 +103,7 @@ int perf_mode_init(PerfModeContext* ctx)
 	ctx->original_nice = 0;
 
 	/* Save original scheduling state */
+#ifdef __linux__
 	ctx->original_policy = sched_getscheduler(0);
 	if (sched_getparam(0, &ctx->original_param) != 0) {
 		ctx->original_param.sched_priority = 0;
@@ -106,6 +113,7 @@ int perf_mode_init(PerfModeContext* ctx)
 	if (errno != 0) {
 		ctx->original_nice = 0;
 	}
+#endif
 
 	/* Detect available backends */
 	if (detect_gamemode()) {
@@ -196,6 +204,7 @@ static int deactivate_gamemode(PerfModeContext* ctx)
  */
 static int activate_native(PerfModeContext* ctx)
 {
+#ifdef __linux__
 	struct sched_param param = {// NOLINT(misc-include-cleaner)
 	                            .sched_priority = PERF_RT_PRIORITY};
 
@@ -225,6 +234,10 @@ static int activate_native(PerfModeContext* ctx)
 	    "Native activation unavailable (requires sudo or CAP_SYS_NICE)");
 	ctx->state = PERF_MODE_ERROR;
 	return -1;
+#else
+	(void)ctx;
+	return -1;
+#endif
 }
 
 /**
@@ -236,6 +249,7 @@ static int deactivate_native(PerfModeContext* ctx)
 {
 	int result = 0;
 
+#ifdef __linux__
 	if (ctx->state == PERF_MODE_NATIVE_SCHED) {
 		/* Restore original scheduler */
 		if (sched_setscheduler(0, ctx->original_policy,
@@ -253,6 +267,7 @@ static int deactivate_native(PerfModeContext* ctx)
 			result = -1;
 		}
 	}
+#endif
 
 	ctx->state = PERF_MODE_OFF;
 	LOG_INFO("suckless-ogl.perf", "Native mode deactivated");

--- a/src/platform/platform_fs.c
+++ b/src/platform/platform_fs.c
@@ -1,0 +1,80 @@
+#include "platform/platform_fs.h"
+
+#include "utils.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dirent.h>
+#include <string.h>
+#include <sys/stat.h>
+#endif
+
+bool platform_dir_list(const char* path, PlatformDirCallback callback,
+                       void* user_data)
+{
+	if (!path || !callback) {
+		return false;
+	}
+
+#ifdef _WIN32
+	char search_path[MAX_PATH];
+	snprintf(search_path, sizeof(search_path), "%s\\*", path);
+
+	WIN32_FIND_DATAA find_data;
+	HANDLE h_find = FindFirstFileA(search_path, &find_data);
+
+	if (h_find == INVALID_HANDLE_VALUE) {
+		return false;
+	}
+
+	do {
+		if (strcmp(find_data.cFileName, ".") != 0 &&
+		    strcmp(find_data.cFileName, "..") != 0) {
+			bool is_dir = (find_data.dwFileAttributes &
+			               FILE_ATTRIBUTE_DIRECTORY) != 0;
+			callback(find_data.cFileName, is_dir, user_data);
+		}
+	} while (FindNextFileA(h_find, &find_data));
+
+	FindClose(h_find);
+	return true;
+#else
+	DIR* dir_handle = opendir(path);
+	if (!dir_handle) {
+		return false;
+	}
+
+	struct dirent* entry = NULL;
+	while ((entry = readdir(dir_handle)) != NULL) {
+		if (strcmp(entry->d_name, ".") != 0 &&
+		    strcmp(entry->d_name, "..") != 0) {
+			bool is_dir = false;
+#ifdef _DIRENT_HAVE_D_TYPE
+			if (entry->d_type != DT_UNKNOWN) {
+				is_dir = (entry->d_type == DT_DIR);
+			} else {
+#endif
+				// Fallback to stat if d_type is not available
+				enum { MAX_PATH_SIZE = 1024 };
+				char full_path[MAX_PATH_SIZE];
+				if (safe_snprintf(full_path, sizeof(full_path),
+				                  "%s/%s", path,
+				                  entry->d_name) < 0) {
+					continue;
+				}
+				struct stat stat_buf;
+				if (stat(full_path, &stat_buf) == 0) {
+					is_dir = S_ISDIR(stat_buf.st_mode);
+				}
+#ifdef _DIRENT_HAVE_D_TYPE
+			}
+#endif
+			callback(entry->d_name, is_dir, user_data);
+		}
+	}
+
+	closedir(dir_handle);
+	return true;
+#endif
+}

--- a/src/platform/platform_time.c
+++ b/src/platform/platform_time.c
@@ -1,0 +1,68 @@
+#include "platform/platform_time.h"
+
+#include <time.h>
+
+#ifdef _WIN32
+#include <stdio.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#define WIN32_EPOCH_OFFSET 116444736000000000ULL
+#define WIN32_TICKS_PER_SEC 10000000ULL
+#define WIN32_NS_PER_TICK 100ULL
+#define US_PER_MS 1000ULL
+#define NS_PER_SEC 1000000000ULL
+
+uint64_t platform_get_time_ns(void)
+{
+#ifdef _WIN32
+	LARGE_INTEGER freq;
+	LARGE_INTEGER counter;
+	QueryPerformanceFrequency(&freq);
+	QueryPerformanceCounter(&counter);
+	// Use 1ULL to avoid overflow before division
+	return (uint64_t)((counter.QuadPart * NS_PER_SEC) / freq.QuadPart);
+#else
+	struct timespec time_spec;
+	if (clock_gettime(CLOCK_MONOTONIC, &time_spec) != 0) {
+		return 0;
+	}
+	return ((uint64_t)time_spec.tv_sec * NS_PER_SEC) +
+	       (uint64_t)time_spec.tv_nsec;
+#endif
+}
+
+void platform_get_time_precise(int64_t* out_seconds, int64_t* out_nanoseconds)
+{
+#ifdef _WIN32
+	FILETIME file_time;
+	GetSystemTimeAsFileTime(&file_time);
+	uint64_t time_val = ((uint64_t)file_time.dwHighDateTime << 32) |
+	                    file_time.dwLowDateTime;
+	// Convert from 100ns intervals since Jan 1, 1601 to Unix epoch
+	uint64_t unix_time = (time_val - WIN32_EPOCH_OFFSET);
+	*out_seconds = (int64_t)(unix_time / WIN32_TICKS_PER_SEC);
+	*out_nanoseconds =
+	    (int64_t)((unix_time % WIN32_TICKS_PER_SEC) * WIN32_NS_PER_TICK);
+#else
+	struct timespec time_spec;
+	if (clock_gettime(CLOCK_REALTIME, &time_spec) != 0) {
+		*out_seconds = 0;
+		*out_nanoseconds = 0;
+		return;
+	}
+	*out_seconds = (int64_t)time_spec.tv_sec;
+	*out_nanoseconds = (int64_t)time_spec.tv_nsec;
+#endif
+}
+
+void platform_sleep_ms(uint32_t milliseconds_to_sleep)
+{
+#ifdef _WIN32
+	Sleep((DWORD)milliseconds_to_sleep);
+#else
+	usleep(milliseconds_to_sleep * US_PER_MS);
+#endif
+}

--- a/src/platform/platform_utils.c
+++ b/src/platform/platform_utils.c
@@ -1,0 +1,59 @@
+#include "platform/platform_utils.h"
+
+#include <stdlib.h>
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+int32_t platform_get_pid(void)
+{
+#ifdef _WIN32
+	return (int32_t)GetCurrentProcessId();
+#else
+	return (int32_t)getpid();
+#endif
+}
+
+uint64_t platform_get_tid(void)
+{
+#ifdef __linux__
+	return (uint64_t)syscall(SYS_gettid);
+#elif defined(_WIN32)
+	return (uint64_t)GetCurrentThreadId();
+#elif defined(__APPLE__)
+	uint64_t tid;
+	pthread_threadid_np(NULL, &tid);
+	return tid;
+#else
+	return 0;  // Fallback
+#endif
+}
+
+void* platform_aligned_alloc(size_t size, size_t alignment)
+{
+	void* ptr = NULL;
+#ifdef _WIN32
+	ptr = _aligned_malloc(size, alignment);
+#else
+	if (posix_memalign(&ptr, alignment, size) != 0) {
+		return NULL;
+	}
+#endif
+	return ptr;
+}
+
+void platform_aligned_free(void* ptr)
+{
+#ifdef _WIN32
+	_aligned_free(ptr);
+#else
+	free(ptr);
+#endif
+}

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -309,6 +309,15 @@ void postprocess_cleanup(PostProcess* post_processing)
 
 void postprocess_resize(PostProcess* post_processing, int width, int height)
 {
+	/* Ensure dimensions are at least 1 to avoid OpenGL errors (e.g., during
+	 * window minimization) */
+	if (width < 1) {
+		width = 1;
+	}
+	if (height < 1) {
+		height = 1;
+	}
+
 	if (post_processing->width == width &&
 	    post_processing->height == height) {
 		return;

--- a/src/scene.c
+++ b/src/scene.c
@@ -8,12 +8,13 @@
 #include "instanced_rendering.h"
 #include "log.h"
 #include "material.h"
+#include "platform/platform_fs.h"
+#include "platform/platform_utils.h"
 #include "render_utils.h"
 #include "shader.h"
 #include "sphere_sorting.h"
 #include "utils.h"
 #include <cglm/cglm.h>
-#include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,41 +33,52 @@ static int compare_strings(const void* string_a, const void* string_b)
 	return strcmp(*(const char**)string_a, *(const char**)string_b);
 }
 
+struct HdrScanContext {
+	Scene* scene;
+};
+
+static void scene_hdr_file_callback(const char* filename, bool is_dir,
+                                    void* user_data)
+{
+	if (is_dir) {
+		return;
+	}
+
+	struct HdrScanContext* ctx = (struct HdrScanContext*)user_data;
+	Scene* scene = ctx->scene;
+
+	const char* dot = strrchr(filename, '.');
+	if (!dot || strcmp(dot, HDR_EXTENSION) != 0) {
+		return;
+	}
+
+	size_t new_count = (size_t)scene->hdr_count + 1;
+	char** new_files = realloc(scene->hdr_files, new_count * sizeof(char*));
+
+	if (!new_files) {
+		LOG_ERROR("suckless-ogl.scene",
+		          "Failed to realloc memory for HDR files");
+		return;
+	}
+
+	scene->hdr_files = new_files;
+	scene->hdr_count++;
+	scene->hdr_files[scene->hdr_count - 1] = strdup(filename);
+}
+
 static void scene_scan_hdr_files(Scene* scene)
 {
 	scene->hdr_count = 0;
 	scene->hdr_files = NULL;
 	scene->current_hdr_index = -1;
 
-	DIR* dir_handle = opendir(HDR_TEXTURE_PATH);
-	if (!dir_handle) {
+	struct HdrScanContext ctx = {scene};
+	if (!platform_dir_list(HDR_TEXTURE_PATH, scene_hdr_file_callback,
+	                       &ctx)) {
 		LOG_ERROR("suckless-ogl.scene",
 		          "Failed to open assets/textures/hdr directory!");
 		return;
 	}
-
-	struct dirent* entry = NULL;
-	while ((entry = readdir(dir_handle)) != NULL) {
-		char* dot = strrchr(entry->d_name, '.');
-		if (!dot || strcmp(dot, HDR_EXTENSION) != 0) {
-			continue;
-		}
-
-		size_t new_count = (size_t)scene->hdr_count + 1;
-		char** new_files =
-		    realloc(scene->hdr_files, new_count * sizeof(char*));
-
-		if (!new_files) {
-			LOG_ERROR("suckless-ogl.scene",
-			          "Failed to realloc memory for HDR files");
-			continue;
-		}
-
-		scene->hdr_files = new_files;
-		scene->hdr_count++;
-		scene->hdr_files[scene->hdr_count - 1] = strdup(entry->d_name);
-	}
-	closedir(dir_handle);
 
 	if (scene->hdr_count > 1) {
 		qsort(scene->hdr_files, (size_t)scene->hdr_count, sizeof(char*),
@@ -86,11 +98,9 @@ static void scene_init_instancing(Scene* scene)
 	const float grid_w = (float)(cols - 1) * spacing;
 	const float grid_h = (float)(rows - 1) * spacing;
 
-	SphereInstance* data = NULL;
-	// NOLINTNEXTLINE(misc-include-cleaner)
-	if (posix_memalign((void**)&data, SIMD_ALIGNMENT,
-	                   sizeof(SphereInstance) * (size_t)total_count) != 0 ||
-	    !data) {
+	SphereInstance* data = (SphereInstance*)platform_aligned_alloc(
+	    sizeof(SphereInstance) * (size_t)total_count, SIMD_ALIGNMENT);
+	if (!data) {
 		LOG_ERROR("suckless-ogl.scene",
 		          "Failed to allocate aligned memory for instancing");
 		return;
@@ -117,11 +127,10 @@ static void scene_init_instancing(Scene* scene)
 	instanced_group_init(&scene->instanced_group, data, total_count);
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
-	// Use posix_memalign for consistency and to avoid implicit declaration
-	// issues
-	void* raw_mem = NULL;
-	if (posix_memalign(&raw_mem, SIMD_ALIGNMENT,
-	                   sizeof(SphereInstance) * (size_t)total_count) == 0) {
+	// Use platform_aligned_alloc for portability and consistency
+	void* raw_mem = platform_aligned_alloc(
+	    sizeof(SphereInstance) * (size_t)total_count, SIMD_ALIGNMENT);
+	if (raw_mem) {
 		scene->sphere_instances = (SphereInstance*)raw_mem;
 		safe_memcpy(scene->sphere_instances,
 		            sizeof(SphereInstance) * (size_t)total_count, data,
@@ -556,7 +565,7 @@ void scene_cleanup(Scene* scene)
 	skybox_cleanup(&scene->skybox);
 #ifdef USE_TRANSPARENT_BILLBOARDS
 	if (scene->sphere_instances) {
-		free(scene->sphere_instances);
+		platform_aligned_free(scene->sphere_instances);
 		scene->sphere_instances = NULL;
 	}
 	sphere_sorter_cleanup(&scene->sphere_sorter);

--- a/src/simd_utils.c
+++ b/src/simd_utils.c
@@ -68,16 +68,16 @@ void convert_float_to_half_simd(const float* src, uint16_t* dst, size_t count)
 static const uint32_t SIGN_MASK = 0x80000000U;
 static const uint32_t EXP_MASK = 0x7F800000U;
 static const uint32_t MANT_MASK = 0x007FFFFFU;
-static const int EXP_SHIFT = 23;
+static const uint32_t EXP_SHIFT = 23U;
 static const int EXP_BIAS_F32 = 127;
 static const int EXP_BIAS_F16 = 15;
 static const int EXP_MAX_F16 = 31;
-static const int EXP_MAX_F32 = 255;
-static const int MANT_SHIFT_DIFF = 13; /* 23 - 10 */
-static const int HALF_MANT_SHIFT = 10;
+static const uint32_t EXP_MAX_F32 = 255U;
+static const uint32_t MANT_SHIFT_DIFF = 13U; /* 23 - 10 */
+static const uint32_t HALF_MANT_SHIFT = 10U;
 static const uint16_t HALF_QNAN_BIT = 0x0200U;
 /* 31 - 15 */
-static const int HALF_SIGN_SHIFT = 16;
+static const uint32_t HALF_SIGN_SHIFT = 16U;
 
 static uint16_t float_to_half_soft(float value)
 {

--- a/src/sphere_sorting.c
+++ b/src/sphere_sorting.c
@@ -3,6 +3,7 @@
 #include "gl_common.h"           /* For SIMD_ALIGNMENT */
 #include "instanced_rendering.h" /* For SphereInstance */
 #include "log.h"
+#include "platform/platform_utils.h"
 #include "shader.h"
 #include <stdbool.h>
 #include <stdlib.h>
@@ -64,32 +65,26 @@ static bool ensure_cpu_capacity(SphereSorter* sorter, int count)
 	void* new_aux = NULL;
 	void* new_temp = NULL;
 
-	if (posix_memalign(&new_entries, SIMD_ALIGNMENT,
-	                   (size_t)count * sizeof(SphereSortEntry)) != 0) {
-		new_entries = NULL;
-	}
-	if (posix_memalign(&new_aux, SIMD_ALIGNMENT,
-	                   (size_t)count * sizeof(SphereSortEntry)) != 0) {
-		new_aux = NULL;
-	}
-	if (posix_memalign(&new_temp, SIMD_ALIGNMENT,
-	                   (size_t)count * sizeof(SphereInstance)) != 0) {
-		new_temp = NULL;
-	}
+	new_entries = platform_aligned_alloc(
+	    (size_t)count * sizeof(SphereSortEntry), SIMD_ALIGNMENT);
+	new_aux = platform_aligned_alloc(
+	    (size_t)count * sizeof(SphereSortEntry), SIMD_ALIGNMENT);
+	new_temp = platform_aligned_alloc(
+	    (size_t)count * sizeof(SphereInstance), SIMD_ALIGNMENT);
 
 	if (!new_entries || !new_aux || !new_temp) {
 		LOG_ERROR("suckless-ogl.sorter",
 		          "CPU sort scratchpad allocation failed");
-		free(new_entries);
-		free(new_aux);
-		free(new_temp);
+		platform_aligned_free(new_entries);
+		platform_aligned_free(new_aux);
+		platform_aligned_free(new_temp);
 		return false;
 	}
 
 	/* These are per-frame scratchpads — no need to preserve old data. */
-	free(sorter->entries);
-	free(sorter->entries_aux);
-	free(sorter->temp_instances);
+	platform_aligned_free(sorter->entries);
+	platform_aligned_free(sorter->entries_aux);
+	platform_aligned_free(sorter->temp_instances);
 
 	sorter->entries = (SphereSortEntry*)new_entries;
 	sorter->entries_aux = (SphereSortEntry*)new_aux;
@@ -148,21 +143,15 @@ void sphere_sorter_init(SphereSorter* sorter, int initial_capacity)
 	sorter->cpu_capacity = sorter->min_capacity;
 
 	/* Pre-allocate scratchpad for CPU sorting with SIMD alignment */
-	if (posix_memalign(
-	        (void**)&sorter->entries, SIMD_ALIGNMENT,
-	        (size_t)sorter->min_capacity * sizeof(SphereSortEntry)) != 0) {
-		sorter->entries = NULL;
-	}
-	if (posix_memalign(
-	        (void**)&sorter->entries_aux, SIMD_ALIGNMENT,
-	        (size_t)sorter->min_capacity * sizeof(SphereSortEntry)) != 0) {
-		sorter->entries_aux = NULL;
-	}
-	if (posix_memalign(
-	        (void**)&sorter->temp_instances, SIMD_ALIGNMENT,
-	        (size_t)sorter->min_capacity * sizeof(SphereInstance)) != 0) {
-		sorter->temp_instances = NULL;
-	}
+	sorter->entries = (SphereSortEntry*)platform_aligned_alloc(
+	    (size_t)sorter->min_capacity * sizeof(SphereSortEntry),
+	    SIMD_ALIGNMENT);
+	sorter->entries_aux = (SphereSortEntry*)platform_aligned_alloc(
+	    (size_t)sorter->min_capacity * sizeof(SphereSortEntry),
+	    SIMD_ALIGNMENT);
+	sorter->temp_instances = (SphereInstance*)platform_aligned_alloc(
+	    (size_t)sorter->min_capacity * sizeof(SphereInstance),
+	    SIMD_ALIGNMENT);
 }
 
 void sphere_sorter_cleanup(SphereSorter* sorter)
@@ -171,9 +160,9 @@ void sphere_sorter_cleanup(SphereSorter* sorter)
 	GL_SAFE_DELETE_BUFFER(sorter->index_ssbo);
 	GL_SAFE_DELETE_BUFFER(sorter->sorted_instance_ssbo);
 	GL_SAFE_DELETE_PROGRAM(sorter->compute_program);
-	free(sorter->entries);
-	free(sorter->entries_aux);
-	free(sorter->temp_instances);
+	platform_aligned_free(sorter->entries);
+	platform_aligned_free(sorter->entries_aux);
+	platform_aligned_free(sorter->temp_instances);
 	sorter->entries = NULL;
 	sorter->entries_aux = NULL;
 	sorter->temp_instances = NULL;

--- a/src/window.c
+++ b/src/window.c
@@ -25,6 +25,7 @@ GLFWwindow* window_create(int width, int height, const char* title, int samples)
 	if (samples > 1) {
 		glfwWindowHint(GLFW_SAMPLES, samples);
 	}
+	glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
 
 	GLFWwindow* window = glfwCreateWindow(width, height, title, NULL, NULL);
 	if (!window) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,19 @@
 # CONFIGURATION COMMUNE
 # =============================================================================
 
-set(TEST_COMMON_LIBS unity cglm glad cjson ${GLFW3_LIBRARIES} m dl)
-set(TEST_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/include ${stb_SOURCE_DIR} ${cjson_SOURCE_DIR})
+set(TEST_COMMON_LIBS unity cglm glad cjson ${GLFW3_LIBRARIES} Threads::Threads)
+if(UNIX)
+    list(APPEND TEST_COMMON_LIBS m dl)
+endif()
+set(TEST_INCLUDE_DIRS
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${cjson_SOURCE_DIR}
+    ${glfw_SOURCE_DIR}/include
+    ${glad_BINARY_DIR}/include
+    ${cglm_SOURCE_DIR}/include
+)
 
 if(ENABLE_TRACY)
     list(APPEND TEST_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/deps/tracy/public")
@@ -65,6 +76,16 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_sh_integration\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_coordinator\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_loader\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_security\\.c$")
+
+# Exclure les tests spécifiques à POSIX sur Windows
+if(WIN32)
+    message(STATUS "Excluding POSIX-only tests from Windows build")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_log\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_loader_perf\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_api\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_uniforms_loc\\.c$")
+endif()
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)
 set(OPENGL_TESTS
@@ -273,6 +294,8 @@ add_executable(test_gpu_profiler_repro
     ${CMAKE_SOURCE_DIR}/src/tracy_log.c
     ${CMAKE_SOURCE_DIR}/src/metric_stack.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_time.c
 )
 if(ENABLE_TRACY)
     target_sources(test_gpu_profiler_repro PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
@@ -354,6 +377,8 @@ add_executable(test_ibl_coordinator
     ${CMAKE_SOURCE_DIR}/src/log.c
     ${CMAKE_SOURCE_DIR}/src/tracy_log.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_time.c
 )
 if(ENABLE_TRACY)
     target_sources(test_ibl_coordinator PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
@@ -384,7 +409,9 @@ add_executable(test_benchmark_sphere_sorting
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_shader_compute.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
 )
+target_sources(test_benchmark_sphere_sorting PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
 
 target_include_directories(test_benchmark_sphere_sorting PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks
@@ -436,7 +463,9 @@ add_executable(test_sphere_sorting
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
     ${CMAKE_SOURCE_DIR}/src/sphere_sorting.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
 )
+target_sources(test_sphere_sorting PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
 target_include_directories(test_sphere_sorting PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
@@ -457,6 +486,7 @@ add_executable(test_benchmark_sphere_sorting_perf
     ${CMAKE_SOURCE_DIR}/src/sphere_sorting.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
 )
+target_sources(test_benchmark_sphere_sorting_perf PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
 target_include_directories(test_benchmark_sphere_sorting_perf PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
@@ -517,7 +547,8 @@ target_include_directories(test_async_coordinator PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/include
     ${unity_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/_deps/glad-build/include
+    ${glad_BINARY_DIR}/include
+    ${glfw_SOURCE_DIR}/include
 )
 target_link_libraries(test_async_coordinator PRIVATE cglm m)
 add_test(NAME test_async_coordinator COMMAND test_async_coordinator)
@@ -531,17 +562,23 @@ add_executable(test_async_loader
     ${CMAKE_SOURCE_DIR}/src/async_loader.c
     ${CMAKE_SOURCE_DIR}/src/perf_timer.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_time.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
 )
 target_include_directories(test_async_loader PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/include
     ${unity_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/_deps/glad-build/include
+    ${glad_BINARY_DIR}/include
     ${stb_SOURCE_DIR}
 )
 target_compile_definitions(test_async_loader PRIVATE GL_COMMON_NO_GLFW GL_COMMON_NO_GLAD)
-target_link_libraries(test_async_loader PRIVATE cglm m pthread dl)
+if(UNIX)
+    target_link_libraries(test_async_loader PRIVATE cglm m pthread dl)
+else()
+    target_link_libraries(test_async_loader PRIVATE cglm pthread)
+endif()
 add_test(NAME test_async_loader COMMAND test_async_loader)
 # =============================================================================
 # TEXTURE SECURITY TEST (MOCKED)
@@ -555,15 +592,21 @@ add_executable(test_texture_security
     ${CMAKE_SOURCE_DIR}/src/utils.c
     ${CMAKE_SOURCE_DIR}/src/io.c
     ${CMAKE_SOURCE_DIR}/src/stb_image_impl.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_time.c
 )
 target_include_directories(test_texture_security PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/include
     ${unity_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/_deps/glad-build/include
+    ${glad_BINARY_DIR}/include
     ${stb_SOURCE_DIR}
 )
 target_compile_definitions(test_texture_security PRIVATE GL_COMMON_NO_GLFW GL_COMMON_NO_GLAD)
-target_link_libraries(test_texture_security PRIVATE cglm m pthread dl)
+if(UNIX)
+    target_link_libraries(test_texture_security PRIVATE cglm m pthread dl)
+else()
+    target_link_libraries(test_texture_security PRIVATE cglm pthread)
+endif()
 add_test(NAME test_texture_security COMMAND test_texture_security)

--- a/tests/test_async_loader.c
+++ b/tests/test_async_loader.c
@@ -9,6 +9,7 @@
 #include "async_loader.h"
 #include "gl_common.h"
 #include "log.h"
+#include "platform/platform_time.h"
 #include "profiler.h"
 #include <pthread.h>
 #include <stdbool.h>
@@ -123,10 +124,7 @@ void gpu_profiler_end_stage(GPUProfiler* profiler)
 
 static void sleep_ms(long milliseconds)
 {
-	struct timespec req;
-	req.tv_sec = milliseconds / 1000L;
-	req.tv_nsec = (milliseconds % 1000L) * 1000000L;
-	nanosleep(&req, NULL);
+	platform_sleep_ms((uint32_t)milliseconds);
 }
 
 /* --- Tests --- */

--- a/tests/test_benchmark_sphere_sorting_perf.c
+++ b/tests/test_benchmark_sphere_sorting_perf.c
@@ -1,6 +1,6 @@
-#define _POSIX_C_SOURCE 200809L
 #include "gl_common.h"
 #include "instanced_rendering.h"
+#include "platform/platform_utils.h"
 #include "sphere_sorting.h"
 #include <cglm/cglm.h>
 #include <stdio.h>
@@ -98,13 +98,14 @@ int main(void)
 	SphereInstance* instances_baseline = NULL;
 	SphereInstance* instances_optimized = NULL;
 
-	if (posix_memalign((void**)&instances_baseline, SIMD_ALIGNMENT,
-	                   COUNT * sizeof(SphereInstance)) != 0) {
-		return 1;
-	}
-	if (posix_memalign((void**)&instances_optimized, SIMD_ALIGNMENT,
-	                   COUNT * sizeof(SphereInstance)) != 0) {
-		free(instances_baseline);
+	instances_baseline = (SphereInstance*)platform_aligned_alloc(
+	    COUNT * sizeof(SphereInstance), SIMD_ALIGNMENT);
+	instances_optimized = (SphereInstance*)platform_aligned_alloc(
+	    COUNT * sizeof(SphereInstance), SIMD_ALIGNMENT);
+
+	if (!instances_baseline || !instances_optimized) {
+		platform_aligned_free(instances_baseline);
+		platform_aligned_free(instances_optimized);
 		return 1;
 	}
 
@@ -153,8 +154,8 @@ int main(void)
 	sphere_sorter_cleanup(&sorter_optimized);
 
 	/* Free the buffers we allocated initially */
-	free(instances_baseline);
-	free(instances_optimized);
+	platform_aligned_free(instances_baseline);
+	platform_aligned_free(instances_optimized);
 
 	return 0;
 }

--- a/tests/test_sphere_sorting.c
+++ b/tests/test_sphere_sorting.c
@@ -1,5 +1,4 @@
-// tests/test_sphere_sorting.c
-#define _POSIX_C_SOURCE 200809L /* For posix_memalign */
+#include "platform/platform_utils.h"
 #include "sphere_sorting.h"
 #include "unity.h"
 #include <cglm/cglm.h>
@@ -33,12 +32,12 @@ static SphereInstance* create_dummy_instances(int count, int min_capacity)
 {
 	int alloc_count = (count > min_capacity) ? count : min_capacity;
 	SphereInstance* instances = NULL;
-	/* Use posix_memalign to match sorter allocation strategy (safe for
-	 * swapping) */
+	/* Use platform_aligned_alloc to match sorter allocation strategy */
 	/* SIMD_ALIGNMENT is available via sphere_sorting.h ->
 	 * instanced_rendering.h -> gl_common.h */
-	if (posix_memalign((void**)&instances, SIMD_ALIGNMENT,
-	                   (size_t)alloc_count * sizeof(SphereInstance)) != 0) {
+	instances = (SphereInstance*)platform_aligned_alloc(
+	    (size_t)alloc_count * sizeof(SphereInstance), SIMD_ALIGNMENT);
+	if (!instances) {
 		return NULL;
 	}
 	memset(instances, 0, (size_t)alloc_count * sizeof(SphereInstance));
@@ -145,7 +144,7 @@ void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
 	TEST_ASSERT_FLOAT_WITHIN(TOLERANCE, ROUGHNESS_A,
 	                         sorter.temp_instances[2].roughness);
 
-	free(instances);
+	platform_aligned_free(instances);
 	sphere_sorter_cleanup(&sorter);
 }
 
@@ -195,7 +194,7 @@ void test_SphereSorter_SortRadix_ShouldOrderBackToFront(void)
 	TEST_ASSERT_FLOAT_WITHIN(TOLERANCE, ROUGHNESS_A,
 	                         sorter.temp_instances[2].roughness);
 
-	free(instances);
+	platform_aligned_free(instances);
 	sphere_sorter_cleanup(&sorter);
 }
 
@@ -216,7 +215,7 @@ void test_SphereSorter_Resize_ShouldHandleMoreThanCapacity(void)
 	/* Check that capacity grew */
 	TEST_ASSERT_GREATER_OR_EQUAL(count, sorter.cpu_capacity);
 
-	free(instances);
+	platform_aligned_free(instances);
 	sphere_sorter_cleanup(&sorter);
 }
 
@@ -241,7 +240,7 @@ void test_SphereSorter_CapacitySync_ShouldNotCrash(void)
 
 	TEST_ASSERT_GREATER_OR_EQUAL(count, sorter.cpu_capacity);
 
-	free(instances);
+	platform_aligned_free(instances);
 	sphere_sorter_cleanup(&sorter);
 }
 

--- a/toolchain-mingw.cmake
+++ b/toolchain-mingw.cmake
@@ -1,0 +1,28 @@
+# CMake Toolchain file for Cross-Compiling to Windows using MinGW
+#
+# Usage:
+# cmake -DCMAKE_TOOLCHAIN_FILE=toolchain-mingw.cmake ..
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+# Target triple
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# Cross compilers
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# Search paths for dependencies
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# Adjust the search behavior:
+# Search for programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# Search for headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Optional: Link everything statically for easier deployment under Wine/Windows
+# set(CMAKE_EXE_LINKER_FLAGS "-static")


### PR DESCRIPTION
## Description

Cette Pull Request introduit le support de la compilation croisée pour Windows (via MinGW) et inclut plusieurs correctifs de portabilité pour assurer la compatibilité inter-systèmes (Linux & Windows). Le code a été restructuré pour abstraire les appels POSIX, et des solutions de contournement ont été mises en place pour stabiliser l'expérience utilisateur sous Wine.

## Run
<img width="1021" height="803" alt="image" src="https://github.com/user-attachments/assets/b7dc4c67-2c81-4172-aef8-66f09103c601" />

```shell

suckless-ogl [ feat/pal/windows][$][△ v3.31.6][⏱ 2s]
❯ just run-win
-- SSBO rendering: DISABLED (using legacy instanced rendering)
-- Offline mode: Checking for local dependencies in /home/latty/Prog/__PERSO__/suckless-ogl/deps
[...]
-- Fetching cglm...
-- Fetching glad...
-- Fetching stb...
-- Forcing GLFW3 FetchContent for IDE compatibility...
-- Using Win32 for window creation
-- Fetching cJSON...
-- LTO (IPO) is supported and enabled for Profiling/Release
-- Native Architecture Optimization: DISABLED (Cross-compiling)
-- GameMode not available - using native scheduling fallback
-- Excluding POSIX-only tests from Windows build
[...]
[48%] Linking CXX executable app.exe
[...]
it looks like wine32 is missing, you should install it.
multiarch needs to be enabled first.  as root, please
execute "dpkg --add-architecture i386 && apt-get update &&
apt-get install wine32:i386"
2026-03-05 17:36:48,271 [32:36] - OpenGL Debug - INFO     - OpenGL Debug Callback initialized (High Sensitivity)
2026-03-05 17:36:48,292 [32:36] - suckless-ogl.window - INFO     - Context Version: 4.6
2026-03-05 17:36:48,309 [32:36] - suckless-ogl.window - INFO     - Renderer: Mesa Intel(R) Iris(R) Xe Graphics (RPL-U)
2026-03-05 17:36:48,336 [32:36] - suckless-ogl.window - INFO     - Version: 4.6 (Core Profile) Mesa 25.0.7-2
2026-03-05 17:36:48,359 [32:36] - suckless-ogl.async - INFO     - Async loader initialized.
2026-03-05 17:36:48,396 [32:36] - OpenGL Debug - INFO     - id: 0x0, source: Application, type: Push Group, severity: Notification, message: IBL: BRDF LUT
2026-03-05 17:36:48,488 [32:36] - perf.hybrid - INFO     - IBL: BRDF LUT: [CPU: 29.71 ms] [GPU: 91.855 ms]
2026-03-05 17:36:48,517 [32:36] - suckless-ogl.scene - INFO     - Found 5 HDR files.
2026-03-05 17:36:48,542 [32:36] - Shader - INFO     - Linked shader program 'shaders/background.vert + shaders/background.frag' (ID 3). Binary size: 6317 bytes
2026-03-05 17:36:48,571 [32:36] - Shader - INFO     - Linked shader program 'shaders/debug_tex.vert + shaders/debug_tex.frag' (ID 6). Binary size: 5233 bytes
2026-03-05 17:36:48,602 [32:36] - Shader - INFO     - Linked shader program 'shaders/debug_line.vert + shaders/debug_line.frag' (ID 9). Binary size: 9853 bytes
2026-03-05 17:36:48,644 [32:36] - Shader - INFO     - Linked shader program 'shaders/pbr_ibl_billboard.vert + shaders/pbr_ibl_billboard.frag' (ID 12). Binary size: 56173 bytes
2026-03-05 17:36:48,671 [32:36] - material - INFO     - Loaded 100 material presets
2026-03-05 17:36:48,717 [32:36] - Shader - INFO     - Linked shader program 'shaders/pbr_ibl_instanced.vert + shaders/pbr_ibl_instanced.frag' (ID 25). Binary size: 51041 bytes
2026-03-05 17:36:48,741 [32:36] - suckless-ogl.env - INFO     - Queuing async load for: assets/textures/hdr/abandoned_garage_4k.hdr
2026-03-05 17:36:48,769 [32:36] - Shader - INFO     - Linked shader program 'shaders/ui.vert + shaders/ui.frag' (ID 28). Binary size: 5693 bytes
2026-03-05 17:36:48,803 [32:36] - Shader - INFO     - Linked shader program 'shaders/ui_spinner.vert + shaders/ui_spinner.frag' (ID 31). Binary size: 6581 bytes
2026-03-05 17:36:48,846 [32:36] - ui - INFO     - UI system initialized successfully
2026-03-05 17:36:48,884 [32:36] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_prefilter.frag' (ID 38). Binary size: 4533 bytes
2026-03-05 17:36:48,950 [32:36] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_downsample.frag' (ID 41). Binary size: 5601 bytes
2026-03-05 17:36:49,008 [32:36] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/bloom_upsample.frag' (ID 44). Binary size: 4941 bytes
2026-03-05 17:36:49,076 [32:36] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/postprocess.frag' (ID 47). Binary size: 28129 bytes
2026-03-05 17:36:49,109 [32:36] - suckless-ogl.postprocess - INFO     - Compiled OPTIMIZED shader with effects:
2026-03-05 17:36:49,134 [32:36] - suckless-ogl.postprocess - INFO     -   â Manual Exposure
2026-03-05 17:36:49,156 [32:36] - suckless-ogl.postprocess - INFO     -   â Color Grading
2026-03-05 17:36:49,177 [32:36] - suckless-ogl.postprocess - INFO     -   â FXAA
2026-03-05 17:36:49,194 [32:36] - suckless-ogl.postprocess - INFO     - Shader optimization complete (Flags: 0x00001024)
2026-03-05 17:36:49,224 [32:36] - Shader - INFO     - Linked shader program 'shaders/postprocess.vert + shaders/lum_downsample.frag' (ID 50). Binary size: 7281 bytes
2026-03-05 17:36:49,230 [32:304] - suckless-ogl.texture - INFO     - HDR image loaded (CPU): 4096x2048, channels=3
2026-03-05 17:36:49,260 [32:36] - suckless-ogl.postprocess - INFO     - Post-processing initialized (1024x768)
2026-03-05 17:36:49,307 [32:36] - suckless-ogl.postprocess - INFO     - Dummy texture set: 1
2026-03-05 17:36:49,324 [32:36] - suckless-ogl.perf - WARNING  - No performance optimization backend available
2026-03-05 17:36:49,351 [32:36] - suckless-ogl.perf - INFO     - Performance mode initialized (backend: None)
2026-03-05 17:36:49,471 [32:304] - simd_utils - WARNING  - SIMD Optimization: Software Fallback (No F16C/AVX) - VERY SLOW
2026-03-05 17:36:49,500 [32:36] - suckless-ogl.texture - INFO     - Pre-allocated HDR texture 27 (4096x2048, base level only)
2026-03-05 17:36:49,729 [32:304] - suckless-ogl.async - INFO     - Finished loading & converting: assets/textures/hdr/abandoned_garage_4k.hdr
2026-03-05 17:36:49,774 [32:36] - suckless-ogl.env - INFO     - Finalizing environment load (Step 1/3): Upload...
2026-03-05 17:36:49,804 [32:36] - suckless-ogl.texture - INFO     - Reusing cached HDR texture ID 27 (4096x2048)
2026-03-05 17:36:49,842 [32:36] - suckless-ogl.env - INFO     - Finalizing environment load (Step 2/3): Mipmaps...
2026-03-05 17:36:49,919 [32:36] - suckless-ogl.env - INFO     - Finalizing environment load (Step 3/3): Start IBL...
2026-03-05 17:36:49,958 [32:36] - suckless-ogl.ibl - INFO     - [Frame 143] - Luminance...
2026-03-05 17:36:49,992 [32:36] - perf.hybrid - INFO     - IBL: Luminance Reduction Start: [CPU: 0.44 ms] [GPU: 3.245 ms]
2026-03-05 17:36:50,034 [32:36] - perf.hybrid - INFO     - Progressive IBL: Luminance: [CPU: 76.31 ms] [GPU: 76.301 ms]
2026-03-05 17:36:50,122 [32:36] - suckless-ogl.ibl - INFO     - [Frame 144] Progressive IBL: Luminance Wait â wall: 164.20 ms
2026-03-05 17:36:50,169 [32:36] - suckless-ogl.ibl - INFO     - [Frame 146] - Specular Init...
2026-03-05 17:36:50,704 [32:36] - suckless-ogl.ibl - INFO     - [Frame 180] Progressive IBL: Specular â 34 slices, GPU min/avg/max: 8.25 / 12.34 / 19.09 ms, GPU total: 419.43 ms, wall: 497.65 ms
2026-03-05 17:36:51,073 [32:36] - suckless-ogl.ibl - INFO     - [Frame 192] Progressive IBL: Irradiance â 12 slices, GPU min/avg/max: 0.17 / 20.06 / 25.01 ms, GPU total: 240.74 ms, wall: 303.37 ms
2026-03-05 17:36:51,142 [32:36] - suckless-ogl.env - INFO     - [Frame 192] Environment swap finalized.
2026-03-05 17:36:56,818 [32:36] - suckless-ogl.app - INFO     - Text Overlay: FPS + Position
2026-03-05 17:37:15,189 [32:36] - ui - INFO     - UI system destroyed
2026-03-05 17:37:15,219 [32:36] - suckless-ogl.postprocess - INFO     - Post-processing cleaned up
2026-03-05 17:37:15,257 [32:36] - suckless-ogl.async - INFO     - Async loader destroyed.
2026-03-05 17:37:15,287 [32:36] - material - INFO     - Material library memory freed successfully.
2026-03-05 17:37:15,324 [32:36] - suckless-ogl.perf - INFO     - Performance mode cleaned up
```

## Changements Principaux

### 🏗️ Build & Compilation Croisée ([CMakeLists.txt](tests/CMakeLists.txt:0:0-0:0))
- **Isolation des tests POSIX** : Les tests unitaires strictement liés à POSIX (`sys/resource.h`, `unistd.h`) sont désormais exclus lors d'un build Windows.
- **Liaison Conditionnelle** : Les drapeaux d'édition de liens spécifiques à Linux (`-rdynamic`, `m`, [dl](src/app_input.c:232:0-253:1), etc.) sont correctement protégés dans des blocs conditionnels `if(UNIX AND NOT APPLE)`.
- **Dépendances de Tests** : Les tests utilisant des mocks (ex: `test_async_loader`) lient désormais explicitement les modules PAL (Platform Abstraction Layer) tels que [platform_time.c](src/platform/platform_time.c:0:0-0:0) et `platform_utils.c` pour résoudre les erreurs de références non définies (`platform_sleep_ms`).

### 🔧 Portabilité & Core (PAL)
- **Corrections SIMD** : Casts appliqués dans [simd_utils.c](src/simd_utils.c:0:0-0:0) pour corriger des erreurs de compilation/linting liées aux opérations binaires sur des entiers signés (`hicpp-signed-bitwise`).
- **Gestion du Focus sous Wine** :
  - **Désautominimisation** : Ajout de l'indication `glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE)` pour éviter que la fenêtre ne se réduise automatiquement lors d'une perte de focus.
  - **Recapture de Souris (Workaround)** : Implémentation d'une réinitialisation explicite du mode du curseur (`GLFW_CURSOR_NORMAL` -> recentrage forcé -> `GLFW_CURSOR_DISABLED`) lors des transitions Plein Écran / Fenêtré pour forcer l'OS/Wine à récupérer le focus de la souris.

### 📚 Documentation
- Mise à jour du document [docs/portability_pal.md](docs/portability_pal.md:0:0-0:0) pour refléter :
  - Les ajustements liés à la compilation croisée avec MinGW.
  - Les limitations connues et les correctifs appliqués concernant la gestion du plein écran sous Wine.

## Tests Effectués
- [x] Commandes `just build` (natif Linux) et `just build-win` (croisé Windows) s'exécutent avec succès.
- [x] `just lint` (Clang-Tidy + Ruff) et `just format` (Clang-Format + Ruff) passent sans aucune erreur.
- [x] Vérification du comportement du curseur sous Windows/Wine via l'exécutable généré.
