### PR TITLE
Fix: Post-Processing Regressions and Histogram Debug Stability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,6 @@ jobs:
 
   # --- NEW JOB : TESTS WINDOWS (WINE) ---
   test-windows:
-    needs: [lint-and-format]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,9 @@ if(ENABLE_SHADER_OPTIMIZATION)
     message(STATUS "Shader Optimization: ENABLED (Static compile)")
 endif()
 
+# Option pour activer les tests
+option(BUILD_TESTS "Build and enable unit tests" ON)
+
 # Tracy Profiler Integration
 option(ENABLE_TRACY "Enable Tracy Profiler integration" OFF)
 if(ENABLE_TRACY)
@@ -451,7 +454,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # --- Unit Testing ---
-if(NOT ENABLE_TRACY)
+if(BUILD_TESTS AND NOT ENABLE_TRACY)
     enable_testing()
 
     # --- Code Coverage ---

--- a/docs/auto_exposure_debug_histogram.md
+++ b/docs/auto_exposure_debug_histogram.md
@@ -1,0 +1,53 @@
+# Auto Exposure Debug Histogram
+
+This document details the implementation and testing of the luminance histogram displayed in the "Auto Exposure Debug" view.
+
+## Overview
+
+The Auto Exposure Debug view provides a real-time visualization of the scene's luminance distribution. This is essential for tuning auto-exposure parameters such as `min_luminance`, `max_luminance`, and `key_value`.
+
+### Key Features
+- **Real-time Histogram**: Displays the distribution of luminance across 256 buckets.
+- **PBO Integration**: Uses Pixel Buffer Objects (PBOs) for asynchronous readback from VRAM to RAM, minimizing CPU stalls.
+- **Continuity Caching**: Implements a cache to ensure the histogram display remains stable even when the GPU is slow to update the data.
+- **Independence from AE State**: The histogram calculation and rendering are automatically triggered when the debug view is active, even if the actual Auto Exposure effect is disabled.
+
+## Technical Implementation
+
+### 1. Luminance Downsampling
+Before the histogram can be calculated, the scene is downsampled to a 64x64 texture (`LUM_HISTOGRAM_MAP_SIZE`) where each texel represents the log-luminance of a block of pixels.
+- **Shader**: `shaders/lum_downsample.frag`
+
+### 2. Asynchronous Readback (PBO)
+Instead of a direct `glGetTexImage` (which is a blocking operation), the readback is requested at the end of the post-processing pass and collected in subsequent frames.
+- **Double Buffering**: Two PBOs (`histogram_pbo[2]`) are used to alternate between request and readback frames.
+- **Sync Objects**: `glFenceSync` is used to track when the GPU has finished writing to the PBO.
+
+### 3. Caching & Continuity Logic
+To avoid the UI flickering when a frame's readback isn't ready, the system keeps the last successfully calculated histogram data in a cache.
+- **Cache Fields** (`PostProcess` struct):
+  - `last_buckets[256]`
+  - `last_min_lum`
+  - `last_max_lum`
+  - `last_histogram_updated` (flag)
+
+When `postprocess_compute_luminance_histogram` is called:
+1. It checks if the current PBO sync object is signaled.
+2. If signaled:
+   - It maps the PBO and zeros out the `last_buckets` cache.
+   - It re-calculates the histogram from the new data.
+   - It unmaps the PBO and updates the cache timestamp/flag.
+3. It always returns the contents of the cache if `last_histogram_updated` is true, providing a seamless visual experience.
+
+## Testing Strategy
+
+A dedicated test suite `tests/test_auto_exposure_debug.c` ensures the robustness of this system.
+
+### Test Cases
+- **`test_histogram_caching_and_continuity`**: Verifies that the cache correctly provides data when the sync object is not yet signaled, and updates correctly when it is.
+- **`test_histogram_auto_trigger_when_ae_off`**: Confirms that enabling `POSTFX_EXPOSURE_DEBUG` automatically triggers the `fx_auto_exposure_render` pass inside `postprocess_end`, ensuring live data is available even if Auto Exposure is OFF.
+- **`test_histogram_cache_no_accumulation`**: Ensures that the `last_buckets` cache is properly cleared before being filled with new data, preventing values from "climbing" or stagnating over time.
+
+## Visual Verification
+
+When active, the histogram shows a dynamic bar chart. If the scene changes (e.g., looking at a light source), the histogram should shift instantly to the right. The caching mechanism ensures this movement is smooth without dropped frames or flickering to zero.

