### PR TITLE
Fix/toggle fullscreen

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -216,6 +216,16 @@ test-integration-asan: asan
     @{{distrobox}} chmod +x scripts/test_integration_asan.sh
     @{{distrobox}} bash scripts/test_integration_asan.sh
 
+# Stress test: rapid fullscreen/windowed toggling to find deadlocks
+stress-fullscreen iterations="100" delay="50": build
+    @chmod +x scripts/test_stress_fullscreen.sh
+    @{{distrobox}} bash scripts/test_stress_fullscreen.sh {{build_dir}}/app {{iterations}} {{delay}}
+
+# Stress test fullscreen under ASan (slower but catches memory bugs)
+stress-fullscreen-asan iterations="50" delay="100": asan
+    @chmod +x scripts/test_stress_fullscreen.sh
+    @{{distrobox}} bash scripts/test_stress_fullscreen.sh ./build-asan/app {{iterations}} {{delay}}
+
 # Run programmatic ApiTrace performance verification
 test-apitrace: build
     @{{distrobox}} chmod +x scripts/verify_apitrace_perf.sh

--- a/docs/fullscreen_deadlock.md
+++ b/docs/fullscreen_deadlock.md
@@ -21,9 +21,54 @@ The deadlock was caused by a synchronization conflict between the GLFW event loo
     *   The **Driver/Compositor** is waiting for the application to finish its current GPU work (like a pending `glfwSwapBuffers` or fence sync) to complete the mode switch.
     *   The **Application** is blocked inside the resize callback, trying to allocate/delete GPU resources, but the driver's command queue is often locked or stalled during the mode switch handshake.
 
+### Sequence Before (DEADLOCK)
+
+```mermaid
+sequenceDiagram
+    participant Main as Main Thread
+    participant GLFW as GLFW
+    participant Driver as NVIDIA Driver
+    participant GPU as GPU Pipeline
+
+    Main->>GLFW: glfwPollEvents()
+    GLFW->>Main: key_callback(F)
+    Main->>GLFW: glfwSetWindowMonitor()
+    GLFW->>Driver: Mode switch request
+    Note over Driver: Waits for GPU fence...
+    Driver-->>GLFW: Resize event
+    GLFW->>Main: framebuffer_size_callback()
+    Main->>GPU: glDeleteTextures / glGenTextures
+    Note over GPU,Driver: GPU blocked by pending swap
+    Note over Main,GPU: 💀 DEADLOCK
+```
+
 ## Implementation: Deferred Resize
 
 The solution is a **Deferred Resize** pattern, which decouples the window manager's resize event from the expensive GPU resource recreation.
+
+### Sequence After (FIXED)
+
+```mermaid
+sequenceDiagram
+    participant Main as Main Thread
+    participant GLFW as GLFW
+    participant Driver as NVIDIA Driver
+    participant GPU as GPU Pipeline
+
+    Main->>GPU: glFinish() — drain pipeline
+    GPU-->>Main: All commands complete
+    Main->>GLFW: glfwSetWindowMonitor()
+    GLFW->>Driver: Mode switch request
+    Driver-->>GLFW: Resize event
+    GLFW->>Main: framebuffer_size_callback()
+    Note over Main: Only stores dimensions + flag
+    Main-->>GLFW: Return immediately
+    GLFW-->>Main: glfwSetWindowMonitor() returns
+    Note over Main: Next frame begins...
+    Main->>Main: app_run: resize_pending? YES
+    Main->>GPU: postprocess_resize() — safe context
+    GPU-->>Main: FBOs recreated ✓
+```
 
 ### 1. Lightweight Callback
 

