### PR TITLE
feat: Advanced Bloom Debug Mode & Interactive Mip Cycling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,6 +176,12 @@ jobs:
         env:
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
         run: |
+          if [ -z "$SURGE_TOKEN" ]; then
+            echo "⚠️ SURGE_TOKEN est vide ou indisponible (PR provenant d'un fork potentiellement)."
+            echo "⏭️ Déploiement du preview Surge ignoré pour ne pas briser le CI."
+            echo "PREVIEW_URL=(Aperçu non disponible pour les forks)" >> $GITHUB_ENV
+            exit 0
+          fi
           PR_NUMBER=${{ github.event.number }}
           DEPLOY_DOMAIN="suckless-ogl-pr-$PR_NUMBER.surge.sh"
           npx surge site/ $DEPLOY_DOMAIN --token $SURGE_TOKEN

--- a/docs/bloom_debug.md
+++ b/docs/bloom_debug.md
@@ -1,0 +1,32 @@
+# Bloom Debugging Guide
+
+This document describes the specialized debug mode for the Bloom post-processing effect.
+
+## Overview
+
+The Bloom effect is constructed through multiple stages (Prefilter, Downsample chain, Upsample chain). The debug mode allows you to visualize these intermediate buffers to verify the luminance thresholding and the blur distribution.
+
+## Controls
+
+- **SHIFT + 'B'**: Cycles through the construction stages.
+    - **Final Map**: The final reconstructed bloom texture (Level 0).
+    - **Prefilter**: The result of the high-pass filter.
+    - **Downsample**: Visualization of a specific level in the downsampling chain.
+    - **Upsample**: Visualization of the progressive blending.
+- **ALT + 'B'**: Cycles through **Mip Levels** (0 to 4).
+    - In **Downsample** mode: Shows the output of each downscaling pass.
+    - In **Upsample** mode: Shows the result of the blending at different resolutions.
+
+## Implementation Details
+
+### Rendering Pipeline
+
+When `POSTFX_BLOOM_DEBUG` is active in the `active_effects` bitmask:
+1. `fx_bloom_render` executes only up to the requested `debug_step`.
+2. The pipeline uses `goto end_bloom` to bypass unnecessary work.
+3. The `postprocess.frag` shader detects the debug flag and outputs the sampled `bloomTexture` directly, bypassing other effects (Film Grain, Vignette, etc.) for a clean visualization.
+
+### UI Integration
+
+The current state is displayed in the **Status Overlay** (toggle with F1):
+`Bloom Debug: [Stage] | Mip: [N]`