--- a/docs/exposure_analysis.md
+++ b/docs/exposure_analysis.md
@@ -167,3 +167,5 @@ digraph AutoExposure {
   Scene -> Final [color="#7aa2f7", penwidth=2.5, label="LDR Path"];
 }
 ```
+
+**[> Read the Auto Exposure Debug Histogram Documentation](auto_exposure_debug_histogram.md)**

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@
 - **Performance Mode**: Adaptive optimization (GameMode/Native) for maximum frame stability. [See Documentation](perf_and_notifications.md).
 - **Isolated Environment**: Native `distrobox` support to guarantee a reproducible build environment.
 - **Quality & Testing**: Unit testing suite, code coverage, static analysis, and [Standalone Mocking](standalone_testing_mocking.md).
+- **Post-Processing Pipeline**: Advanced stack including [Auto-Exposure](exposure_analysis.md), [Bloom](postprocess_optimizations_2026-02.md), and [Debug Histograms](auto_exposure_debug_histogram.md).
 
 ## 🛠️ Compilation and Usage
 

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -21,6 +21,7 @@
 #include <cglm/types.h>
 
 /* --- DEFAULT VALUES --- */
+#define POSTPROCESS_HISTOGRAM_BUCKETS 256
 
 #define DEFAULT_VIGNETTE_INTENSITY 0.8F  /**< Default vignette strength. */
 #define DEFAULT_VIGNETTE_SMOOTHNESS 0.5F /**< Default vignette falloff. */
@@ -353,6 +354,7 @@ typedef struct PostProcess {
 	float time;             /**< Accumulated time for noise/animation. */
 	float delta_time;       /**< Last frame delta. */
 	GLuint dummy_black_tex; /**< Fallback texture. */
+	GLuint dummy_uint_tex;
 
 	bool is_optimized; /**< true if Uber-shader uses static preprocessor
 	                      flags. */
@@ -379,6 +381,13 @@ typedef struct PostProcess {
 
 	float current_exposure; /**< Cached exposure from GPU readback. */
 	float auto_threshold;   /**< Dynamic exposure target. */
+
+	/* --- Histogram Cache (Avoid UI flickering) --- */
+	int last_buckets[POSTPROCESS_HISTOGRAM_BUCKETS];
+	float last_min_lum;
+	float last_max_lum;
+	int last_histogram_updated;
+
 	uint64_t frame_count; /**< Internal frame counter for readback sync. */
 } PostProcess;
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,8 +114,10 @@ nav:
     - Specular Anti-Aliasing: specular_aa.md
     - Banding & Dithering: banding.md
     - Exposure Analysis: exposure_analysis.md
+    - Debug Histogram: auto_exposure_debug_histogram.md
     - Photographic Standards: photographic_standards.md
     - Environment Transitions: env_transitions.md
+    - Post-Process Optimizations (Feb 2026): postprocess_optimizations_2026-02.md
   - "Controls & Input":
     - Mouse Control: mouse_camera_control.md
     - Keyboard System: keyboard_system.md

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -211,6 +211,16 @@ int postprocess_init(PostProcess* post_processing,
 	LOG_INFO("suckless-ogl.postprocess",
 	         "Post-processing initialized (%dx%d)", width, height);
 
+	/* Create dummy uint texture for stencil */
+	post_processing->dummy_uint_tex =
+	    render_utils_create_texture_2d(1, 1, GL_R8UI, 1, "Dummy Stencil");
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, post_processing->dummy_uint_tex);
+	uint32_t zero = 0;
+	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 1, 1, GL_RED_INTEGER,
+	                GL_UNSIGNED_INT, &zero);
+	glBindTexture(GL_TEXTURE_2D, 0);
+
 	return 1;
 }
 
@@ -279,6 +289,11 @@ void postprocess_cleanup(PostProcess* post_processing)
 {
 	if (!post_processing) {
 		return;
+	}
+
+	if (post_processing->dummy_uint_tex) {
+		glDeleteTextures(1, &post_processing->dummy_uint_tex);
+		post_processing->dummy_uint_tex = 0;
 	}
 
 	destroy_readback_buffers(post_processing);
@@ -367,6 +382,27 @@ void postprocess_resize(PostProcess* post_processing, int width, int height)
 
 static void postprocess_on_state_change(PostProcess* post_processing)
 {
+	/* Clear stale sync objects if effect was disabled to prevent stalls
+	 * when re-enabling */
+	if (!postprocess_is_enabled(post_processing, POSTFX_AUTO_EXPOSURE)) {
+		for (int i = 0; i < 2; i++) {
+			if (post_processing->exposure_sync[i]) {
+				glDeleteSync(post_processing->exposure_sync[i]);
+				post_processing->exposure_sync[i] = NULL;
+			}
+		}
+	}
+	if (!postprocess_is_enabled(post_processing, POSTFX_EXPOSURE_DEBUG)) {
+		for (int i = 0; i < 2; i++) {
+			if (post_processing->histogram_sync[i]) {
+				glDeleteSync(
+				    post_processing->histogram_sync[i]);
+				post_processing->histogram_sync[i] = NULL;
+			}
+		}
+	}
+
+	post_processing->ubo_dirty = true;
 	if (post_processing->is_optimized) {
 		if (post_processing->active_effects ==
 		    post_processing->compiled_flags) {
@@ -627,24 +663,47 @@ void postprocess_end(PostProcess* post_processing)
 		fx_dof_render(post_processing);
 	}
 
-	/* Auto Exposure Pass */
-	if (postprocess_is_enabled(post_processing, POSTFX_AUTO_EXPOSURE)) {
-		// TODO: use RAII here !
+	/* Auto Exposure Pass & Debug Histogram */
+	bool ae_active =
+	    postprocess_is_enabled(post_processing, POSTFX_AUTO_EXPOSURE);
+	bool debug_active =
+	    postprocess_is_enabled(post_processing, POSTFX_EXPOSURE_DEBUG);
+
+	if (ae_active || debug_active) {
 		GPU_STAGE_PROFILER(post_processing->gpu_profiler,
 		                   "Auto Exposure",
 		                   GPU_PROFILER_AUTO_EXPOSURE_COLOR);
+
+		/* We always need the downsample/luminance pass if either AE or
+		 * Debug is on */
 		fx_auto_exposure_render(post_processing);
 
-		/* Trigger Async Readback for current frame (will be ready in
+		/* Trigger Async Readbacks for current frame (will be ready in
 		 * next frames) */
 		int write_idx = (int)((post_processing->frame_count + 1) % 2);
-		glBindBuffer(GL_PIXEL_PACK_BUFFER,
-		             post_processing->exposure_pbo[write_idx]);
-		glBindTexture(GL_TEXTURE_2D,
-		              post_processing->auto_exposure_fx.exposure_tex);
-		glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
-		post_processing->exposure_sync[write_idx] =
-		    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+
+		if (ae_active && !post_processing->exposure_sync[write_idx]) {
+			glBindBuffer(GL_PIXEL_PACK_BUFFER,
+			             post_processing->exposure_pbo[write_idx]);
+			glBindTexture(
+			    GL_TEXTURE_2D,
+			    post_processing->auto_exposure_fx.exposure_tex);
+			glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
+			post_processing->exposure_sync[write_idx] =
+			    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+		}
+
+		if (debug_active &&
+		    !post_processing->histogram_sync[write_idx]) {
+			glBindBuffer(GL_PIXEL_PACK_BUFFER,
+			             post_processing->histogram_pbo[write_idx]);
+			glBindTexture(
+			    GL_TEXTURE_2D,
+			    post_processing->auto_exposure_fx.downsample_tex);
+			glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_FLOAT, 0);
+			post_processing->histogram_sync[write_idx] =
+			    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+		}
 
 		glBindTexture(GL_TEXTURE_2D, 0);
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
@@ -720,9 +779,10 @@ void postprocess_end(PostProcess* post_processing)
 		glBindTexture(GL_TEXTURE_2D, post_processing->dof_fx.blur_tex);
 
 		/* Bind Stencil Texture View (Unit 7) */
-		glActiveTexture(GL_TEXTURE0 + POSTPROCESS_TEX_UNIT_STENCIL);
-		glBindTexture(GL_TEXTURE_2D,
-		              post_processing->scene_stencil_view);
+		render_utils_bind_texture_safe(
+		    GL_TEXTURE0 + POSTPROCESS_TEX_UNIT_STENCIL,
+		    post_processing->scene_stencil_view,
+		    post_processing->dummy_uint_tex);
 
 		/* Upload UBO: always update time/effects header, full rebuild
 		 * only when parameters changed (ubo_dirty). */
@@ -839,6 +899,13 @@ void postprocess_end(PostProcess* post_processing)
 
 		/* Dessiner le quad */
 		glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
+
+		/* Cleanup texture unit bindings to avoid leaking state into UI
+		 * or next frame, which can trigger driver validation warnings.
+		 */
+		render_utils_reset_texture_units(
+		    0, POSTPROCESS_TEX_UNIT_STENCIL + 1,
+		    post_processing->dummy_black_tex);
 	}
 
 	/* Unbind shared VAO after all fullscreen passes are complete */
@@ -886,6 +953,9 @@ void postprocess_set_histogram_sync(PostProcess* post_processing, int index,
 {
 	post_processing->histogram_sync[index] = sync;
 }
+
+static const float LUM_MIN_EXTREME = 1e30F;
+static const float LUM_MAX_EXTREME = -1e30F;
 
 void postprocess_update_readbacks(PostProcess* post_processing,
                                   uint64_t frame_count)
@@ -994,18 +1064,46 @@ int postprocess_compute_luminance_histogram(PostProcess* post_processing,
 			    GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
 
 			if (lum_data) {
-				fill_histogram_buckets(lum_data, buckets, size,
-				                       min_lum, max_lum);
+				/* Zero out cache before filling to avoid
+				 * accumulation
+				 */
+				for (int i = 0;
+				     i < POSTPROCESS_HISTOGRAM_BUCKETS; i++) {
+					post_processing->last_buckets[i] = 0;
+				}
+
+				*min_lum = LUM_MIN_EXTREME;
+				*max_lum = LUM_MAX_EXTREME;
+
+				fill_histogram_buckets(
+				    lum_data, post_processing->last_buckets,
+				    size, min_lum, max_lum);
+				post_processing->last_min_lum = *min_lum;
+				post_processing->last_max_lum = *max_lum;
+				post_processing->last_histogram_updated = 1;
 				glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
-				processed = 1;
 			}
+			glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
 			glDeleteSync(current_sync);
 			post_processing->histogram_sync[read_idx] = NULL;
 		}
 	}
 
-	/* Trigger Async Transfer for Next Slot if not already pending */
+	/* Provide continuous data from cache if available */
+	if (post_processing->last_histogram_updated) {
+		for (int i = 0; i < size && i < POSTPROCESS_HISTOGRAM_BUCKETS;
+		     i++) {
+			buckets[i] = post_processing->last_buckets[i];
+		}
+		*min_lum = post_processing->last_min_lum;
+		*max_lum = post_processing->last_max_lum;
+		processed = 1;
+	}
+
+	/* Trigger Async Transfer for Next Slot if not already pending.
+	 * This is a safety fallback for standalone tests or benchmarks.
+	 */
 	int write_idx = (int)((frame_count + 1) % 2);
 	if (!post_processing->histogram_sync[write_idx]) {
 		trigger_histogram_readback(post_processing, write_idx);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ set(OPENGL_TESTS
     test_shader_uniforms_loc
     test_stencil_masking
     test_env_transition
+    test_auto_exposure_debug
 )
 
 # Pour chaque fichier test trouvé

--- a/tests/test_auto_exposure_debug.c
+++ b/tests/test_auto_exposure_debug.c
@@ -1,0 +1,202 @@
+#include <glad/glad.h>
+
+#include "gpu_profiler.h"
+#include "postprocess.h"
+#include "unity.h"
+#include <GLFW/glfw3.h>
+#include <stdlib.h>
+#include <string.h>
+
+static GLFWwindow* test_window = NULL;
+static GPUProfiler dummy_profiler;
+
+static const int RENDER_WIDTH = 640;
+static const int RENDER_HEIGHT = 480;
+static const int MAP_SIZE = 64;
+
+void setUp(void)
+{
+	if (!glfwInit()) {
+		TEST_FAIL_MESSAGE("Failed to initialize GLFW");
+	}
+	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
+	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	test_window =
+	    glfwCreateWindow(RENDER_WIDTH, RENDER_HEIGHT, "Test", NULL, NULL);
+	if (!test_window) {
+		glfwTerminate();
+		TEST_FAIL_MESSAGE("Failed to create window");
+	}
+	glfwMakeContextCurrent(test_window);
+	gladLoadGLLoader((GLADloadproc)glfwGetProcAddress);
+	gpu_profiler_init(&dummy_profiler);
+}
+
+void tearDown(void)
+{
+	gpu_profiler_cleanup(&dummy_profiler);
+	if (test_window) {
+		glfwDestroyWindow(test_window);
+	}
+	glfwTerminate();
+}
+
+/**
+ * Test standard histogram computation and cache verification
+ */
+void test_histogram_caching_and_continuity(void)
+{
+	// USE HEAP for PostProcess to avoid stack issues
+	PostProcess* post_proc = (PostProcess*)calloc(1, sizeof(PostProcess));
+	postprocess_init(post_proc, &dummy_profiler, RENDER_WIDTH,
+	                 RENDER_HEIGHT);
+	postprocess_enable(post_proc, POSTFX_EXPOSURE_DEBUG);
+
+	int buckets[POSTPROCESS_HISTOGRAM_BUCKETS] = {0};
+	float min_lum = 0.0F;
+	float max_lum = 0.0F;
+
+	// 1. Initial State: sync objects are NULL
+	int result = postprocess_compute_luminance_histogram(
+	    post_proc, 0, buckets, POSTPROCESS_HISTOGRAM_BUCKETS, &min_lum,
+	    &max_lum);
+	TEST_ASSERT_EQUAL_INT(0, result);
+
+	// 2. Mock PBO content for Frame 1 (reads from index 1)
+	int write_idx = 1;
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, post_proc->histogram_pbo[write_idx]);
+	float* mock_data =
+	    (float*)malloc((size_t)(MAP_SIZE * MAP_SIZE) * sizeof(float));
+	for (int i = 0; i < MAP_SIZE * MAP_SIZE; i++) {
+		mock_data[i] = -5.0F;  // Maps to bucket 0
+	}
+	glBufferSubData(
+	    GL_PIXEL_PACK_BUFFER, 0,
+	    (GLsizeiptr)((size_t)(MAP_SIZE * MAP_SIZE) * sizeof(float)),
+	    mock_data);
+	free(mock_data);
+	post_proc->histogram_sync[write_idx] =
+	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	glFlush();
+	glFinish();  // Ensure data is ready
+
+	// 3. Process data for Frame 1
+	result = postprocess_compute_luminance_histogram(
+	    post_proc, 1, buckets, POSTPROCESS_HISTOGRAM_BUCKETS, &min_lum,
+	    &max_lum);
+	TEST_ASSERT_EQUAL_INT(1, result);
+	TEST_ASSERT_EQUAL_INT(MAP_SIZE * MAP_SIZE, buckets[0]);
+
+	// 4. Test Cache Continuity for Frame 2
+	// Frame 1 auto-triggered a readback for index 0 (Frame 2).
+	// In the test, we mock a slow GPU by either deleting the sync OR
+	// replacing it with a non-signaled one.
+	// Simplest: clear the sync to simulate it's NOT ready.
+	if (post_proc->histogram_sync[0]) {
+		glDeleteSync(post_proc->histogram_sync[0]);
+		post_proc->histogram_sync[0] = NULL;
+	}
+
+	result = postprocess_compute_luminance_histogram(
+	    post_proc, 2, buckets, POSTPROCESS_HISTOGRAM_BUCKETS, &min_lum,
+	    &max_lum);
+	TEST_ASSERT_EQUAL_INT(1, result);  // Still returns 1 from cache
+	TEST_ASSERT_EQUAL_INT(MAP_SIZE * MAP_SIZE, buckets[0]);
+
+	postprocess_cleanup(post_proc);
+	free(post_proc);
+}
+
+void test_histogram_auto_trigger_when_ae_off(void)
+{
+	PostProcess post_proc = {0};
+	postprocess_init(&post_proc, &dummy_profiler, RENDER_WIDTH,
+	                 RENDER_HEIGHT);
+	postprocess_enable(&post_proc, POSTFX_EXPOSURE_DEBUG);
+
+	GLuint dummy_tex;
+	glGenTextures(1, &dummy_tex);
+	glBindTexture(GL_TEXTURE_2D, dummy_tex);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, RENDER_WIDTH, RENDER_HEIGHT,
+	             0, GL_RGBA, GL_FLOAT, NULL);
+	post_proc.scene_color_tex = dummy_tex;
+
+	postprocess_end(&post_proc);
+	TEST_ASSERT_NOT_NULL(post_proc.histogram_sync[1]);
+
+	glDeleteTextures(1, &dummy_tex);
+	postprocess_cleanup(&post_proc);
+}
+
+void test_histogram_cache_no_accumulation(void)
+{
+	PostProcess post_proc = {0};
+	postprocess_init(&post_proc, &dummy_profiler, RENDER_WIDTH,
+	                 RENDER_HEIGHT);
+	postprocess_enable(&post_proc, POSTFX_EXPOSURE_DEBUG);
+
+	int buckets[POSTPROCESS_HISTOGRAM_BUCKETS] = {0};
+	float min_lum = 0.0F;
+	float max_lum = 0.0F;
+
+	// Fill index 1 with -5.0f
+	int write_idx = 1;
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, post_proc.histogram_pbo[write_idx]);
+	float* data1 =
+	    (float*)malloc((size_t)(MAP_SIZE * MAP_SIZE) * sizeof(float));
+	for (int i = 0; i < MAP_SIZE * MAP_SIZE; i++)
+		data1[i] = -5.0F;
+	glBufferSubData(
+	    GL_PIXEL_PACK_BUFFER, 0,
+	    (GLsizeiptr)((size_t)(MAP_SIZE * MAP_SIZE) * sizeof(float)), data1);
+	free(data1);
+	post_proc.histogram_sync[write_idx] =
+	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	glFlush();
+	glFinish();
+
+	postprocess_compute_luminance_histogram(&post_proc, 1, buckets,
+	                                        POSTPROCESS_HISTOGRAM_BUCKETS,
+	                                        &min_lum, &max_lum);
+	TEST_ASSERT_EQUAL_INT(MAP_SIZE * MAP_SIZE, buckets[0]);
+
+	// Load 5.0F into index 0
+	write_idx = 0;
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, post_proc.histogram_pbo[write_idx]);
+	float* data2 =
+	    (float*)malloc((size_t)(MAP_SIZE * MAP_SIZE) * sizeof(float));
+	for (int i = 0; i < MAP_SIZE * MAP_SIZE; i++)
+		data2[i] = 5.0F;
+	glBufferSubData(
+	    GL_PIXEL_PACK_BUFFER, 0,
+	    (GLsizeiptr)((size_t)(MAP_SIZE * MAP_SIZE) * sizeof(float)), data2);
+	free(data2);
+	// Delete any auto-triggered sync to avoid interference
+	if (post_proc.histogram_sync[write_idx]) {
+		glDeleteSync(post_proc.histogram_sync[write_idx]);
+	}
+	post_proc.histogram_sync[write_idx] =
+	    glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	glFlush();
+	glFinish();
+
+	postprocess_compute_luminance_histogram(&post_proc, 2, buckets,
+	                                        POSTPROCESS_HISTOGRAM_BUCKETS,
+	                                        &min_lum, &max_lum);
+	TEST_ASSERT_EQUAL_INT(0, buckets[0]);  // No accumulation
+	TEST_ASSERT_EQUAL_INT(MAP_SIZE * MAP_SIZE,
+	                      buckets[POSTPROCESS_HISTOGRAM_BUCKETS - 1]);
+
+	postprocess_cleanup(&post_proc);
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_histogram_caching_and_continuity);
+	RUN_TEST(test_histogram_auto_trigger_when_ae_off);
+	RUN_TEST(test_histogram_cache_no_accumulation);
+	return UNITY_END();
+}


### PR DESCRIPTION
# Fix: Post-Processing Regressions and Histogram Debug Stability

## Summary
Cette PR adresse plusieurs régressions et instabilités identifiées dans le pipeline de post-processing (notamment depuis le commit `48b0dd59`). L'objectif principal était de stabiliser l'affichage debug de l'histogramme de luminance, de résoudre des warnings matériels (OpenGL) et d'assurer une synchronisation robuste entre le GPU et le CPU via les Pixel Buffer Objects (PBO).

## Key Changes

### 🛠️ Core Logic & Fixes
- **Histogram Caching** : Implémentation d'un mécanisme de cache persistant (`last_buckets`). Cela élimine le "clignotement" visuel quand le GPU n'a pas encore fini d'écrire dans le PBO pour la frame actuelle.
- **Luminance Range Fix** : Réinitialisation correcte de `min_lum` et `max_lum` à des valeurs extrêmes (`1e30F`) avant chaque extraction PBO. Auparavant, les labels de plage restaient souvent statiques ou erronés.
- **Stencil Type Mismatch** : Ajout d'une texture dummy spécialisée `dummy_uint_tex` (format `GL_R8UI`). Cela résout les avertissements de driver OpenGL qui tentaient de lier une texture `RGBA8` sur un `usampler2D`.
- **Sync Management** : Nettoyage systématique des objets `GLsync` dans [postprocess_on_state_change](src/postprocess.c:382:0-416:1) pour éviter des fuites de mémoire GPU et des saccades lors de l'activation/désactivation des effets.
- **Auto-Triggering** : Le calcul de l'histogramme est désormais automatiquement déclenché par le flag `POSTFX_EXPOSURE_DEBUG`, même si l'Auto-Exposure est désactivé.

### 🧪 Testing
- **Nouveaux Tests Unitaires** : Ajout de [tests/test_auto_exposure_debug.c](tests/test_auto_exposure_debug.c:0:0-0:0).
  - Vérification de la continuité des données (cache).
  - Test du découplage entre le mode debug et l'effet Auto-Exposure.
  - Test de non-accumulation des données entre les frames.
- **Stabilité CI** : Ajout de `glFinish()` dans les tests pour garantir la disponibilité des données PBO dans les environnements de rendu lents (Xvfb/CI).

### 📝 Documentation
- Ajout d'un guide technique complet : [docs/auto_exposure_debug_histogram.md](docs/auto_exposure_debug_histogram.md:0:0-0:0).
- Mise à jour de l'index (`mkdocs.yml`) et des analyses d'exposition existantes.

## Verification
Le bon fonctionnement peut être vérifié en lançant la suite de tests dédiée :

```bash
# Compiler et lancer les tests d'auto-exposure
just test test_auto_exposure_debug
```

Visuellement, l'affichage Exposure Debug View (dans le menu UI) doit être fluide, dynamique et ne plus présenter de clignotements, même sous charge GPU variable.

### Commits

* dbd00644 - fix(postprocess): implement stable histogram caching and synchronization
* 77b78b8b - test(auto_exposure): add comprehensive PBO readback and caching tests
* 6afa130d - docs: add technical guide for exposure histogram and PBO readback