--- a/docs/fullscreen_deadlock.md
+++ b/docs/fullscreen_deadlock.md
@@ -1,0 +1,89 @@
+# Fullscreen Toggle Deadlock (NVIDIA)
+
+## Overview
+
+A non-deterministic deadlock was identified when toggling between windowed and fullscreen modes, particularly on NVIDIA hardware (especially using Prime Render Offload). The application would freeze completely during the transition, requiring a force kill.
+
+## Root Cause Analysis
+
+The deadlock was caused by a synchronization conflict between the GLFW event loop, the window manager/compositor, and the OpenGL driver.
+
+### The Problematic Sequence
+
+1.  **Toggle Triggered**: The user presses 'F', which calls `app_toggle_fullscreen()`.
+2.  **Synchronous Driver Call**: `app_toggle_fullscreen()` calls `glfwSetWindowMonitor()`. This is a synchronous operation that blocks until the window manager and driver acknowledge the mode switch.
+3.  **Nested Callback**: While blocked inside `glfwSetWindowMonitor()`, the window manager sends a resize event. GLFW dispatches this event immediately by calling `framebuffer_size_callback()`.
+4.  **Heavy GPU Work**: The callback invoked `postprocess_resize()`, which performed heavy GPU resource management:
+    *   Destroying existing Framebuffer Objects (FBOs) and textures.
+    *   Allocating new textures for Bloom, Depth of Field, etc.
+    *   Recompiling/re-linking shaders for some post-process effects.
+5.  **Circular Dependency (Deadlock)**:
+    *   The **Driver/Compositor** is waiting for the application to finish its current GPU work (like a pending `glfwSwapBuffers` or fence sync) to complete the mode switch.
+    *   The **Application** is blocked inside the resize callback, trying to allocate/delete GPU resources, but the driver's command queue is often locked or stalled during the mode switch handshake.
+
+## Implementation: Deferred Resize
+
+The solution is a **Deferred Resize** pattern, which decouples the window manager's resize event from the expensive GPU resource recreation.
+
+### 1. Lightweight Callback
+
+The `framebuffer_size_callback` no longer performs any GPU resource allocation. It only updates the viewport (which is cheap and safe) and stores the new dimensions in the `App` state.
+
+```c
+void framebuffer_size_callback(GLFWwindow* window, int width, int height) {
+    App* app = (App*)glfwGetWindowUserPointer(window);
+    app->width = width;
+    app->height = height;
+    glViewport(0, 0, width, height);
+
+    // Only set the request flag
+    app->pending_width = width;
+    app->pending_height = height;
+    app->resize_pending = 1;
+}
+```
+
+### 2. GPU Pipeline Drain
+
+In `app_toggle_fullscreen()`, we now call `glFinish()` before invoking `glfwSetWindowMonitor()`. This ensures that the GPU pipeline is completely drained and all pending commands (fences, PBO transfers, swaps) are finished before the driver attempts the mode switch.
+
+### 3. Main Loop Processing
+
+The actual heavy lifting (`postprocess_resize`) is moved to the start of the next frame in `app_run`, safely outside the GLFW callback context.
+
+```c
+// Inside app_run() while loop
+glfwPollEvents();
+
+if (app->resize_pending) {
+    postprocess_resize(&app->postprocess, app->pending_width, app->pending_height);
+    app->resize_pending = 0;
+}
+```
+
+## Stress Testing
+
+A dedicated stress test was created to verify this fix: `scripts/test_stress_fullscreen.sh`.
+
+### How it works
+- It uses `xdotool` to send 'F' keystrokes rapidly (e.g., 10ms-50ms intervals).
+- It monitors the application's **log output** rather than window visibility. A deadlocked application may still have a visible window, but it will stop logging "Switched to fullscreen/windowed".
+- If the expected log message doesn't appear within 5 seconds, it detects a hang, captures a full GDB stack trace of all threads, and terminates the app.
+
+### Running the test
+```bash
+# Standard test
+just stress-fullscreen
+
+# Aggressive test with ASan
+just stress-fullscreen-asan 200 10
+```
+
+## Summary of Changes
+
+| File | Change |
+| :--- | :--- |
+| `include/app.h` | Added `resize_pending`, `pending_width`, `pending_height` fields. |
+| `src/app_input.c` | Updated `framebuffer_size_callback` to use flags; added `glFinish()` to toggle. |
+| `src/app.c` | Added deferred resize processing logic and state initialization. |
+| `Justfile` | Added `stress-fullscreen` automation. |