--- a/docs/bloom_debug.md
+++ b/docs/bloom_debug.md
@@ -9,19 +9,20 @@ The Bloom effect is constructed through multiple stages (Prefilter, Downsample c
 ## Controls
 
 - **SHIFT + 'B'**: Cycles through the construction stages.
-    - **Final Map**: The final reconstructed bloom texture (Level 0).
-    - **Prefilter**: The result of the high-pass filter.
-    - **Downsample**: Visualization of a specific level in the downsampling chain.
-    - **Upsample**: Visualization of the progressive blending.
+  - **Final Map**: The final reconstructed bloom texture (Level 0).
+  - **Prefilter**: The result of the high-pass filter.
+  - **Downsample**: Visualization of a specific level in the downsampling chain.
+  - **Upsample**: Visualization of the progressive blending.
 - **ALT + 'B'**: Cycles through **Mip Levels** (0 to 4).
-    - In **Downsample** mode: Shows the output of each downscaling pass.
-    - In **Upsample** mode: Shows the result of the blending at different resolutions.
+  - In **Downsample** mode: Shows the output of each downscaling pass.
+  - In **Upsample** mode: Shows the result of the blending at different resolutions.
 
 ## Implementation Details
 
 ### Rendering Pipeline
 
 When `POSTFX_BLOOM_DEBUG` is active in the `active_effects` bitmask:
+
 1. `fx_bloom_render` executes only up to the requested `debug_step`.
 2. The pipeline uses `goto end_bloom` to bypass unnecessary work.
 3. The `postprocess.frag` shader detects the debug flag and outputs the sampled `bloomTexture` directly, bypassing other effects (Film Grain, Vignette, etc.) for a clean visualization.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@
 - **Isolated Environment**: Native `distrobox` support to guarantee a reproducible build environment.
 - **Quality & Testing**: Unit testing suite, code coverage, static analysis, and [Standalone Mocking](standalone_testing_mocking.md).
 - **Interactive Keyboard Overlay**: Modern Cyberpunk UI with [Responsive Scaling](keyboard_system.md) and [Visual Parameter Reference](ui_visual_parameters.md).
-- **Post-Processing Pipeline**: Advanced stack including [Auto-Exposure](exposure_analysis.md), [Bloom](postprocess_optimizations_2026-02.md), and [Debug Histograms](auto_exposure_debug_histogram.md).
+- **Post-Processing Pipeline**: Advanced stack including [Auto-Exposure](exposure_analysis.md), [Bloom](postprocess_optimizations_2026-02.md), [Bloom Debugging](bloom_debug.md), and [Debug Histograms](auto_exposure_debug_histogram.md).
 
 ## 🛠️ Compilation and Usage
 

--- a/docs/keyboard_system.md
+++ b/docs/keyboard_system.md
@@ -75,8 +75,12 @@ The UI automatically color-codes keys based on their `BindingType`:
 
 - **Cyan (`BINDING_TYPE_TOGGLE`)**: On/Off switches.
 - **Green (`BINDING_TYPE_CYCLE`)**: Actions that cycle through multiple states.
-- **Orange/Yellow (`GLFW_MOD_SHIFT`)**: Combination keys.
+- **Orange/Yellow (`GLFW_MOD_SHIFT`, `GLFW_MOD_ALT`)**: Combination keys.
 - **Blue (`BINDING_TYPE_ACTION`)**: One-shot actions (Reset, Screenshot, Exit).
+
+### Status Bar Integration
+
+Some debug modes (like Bloom Debug) integrate directly with the **Main Info Overlay** (F1) to display the currently active stage or sub-level (mip), providing real-time feedback during navigation.
 
 ## UI Customization
 

--- a/include/effects/fx_bloom.h
+++ b/include/effects/fx_bloom.h
@@ -31,6 +31,8 @@ typedef struct {
 	Shader* upsample_shader;
 	GLuint fbo;
 	BloomMip mips[BLOOM_MIP_LEVELS];
+	int debug_step; /* 0: Final, 1: Prefilter, 2: Downsample, 3: Upsample */
+	int debug_mip;  /* Sub-level for Downsample/Upsample debug */
 } BloomFX;
 
 /* Initialisation des ressources Bloom */

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -88,6 +88,7 @@ typedef enum {
 	POSTFX_VECTOR_FIELD_DEBUG =
 	    (1U << 15U), /**< Vector field velocity visualization. */
 	POSTFX_STENCIL_DEBUG = (1U << 16U), /**< Stencil mask visualization. */
+	POSTFX_BLOOM_DEBUG = (1U << 17U),   /**< Bloom debug view. */
 } PostProcessEffect;
 
 /** @brief Default mask of active effects. */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
     - Environment Transitions: env_transitions.md
     - Post-Process Optimizations (Feb 2026): postprocess_optimizations_2026-02.md
     - Motion Blur Analysis: motion_blur_analysis.md
+    - Bloom Debugging: bloom_debug.md
   - "Controls & Input":
     - Mouse Control: mouse_camera_control.md
     - Keyboard Help System: keyboard_system.md

--- a/shaders/postprocess.frag
+++ b/shaders/postprocess.frag
@@ -51,6 +51,13 @@ void main()
 		return;
 	}
 
+	/* 1d. Priority Debug Check for Bloom Stages */
+	if (enableBloomDebug) {
+		vec3 bloomCol = texture(bloomTexture, TexCoords).rgb;
+		FragColor = vec4(bloomCol, 1.0);
+		return;
+	}
+
 	vec3 color;
 	/* Stencil Check: 0 = Skybox/Background, 1 = Object */
 	uint stencil = texture(stencilTexture, TexCoords).r;

--- a/shaders/postprocess/ubo.glsl
+++ b/shaders/postprocess/ubo.glsl
@@ -194,3 +194,9 @@ const bool enableStencilDebug = bool(OPT_ENABLE_STENCIL_DEBUG);
 #else
 #define enableStencilDebug ((activeEffects & (1u << 16u)) != 0u)
 #endif
+
+#ifdef OPT_ENABLE_BLOOM_DEBUG
+const bool enableBloomDebug = bool(OPT_ENABLE_BLOOM_DEBUG);
+#else
+#define enableBloomDebug ((activeEffects & (1u << 17u)) != 0u)
+#endif

--- a/src/app_binding.c
+++ b/src/app_binding.c
@@ -91,6 +91,12 @@ void app_binding_registry_init(AppBindingRegistry* registry)
 	add_binding(GLFW_KEY_B, 0, "Toggle Bloom",
 	            "Toggles the bloom/glow effect.", BINDING_CAT_POSTFX,
 	            BINDING_TYPE_TOGGLE);
+	add_binding(GLFW_KEY_B, GLFW_MOD_SHIFT, "Cycle Bloom Debug Stage",
+	            "Cycles through bloom intermediate maps and stages.",
+	            BINDING_CAT_POSTFX, BINDING_TYPE_CYCLE);
+	add_binding(GLFW_KEY_B, GLFW_MOD_ALT, "Cycle Bloom Debug Mip",
+	            "Cycles through bloom levels (mips) in debug mode.",
+	            BINDING_CAT_POSTFX, BINDING_TYPE_CYCLE);
 	add_binding(GLFW_KEY_M, 0, "Toggle Motion Blur",
 	            "Toggles the velocity-based motion blur.",
 	            BINDING_CAT_POSTFX, BINDING_TYPE_TOGGLE);

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -291,9 +291,11 @@ static void get_key_base_color(const AppBindingRegistry* registry, int key,
 	const AppBinding* direct = app_binding_registry_get(registry, key, 0);
 	const AppBinding* shifted =
 	    app_binding_registry_get(registry, key, (int)GLFW_MOD_SHIFT);
+	const AppBinding* alted =
+	    app_binding_registry_get(registry, key, (int)GLFW_MOD_ALT);
 
 	glm_vec3_copy((float*)KEY_COLOR_DEFAULT, out_col);
-	if (direct != NULL || shifted != NULL) {
+	if (direct != NULL || shifted != NULL || alted != NULL) {
 		*out_has_binding = true;
 	} else {
 		*out_has_binding = false;
@@ -314,7 +316,7 @@ static void get_key_base_color(const AppBindingRegistry* registry, int key,
 		} else {
 			glm_vec3_copy((float*)KEY_COLOR_TOGGLE, out_col);
 		}
-	} else if (shifted != NULL) {
+	} else if (shifted != NULL || alted != NULL) {
 		glm_vec3_copy((float*)KEY_COLOR_COMBINATION, out_col);
 	}
 }
@@ -464,7 +466,7 @@ void app_draw_help_overlay(const App* app)
 	                    (float*)KEY_COLOR_CYCLE, HELP_TEXT_ALPHA, ui_scale,
 	                    app->width, app->height);
 	ui_draw_text_scaled(
-	    (UIContext*)&app->overlay.ui, "■ Shift+ Combo",
+	    (UIContext*)&app->overlay.ui, "■ Combination (Shift/Alt+)",
 	    legend_x_start + (legend_step * LEGEND_COMBO_STEP_MULT), legend_y,
 	    (float*)KEY_COLOR_COMBINATION, HELP_TEXT_ALPHA, ui_scale,
 	    app->width, app->height);
@@ -697,6 +699,23 @@ static void draw_luminance_histogram_graph(const App* app, const int* buckets,
 	             app->width, app->height);
 }
 
+static void draw_bloom_debug_status(const App* app, UILayout* layout)
+{
+	if (postprocess_is_enabled((PostProcess*)&app->postprocess,
+	                           POSTFX_BLOOM_DEBUG)) {
+		char buf[DEBUG_TEXT_BUFFER_SIZE];
+		int step = app->postprocess.bloom_fx.debug_step;
+		int mip = app->postprocess.bloom_fx.debug_mip;
+		const char* stages[] = {"Final Map", "Prefilter", "Downsample",
+		                        "Upsample"};
+
+		(void)safe_snprintf(buf, sizeof(buf),
+		                    "Bloom Debug: %s | Mip: %d",
+		                    stages[step % 4], mip);
+		ui_layout_text(layout, buf, (float*)DEBUG_ORANGE_COLOR);
+	}
+}
+
 void app_draw_debug_overlay(const App* app)
 {
 	int buckets[HISTO_BUCKETS];
@@ -825,6 +844,7 @@ void app_render_ui(const App* app)
 
 	draw_main_info_overlay(app, &layout);
 	draw_exposure_overlay(app, &layout);
+	draw_bloom_debug_status(app, &layout);
 	draw_loading_indicator(app);
 
 	if (postprocess_is_enabled((PostProcess*)&app->postprocess,

--- a/src/effects/fx_bloom.c
+++ b/src/effects/fx_bloom.c
@@ -124,6 +124,10 @@ void fx_bloom_render(PostProcess* post_processing)
 
 	glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
 
+	if (post_processing->bloom_fx.debug_step == 1) { /* Prefilter only */
+		goto end_bloom;
+	}
+
 	/* 2. Downsample */
 	shader_use(bloom->downsample_shader);
 
@@ -144,6 +148,10 @@ void fx_bloom_render(PostProcess* post_processing)
 		glViewport(0, 0, mip_dst->width, mip_dst->height);
 
 		glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
+	}
+
+	if (post_processing->bloom_fx.debug_step == 2) { /* Downsample only */
+		goto end_bloom;
 	}
 
 	/* 3. Upsample with Blending */
@@ -170,6 +178,8 @@ void fx_bloom_render(PostProcess* post_processing)
 	}
 
 	glDisable(GL_BLEND);
+
+end_bloom:
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	glViewport(0, 0, post_processing->width, post_processing->height);
 }

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -745,11 +745,29 @@ void postprocess_end(PostProcess* post_processing)
 		glBindTexture(GL_TEXTURE_2D, post_processing->scene_color_tex);
 
 		/* Bind la texture de Bloom */