--- a/include/app.h
+++ b/include/app.h
@@ -58,6 +58,9 @@ typedef struct App {
 	int is_fullscreen;             /**< Fullscreen toggle state. */
 	int saved_x, saved_y;          /**< Cached pos for window restore. */
 	int saved_width, saved_height; /**< Cached size for window restore. */
+	int resize_pending;            /**< Deferred resize flag. */
+	int pending_width;             /**< Deferred resize target width. */
+	int pending_height;            /**< Deferred resize target height. */
 	int camera_enabled;            /**< Pause camera movement. */
 	EnvManager env_mgr;            /**< Environment/IBL state. */
 	int perf_mode_active; /**< Performance/GameMode optimization active. */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
     - Performance Mode & Notifs: perf_and_notifications.md
     - Billboard Optimization: billboard_optimization.md
     - Stencil Buffer Masking: stencil_masking.md
+    - Fullscreen Deadlock: fullscreen_deadlock.md
     - SIMD Optimization: simd_optimization.md
     - Mesa F32-to-F16 Analysis: mesa_f32_to_f16_analysis.md
   - Guides:

--- a/scripts/test_stress_fullscreen.sh
+++ b/scripts/test_stress_fullscreen.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+# =============================================================================
+# STRESS TEST: Window ↔ Fullscreen Toggle
+# =============================================================================
+# Detects deadlocks by monitoring application LOG OUTPUT rather than window
+# visibility (a frozen/deadlocked app keeps its window visible + process alive).
+#
+# Detection strategy:
+#   After each 'F' keystroke, wait for the app to log either:
+#     "Switched to fullscreen"  or  "Switched to windowed"
+#   If the expected log line does NOT appear within TIMEOUT_SEC → DEADLOCK.
+#
+# Usage:
+#   ./scripts/test_stress_fullscreen.sh <path_to_app> [iterations] [delay_ms]
+#
+# Examples:
+#   ./scripts/test_stress_fullscreen.sh ./build/app           # 100 cycles, 50ms
+#   ./scripts/test_stress_fullscreen.sh ./build/app 200 10    # aggressive
+#   ./scripts/test_stress_fullscreen.sh ./build/app 50 200    # gentle
+# =============================================================================
+
+set -eo pipefail
+
+# --- Configuration ---
+APP_PATH="${1:?Error: No application path provided. Usage: $0 <app_path> [iterations] [delay_ms]}"
+ITERATIONS="${2:-100}"
+DELAY_MS="${3:-50}"
+WINDOW_NAME="Icosphere Phong"
+LOG_FILE="stress_fullscreen.log"
+STACKS_FILE="stress_fullscreen.stacks"
+TIMEOUT_SEC=5  # Max seconds to wait for toggle acknowledgment in logs
+
+# --- Source shared utilities ---
+SCRIPT_DIR=$(dirname "$0")
+source "$SCRIPT_DIR/integration_utils.sh"
+check_dependencies
+
+if [ ! -f "$APP_PATH" ]; then
+    echo "Error: Application binary not found at $APP_PATH."
+    exit 1
+fi
+
+# --- Color output helpers ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+echo -e "${CYAN}╔══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║           FULLSCREEN TOGGLE STRESS TEST                     ║${NC}"
+echo -e "${CYAN}╠══════════════════════════════════════════════════════════════╣${NC}"
+echo -e "${CYAN}║${NC} Binary:     ${YELLOW}$APP_PATH${NC}"
+echo -e "${CYAN}║${NC} Iterations: ${YELLOW}$ITERATIONS${NC}"
+echo -e "${CYAN}║${NC} Delay:      ${YELLOW}${DELAY_MS}ms${NC}"
+echo -e "${CYAN}║${NC} Timeout:    ${YELLOW}${TIMEOUT_SEC}s per toggle${NC}"
+echo -e "${CYAN}║${NC} Detection:  ${YELLOW}Log-based (watches for Switched to ... messages)${NC}"
+echo -e "${CYAN}╚══════════════════════════════════════════════════════════════╝${NC}"
+
+# --- Clean previous artifacts ---
+rm -f "$LOG_FILE" "$STACKS_FILE"
+: > "$LOG_FILE"  # Create empty log file now (needed for tail -f)
+
+# --- Launch application ---
+echo -e "\n${CYAN}[INIT]${NC} Starting application..."
+export ASAN_OPTIONS="exitcode=1:detect_leaks=1:symbolize=1:halt_on_error=0:verify_asan_link_order=0"
+export LSAN_OPTIONS="suppressions=lsan.supp"
+
+# Run app, tee stdout+stderr to log. Use stdbuf to line-buffer so we see
+# log lines as soon as they're printed (critical for our detection strategy).
+stdbuf -oL -eL $APP_PATH > >(tee "$LOG_FILE") 2>&1 &
+APP_PID=$!
+
+# Give stdbuf/tee time to set up
+sleep 0.2
+
+if ! wait_for_window_start $APP_PID "$WINDOW_NAME"; then
+    echo -e "${RED}[FATAL]${NC} Window not found. Aborting."
+    kill $APP_PID 2>/dev/null || true
+    exit 1
+fi
+
+WID=$(xdotool search --sync --onlyvisible --name "$WINDOW_NAME" 2>/dev/null | head -n 1)
+focus_window "$WID"
+
+# Give the app a few frames to fully initialize (IBL load, shaders, etc.)
+sleep 2
+
+echo -e "\n${CYAN}[START]${NC} Beginning stress test: $ITERATIONS fullscreen toggle cycles"
+echo ""
+
+# --- Tracking ---
+SUCCESS_COUNT=0
+HANG_COUNT=0
+CRASH_DETECTED=false
+START_TIME=$(date +%s)
+
+# --- Core detection function ---
+# Waits for a specific pattern to appear in the log file.
+# Returns 0 on success, 1 on crash, 2 on timeout (deadlock).
+wait_for_log_pattern() {
+    local pattern="$1"
+    local line_before="$2"
+    local timeout_ms=$((TIMEOUT_SEC * 1000))
+    local poll_ms=50
+    local waited=0
+
+    while [ $waited -lt $timeout_ms ]; do
+        # Check process is still alive
+        if ! kill -0 $APP_PID 2>/dev/null; then
+            return 1  # Crash
+        fi
+
+        # Count lines matching pattern AFTER the line we snapshotted
+        local current_count
+        current_count=$(grep -c "$pattern" "$LOG_FILE" 2>/dev/null || true)
+        current_count=${current_count:-0}
+        if [ "$current_count" -gt "$line_before" ]; then
+            return 0  # Pattern found — toggle succeeded
+        fi
+
+        sleep 0.$(printf '%03d' $poll_ms)
+        waited=$((waited + poll_ms))
+    done
+
+    # Timeout: the app did not produce the expected log line
+    # This means the app is hung — DEADLOCK
+    return 2
+}
+
+# --- Stack trace capture ---
+capture_stacks() {
+    local iteration=$1
+    local direction=$2
+
+    echo -e "${YELLOW}[DIAG]${NC} Capturing thread stack traces (iteration $iteration, $direction)..."
+
+    {
+        echo "============================================================"
+        echo "DEADLOCK at iteration $iteration ($direction)"
+        echo "Timestamp: $(date -Iseconds)"
+        echo "PID: $APP_PID"
+        echo "============================================================"
+    } >> "$STACKS_FILE"
+
+    if command -v gdb &>/dev/null; then
+        gdb -batch \
+            -ex "set pagination off" \
+            -ex "thread apply all bt full" \
+            -ex "info threads" \
+            -ex "detach" \
+            -p $APP_PID 2>/dev/null >> "$STACKS_FILE" || true
+        echo -e "${YELLOW}[DIAG]${NC} GDB stack traces saved to ${BOLD}$STACKS_FILE${NC}"
+    else
+        echo -e "${YELLOW}[DIAG]${NC} GDB not available. Dumping /proc/$APP_PID/status instead."
+        {
+            echo "--- /proc/$APP_PID/status ---"
+            cat /proc/$APP_PID/status 2>/dev/null || echo "(not available)"
+            echo ""
+            echo "--- /proc/$APP_PID/wchan ---"
+            cat /proc/$APP_PID/wchan 2>/dev/null || echo "(not available)"
+            echo ""
+            # Show all thread stacks via /proc
+            for tid_dir in /proc/$APP_PID/task/*/; do
+                tid=$(basename "$tid_dir")
+                echo "--- Thread $tid stack ---"
+                cat /proc/$APP_PID/task/$tid/stack 2>/dev/null || echo "(not available)"
+                echo ""
+            done
+        } >> "$STACKS_FILE"
+        echo -e "${YELLOW}[DIAG]${NC} /proc stack info saved to ${BOLD}$STACKS_FILE${NC}"
+    fi
+}
+
+# --- Determine expected initial state ---
+# The app starts in windowed mode, so the first 'F' should go fullscreen.
+# We track expected next state to know which log line to wait for.
+EXPECT_FULLSCREEN=true
+
+# --- Helper: send keystroke with timeout protection ---
+# xdotool can hang if the window is frozen (especially --sync variants).
+# We wrap EVERY xdotool interaction in a hard timeout.
+XDOTOOL_TIMEOUT=2  # seconds
+
+send_toggle_key() {
+    local wid
+
+    # Find the window (may have a new WID after fullscreen toggles)
+    wid=$(timeout "$XDOTOOL_TIMEOUT" xdotool search --onlyvisible --name "$WINDOW_NAME" 2>/dev/null | head -n 1)
+    if [ -z "$wid" ]; then
+        # Window temporarily invisible during mode transition — try without --onlyvisible
+        sleep 0.3
+        wid=$(timeout "$XDOTOOL_TIMEOUT" xdotool search --name "$WINDOW_NAME" 2>/dev/null | head -n 1)
+    fi
+
+    if [ -n "$wid" ]; then
+        # NO --sync flags! They block forever on a frozen window.
+        timeout "$XDOTOOL_TIMEOUT" xdotool windowfocus "$wid" 2>/dev/null || true
+        timeout "$XDOTOOL_TIMEOUT" xdotool windowactivate "$wid" 2>/dev/null || true
+        sleep 0.05
+    fi
+
+    # Send the key — also with timeout in case xdotool blocks on a dead window
+    timeout "$XDOTOOL_TIMEOUT" xdotool key --delay 0 F 2>/dev/null || true
+}
+
+# --- Main stress loop ---
+for ((i=1; i<=ITERATIONS; i++)); do
+    # Check process is still alive before each toggle
+    if ! kill -0 $APP_PID 2>/dev/null; then
+        echo -e "${RED}[CRASH]${NC} Application died at iteration $i / $ITERATIONS"
+        CRASH_DETECTED=true
+        break
+    fi
+
+    # Determine expected direction
+    if $EXPECT_FULLSCREEN; then
+        direction="→ FULLSCREEN"
+        log_pattern="Switched to fullscreen"
+    else
+        direction="→ WINDOWED"
+        log_pattern="Switched to windowed"
+    fi
+
+    # Snapshot current count of the expected pattern in log
+    count_before=$(grep -c "$log_pattern" "$LOG_FILE" 2>/dev/null || true)
+    count_before=${count_before:-0}
+
+    # Also snapshot log file size — if it doesn't grow, the app is certainly frozen
+    log_size_before=$(stat -c%s "$LOG_FILE" 2>/dev/null || echo "0")
+
+    # Send the toggle keystroke (timeout-protected)
+    send_toggle_key
+
+    # Small inter-toggle delay
+    if [ "$DELAY_MS" -gt 0 ]; then
+        sleep "$(awk "BEGIN{printf \"%.3f\", $DELAY_MS/1000}")"
+    fi
+
+    # Wait for log acknowledgment (this is the primary deadlock detection)
+    wait_for_log_pattern "$log_pattern" "$count_before"
+    status=$?
+
+    if [ $status -eq 1 ]; then
+        echo -e "${RED}[CRASH]${NC} Application crashed during Toggle #$i ($direction)"
+        CRASH_DETECTED=true
+        break
+    elif [ $status -eq 2 ]; then
+        # Double-check: is the process still alive? If yes → confirmed deadlock
+        if kill -0 $APP_PID 2>/dev/null; then
+            HANG_COUNT=$((HANG_COUNT + 1))
+            echo -e ""
+            echo -e "${RED}╔══════════════════════════════════════════════════════════════╗${NC}"
+            echo -e "${RED}║  DEADLOCK DETECTED at Toggle #$i ($direction)${NC}"
+            echo -e "${RED}╚══════════════════════════════════════════════════════════════╝${NC}"
+
+            # Check if log file grew at all (secondary signal)
+            log_size_after=$(stat -c%s "$LOG_FILE" 2>/dev/null || echo "0")
+            if [ "$log_size_after" = "$log_size_before" ]; then
+                echo -e "${RED}[HANG]${NC}  Log file has NOT grown — app is completely frozen."
+            else
+                echo -e "${RED}[HANG]${NC}  Log file grew but expected pattern missing — app stuck mid-transition."
+            fi
+            echo -e "${RED}[HANG]${NC}  App is alive (PID $APP_PID) but did NOT log \"$log_pattern\""
+            echo -e "${RED}[HANG]${NC}  within ${TIMEOUT_SEC}s — confirmed deadlock."
+
+            capture_stacks "$i" "$direction"
+
+            echo -e "${RED}[FATAL]${NC} Killing frozen application (SIGKILL)."
+            kill -9 $APP_PID 2>/dev/null || true
+            break
+        else
+            echo -e "${RED}[CRASH]${NC} Application crashed during Toggle #$i ($direction)"
+            CRASH_DETECTED=true
+            break
+        fi
+    fi
+
+    # Toggle succeeded, flip expected state
+    if $EXPECT_FULLSCREEN; then
+        EXPECT_FULLSCREEN=false
+    else
+        EXPECT_FULLSCREEN=true
+    fi
+
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+
+    # Progress reporting
+    if (( (i*2) % 20 == 0 )) || (( i == ITERATIONS )); then
+        elapsed=$(( $(date +%s) - START_TIME ))
+        echo -e "${GREEN}[OK]${NC}    Toggle $i / $ITERATIONS completed (${elapsed}s elapsed, ${SUCCESS_COUNT} successful)"
+    fi
+done
+
+# --- Cleanup ---
+END_TIME=$(date +%s)
+TOTAL_TIME=$((END_TIME - START_TIME))
+
+echo ""
+echo -e "${CYAN}╔══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║                    STRESS TEST RESULTS                      ║${NC}"
+echo -e "${CYAN}╠══════════════════════════════════════════════════════════════╣${NC}"
+echo -e "${CYAN}║${NC} Toggles completed: ${GREEN}$SUCCESS_COUNT${NC} / $((ITERATIONS))"
+echo -e "${CYAN}║${NC} Hangs detected:    $(if [ $HANG_COUNT -gt 0 ]; then echo -e "${RED}$HANG_COUNT${NC}"; else echo -e "${GREEN}0${NC}"; fi)"
+echo -e "${CYAN}║${NC} Crash detected:    $(if $CRASH_DETECTED; then echo -e "${RED}YES${NC}"; else echo -e "${GREEN}NO${NC}"; fi)"
+echo -e "${CYAN}║${NC} Total time:        ${TOTAL_TIME}s"
+echo -e "${CYAN}╚══════════════════════════════════════════════════════════════╝${NC}"
+
+# --- Terminate app cleanly if still running ---
+if kill -0 $APP_PID 2>/dev/null; then
+    echo -e "\n${CYAN}[CLEANUP]${NC} Sending ESC to terminate application..."
+    WID=$(timeout 2 xdotool search --onlyvisible --name "$WINDOW_NAME" 2>/dev/null | head -n 1)
+    if [ -n "$WID" ]; then
+        timeout 2 xdotool windowfocus "$WID" 2>/dev/null || true
+        timeout 2 xdotool key Escape 2>/dev/null || true
+    fi
+
+    # Wait for clean exit (10s max)
+    if ! timeout 10 bash -c "while kill -0 $APP_PID 2>/dev/null; do sleep 0.1; done"; then
+        echo -e "${YELLOW}[WARN]${NC} App did not exit cleanly, force killing."
+        kill -9 $APP_PID 2>/dev/null || true
+    fi
+fi
+
+# Wait for the background process group
+wait $APP_PID 2>/dev/null || true
+
+# --- Check for ASan/TSan errors in log ---
+echo ""
+echo -e "${CYAN}[LOG]${NC} Checking $LOG_FILE for errors..."
+if grep -qE "ERROR: (Address|Leak|Thread)Sanitizer" "$LOG_FILE" 2>/dev/null; then
+    echo -e "${RED}[FAIL]${NC} Sanitizer errors found in log!"
+    grep -E "ERROR: (Address|Leak|Thread)Sanitizer" "$LOG_FILE" | head -5
+else
+    echo -e "${GREEN}[OK]${NC}   No sanitizer errors in log."
+fi
+
+# --- Show stack traces if captured ---
+if [ -f "$STACKS_FILE" ] && [ -s "$STACKS_FILE" ]; then
+    echo ""
+    echo -e "${YELLOW}════════════════════════════════════════════════════════════════${NC}"
+    echo -e "${YELLOW}  CAPTURED STACK TRACES (from $STACKS_FILE):${NC}"
+    echo -e "${YELLOW}════════════════════════════════════════════════════════════════${NC}"
+    cat "$STACKS_FILE"
+    echo -e "${YELLOW}════════════════════════════════════════════════════════════════${NC}"
+fi
+
+# --- Final verdict ---
+echo ""
+if $CRASH_DETECTED || [ $HANG_COUNT -gt 0 ]; then
+    echo -e "${RED}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${RED}  STRESS TEST FAILED — Bug reproduced!${NC}"
+    if [ $HANG_COUNT -gt 0 ]; then
+        echo -e "${RED}  Deadlock confirmed after $SUCCESS_COUNT successful toggles.${NC}"
+        echo -e "${RED}  Review: cat $STACKS_FILE${NC}"
+    fi
+    echo -e "${RED}═══════════════════════════════════════════════════════════════${NC}"
+    exit 1
+else
+    echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${GREEN}  STRESS TEST PASSED — $SUCCESS_COUNT toggles with no issues${NC}"
+    echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
+    exit 0
+fi

--- a/src/app.c
+++ b/src/app.c
@@ -38,6 +38,7 @@ int app_init(App* app, int width, int height, const char* title)
 
 	app->camera_enabled = true;
 	app->is_fullscreen = false;
+	app->resize_pending = 0;
 	app->scene.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
 	app->env_mgr.is_first_load = true;
 
@@ -195,6 +196,17 @@ void app_run(App* app)
 			PROFILE_ZONE(poll_ctx, "GLFW PollEvents (Start)");
 			glfwPollEvents();
 			PROFILE_ZONE_END(poll_ctx);
+		}
+
+		/* Process deferred resize from framebuffer_size_callback.
+		 * Heavy GPU work (FBO/texture recreation) is done here, safely
+		 * outside any GLFW callback context, after the mode switch and
+		 * event processing are fully complete. */
+		if (app->resize_pending) {
+			postprocess_resize(&app->postprocess,
+			                   app->pending_width,
+			                   app->pending_height);
+			app->resize_pending = 0;
 		}
 
 		app->frame_count++;

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -34,8 +34,14 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 	app->height = height;
 	glViewport(0, 0, width, height);
 
-	/* Redimensionner le post-processing */
-	postprocess_resize(&app->postprocess, width, height);
+	/* Defer heavy GPU work (FBO/texture recreation) to the next frame.
+	 * This callback can fire synchronously from inside
+	 * glfwSetWindowMonitor() during a fullscreen toggle. Doing GPU resource
+	 * destruction/creation here deadlocks on NVIDIA when the driver is
+	 * mid-mode-switch. */
+	app->pending_width = width;
+	app->pending_height = height;
+	app->resize_pending = 1;
 }
 
 static void handle_pbr_debug_mode(App* app)
@@ -565,6 +571,13 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action,
 void app_toggle_fullscreen(App* app, GLFWwindow* window)
 {
 	static const int REFRESH_RATE_WINDOWED = 0;
+
+	/* Drain the GPU pipeline before switching monitor modes.
+	 * glfwSetWindowMonitor() is synchronous and may trigger
+	 * framebuffer_size_callback from within. If the GPU still has
+	 * pending fences/swaps, the NVIDIA driver can deadlock. */
+	glFinish();
+
 	if (app->is_fullscreen == 0) {
 		GLFWmonitor* monitor = glfwGetPrimaryMonitor();
 		const GLFWvidmode* mode = glfwGetVideoMode(monitor);

--- a/tests/mocks/GLFW/glfw3.h
+++ b/tests/mocks/GLFW/glfw3.h
@@ -84,6 +84,7 @@ void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
 void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
 void glfwSetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int xpos,
                           int ypos, int width, int height, int refreshRate);
+void glfwFocusWindow(GLFWwindow* window);
 
 typedef void (*GLFWscrollfun)(GLFWwindow* window, double xoffset,
                               double yoffset);


### PR DESCRIPTION
# PR: Resolve Fullscreen Toggle Deadlock (NVIDIA)

## Description
This PR addresses a non-deterministic deadlock occurring during windowed ↔ fullscreen transitions, particularly on NVIDIA hardware using Prime Render Offload. The freeze was caused by heavy GPU resource management (FBO/texture reconstruction) occurring inside a synchronous GLFW callback while the driver was mid-mode-switch.

## Root Cause
- `glfwSetWindowMonitor` is synchronous and can trigger [framebuffer_size_callback](src/app_input.c:29:0-44:1) from within its execution.
- Executing `glDelete*` and `glGen*` (via `postprocess_resize`) inside this nested callback led to a circular dependency where the driver waited for the GPU pipeline to drain while the main thread was blocked waiting for the driver.

## Changes

### 🔧 Core Logic (Deferred Resize)
- **[app_input.c](src/app_input.c:0:0-0:0)**: Added `glFinish()` before mode switches to ensure the GPU pipeline is empty.
- **[framebuffer_size_callback](src/app_input.c:29:0-44:1)**: Refactored to be lightweight. It now only sets an `app->resize_pending` flag and updates the viewport.
- **[app.c](src/app.c:0:0-0:0)**: Implementation of the **Deferred Resize** pattern. Heavy post-processing reconstruction now happens at the start of the next frame, safely outside the GLFW/Driver handshake.

### 🧪 Stress Testing Infrastructure
- Created [scripts/test_stress_fullscreen.sh](scripts/test_stress_fullscreen.sh:0:0-0:0):
    - Uses **log-based detection** (watches for `"Switched to ..."` messages) to distinguish between a healthy transition and a frozen app.
    - Automatic **GDB stack trace capture** on deadlock detection.
    - Robust timeout protection for all `xdotool` interactions.
- Updated [Justfile](Justfile:0:0-0:0): 
    - Added `just stress-fullscreen` and `just stress-fullscreen-asan`.
    - Integrated `distrobox` wrapper to ensure library parity (solves `libasan.so.8` missing errors).

### 📚 Documentation
- Added [docs/fullscreen_deadlock.md](docs/fullscreen_deadlock.md:0:0-0:0): A comprehensive guide explaining the race condition with sequence diagrams.
- Updated [mkdocs.yml](mkdocs.yml:0:0-0:0) to include the new guide under the "Optimization" section.

## Testing Done
- Ran 200 cycles of rapid toggling (10ms delay) under ASan without a single hang.
- Verified on NVIDIA Prime Render Offload environment (`__NV_PRIME_RENDER_OFFLOAD=1`).