+		GLuint bloom_tex = 0;
+		if (postprocess_is_enabled(post_processing, POSTFX_BLOOM)) {
+			int step = post_processing->bloom_fx.debug_step;
+			int mip_idx = post_processing->bloom_fx.debug_mip;
+
+			if (step == 1 || step == 2 || step == 3) {
+				/* Prefilter (step 1) uses mip 0.
+				   Downsample (step 2) uses selected mip.
+				   Upsample (step 3) uses selected mip. */
+				bloom_tex =
+				    post_processing->bloom_fx.mips[mip_idx]
+				        .texture;
+			} else {
+				/* Final (step 0) or normal mode: use
+				 * reconstructed mip 0
+				 */
+				bloom_tex =
+				    post_processing->bloom_fx.mips[0].texture;
+			}
+		}
+
 		render_utils_bind_texture_safe(
-		    GL_TEXTURE0 + POSTPROCESS_TEX_UNIT_BLOOM,
-		    postprocess_is_enabled(post_processing, POSTFX_BLOOM)
-		        ? post_processing->bloom_fx.mips[0].texture
-		        : 0,
+		    GL_TEXTURE0 + POSTPROCESS_TEX_UNIT_BLOOM, bloom_tex,
 		    post_processing->dummy_black_tex);
 
 		/* Bind la texture de Profondeur (pour le DoF) */

--- a/src/postprocess_input.c
+++ b/src/postprocess_input.c
@@ -227,7 +227,80 @@ void postprocess_input_handle_key(const PostProcessInputContext* ctx, int key,
 			toggle_postfx(ctx, POSTFX_GRAIN, "Grain");
 			break;
 		case GLFW_KEY_B:
-			toggle_postfx(ctx, POSTFX_BLOOM, "Bloom");
+			if (check_flag(mods, GLFW_MOD_SHIFT)) {
+				/* SHIFT+B: Cycle Bloom Debug Mode:
+				   Off -> Final -> Prefilter -> Downsample ->
+				   Upsample -> Off */
+				int debug_enabled = postprocess_is_enabled(
+				    ctx->postprocess, POSTFX_BLOOM_DEBUG);
+				int current_step =
+				    ctx->postprocess->bloom_fx.debug_step;
+
+				const char* mode_name = NULL;
+				if (!debug_enabled) {
+					/* Off -> Final */
+					postprocess_enable(ctx->postprocess,
+					                   POSTFX_BLOOM_DEBUG);
+					/* Ensure bloom is on for debug */
+					postprocess_enable(ctx->postprocess,
+					                   POSTFX_BLOOM);
+					ctx->postprocess->bloom_fx.debug_step =
+					    0;
+					mode_name = "Bloom Debug: Final Map";
+				} else if (current_step == 0) {
+					/* Final -> Prefilter */
+					ctx->postprocess->bloom_fx.debug_step =
+					    1;
+					mode_name = "Bloom Debug: Prefilter";
+				} else if (current_step == 1) {
+					/* Prefilter -> Downsample */
+					ctx->postprocess->bloom_fx.debug_step =
+					    2;
+					mode_name = "Bloom Debug: Downsample";
+				} else if (current_step == 2) {
+					/* Downsample -> Upsample (is actually
+					 * final map in our impl, let's keep it
+					 * for completeness or intermediate if
+					 * we want) */
+					/* For now let's just use it as
+					 * "Upsample/Final" */
+					ctx->postprocess->bloom_fx.debug_step =
+					    3;
+					mode_name = "Bloom Debug: Upsample";
+				} else {
+					/* Upsample -> Off */
+					postprocess_disable(ctx->postprocess,
+					                    POSTFX_BLOOM_DEBUG);
+					mode_name = "Bloom Debug: OFF";
+				}
+				LOG_INFO("suckless-ogl.postprocess", "%s",
+				         mode_name);
+				action_notifier_push(ctx->notifier, mode_name,
+				                     NOTIF_DUR_NORMAL);
+			} else if (check_flag(mods, GLFW_MOD_ALT)) {
+				/* ALT+B: Cycle Bloom Debug Mip (0-4) */
+				if (postprocess_is_enabled(
+				        ctx->postprocess, POSTFX_BLOOM_DEBUG)) {
+					ctx->postprocess->bloom_fx.debug_mip =
+					    (ctx->postprocess->bloom_fx
+					         .debug_mip +
+					     1) %
+					    BLOOM_MIP_LEVELS;
+
+					char buf[NOTIF_BUF_SIZE];
+					(void)safe_snprintf(
+					    buf, sizeof(buf),
+					    "Bloom Debug Mip: %d",
+					    ctx->postprocess->bloom_fx
+					        .debug_mip);
+					LOG_INFO("suckless-ogl.postprocess",
+					         "%s", buf);
+					action_notifier_push(ctx->notifier, buf,
+					                     NOTIF_DUR_SHORT);
+				}
+			} else {
+				toggle_postfx(ctx, POSTFX_BLOOM, "Bloom");
+			}
 			break;
 		case GLFW_KEY_H:
 			toggle_postfx_complex(ctx, mods, POSTFX_DOF,


### PR DESCRIPTION
# feat: Advanced Bloom Debug Mode & Interactive Mip Cycling
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3e901ddd-4bcc-40d3-b6e9-0516005b81b4" />

## Summary
This PR introduces a comprehensive debug mode for the Bloom post-processing effect. It allows developers to observe the progressive construction of the bloom map, from the initial high-pass prefilter through the dual-filtering downsample/upsample chain. It also adds the ability to cycle through individual mip levels for detailed buffer inspection.

## Key Changes

### 🎨 Rendering & Core Logic
- **Modular Bloom Stages**: Modified `fx_bloom_render` to support early exits via a `debug_step` control, allowing visualization of:
  - `Prefilter`: High-pass luminance thresholding.
  - `Downsample`: The chain of decreasing resolution mips.
  - `Upsample`: Progressive blending and reconstruction.
  - `Final Map`: The resulting additive texture.
- **Shader Pipeline**: Updated [postprocess.frag](shaders/postprocess.frag:0:0-0:0) with a priority debug check. When active, it bypasses final effects (Grain, Vignette, Tonemapping) to display the raw bloom buffer.
- **UBO Expansion**: Integrated the `enableBloomDebug` flag into the Post-Processing Uniform Buffer for zero-overhead state switching.

### ⌨️ Input & UI
- **New Keybindings**:
  - `SHIFT + B`: Cycles through the main construction stages.
  - `ALT + B`: Cycles through the **mip levels (0-4)** within the current stage.
- **Interactive Help (F2)**: Updated the help overlay to correctly highlight and describe the new `Shift` and `Alt` combinations.
- **Real-time Status Overlay**: Added a dedicated debug line to the F1 overlay: `Bloom Debug: [Stage] | Mip: [N]`.

### 📚 Documentation
- **New Guide**: Created [docs/bloom_debug.md](docs/bloom_debug.md:0:0-0:0) detailing the controls and pipeline architecture.
- **MKDocs Integration**: Registered the new guide in [mkdocs.yml](mkdocs.yml:0:0-0:0) and updated [docs/index.md](docs/index.md:0:0-0:0).
- **System Docs**: Updated [keyboard_system.md](docs/keyboard_system.md:0:0-0:0) to reflect the improved support for `Alt` modifiers in the UI.

## How to Test
1. Compile the project (e.g., `make debug`).
2. Run the application and press **SHIFT + 'B'** to enter Bloom Debug mode.
3. Observe the status text in the top-left corner (ensure F1 is active).
4. Use **ALT + 'B'** to cycle through the mips when in "Downsample" or "Upsample" stages.
5. Verify that normal bloom still toggles correctly with a simple **'B'**.
