### PR TITLE
Refactoring de la Documentation et Standardisation de l'Outillage (Mars 2026)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+    "default": true,
+    "MD013": false,
+    "MD033": false,
+    "MD041": false,
+    "MD024": {
+        "siblings_only": true
+    }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@ repos:
     -   id: check-added-large-files
         args: [--maxkb=2000]
 
+-   repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.39.0
+    hooks:
+    -   id: markdownlint
+        args: ["--config", ".markdownlint.json"]
+
 -   repo: local
     hooks:
     -   id: make-format

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,41 +5,59 @@
 Use the convenient Makefile targets from the project root:
 
 ```bash
+
 # Build with dynamic shaders (debug mode)
+
 make debug
 
 # Build with optimized static shaders (release mode)
+
 make release
 
 # Run the application
+
 make run
 
 # Run tests
+
 make test
 
 # Clean build directory
+
 make clean
 
 # Show all available targets
+
 make help-user
+
 ```
 
 ## Shader Optimization Modes
 
 ### Debug Mode (Default)
+
 - **Command**: `make -f Makefile.user debug`
+
 - **Behavior**: Shaders use runtime conditionals (`if` statements)
+
 - **Advantages**:
   - Effects can be toggled at runtime
+
   - Faster iteration during development
+
 - **Use case**: Development, debugging, testing
 
 ### Release Mode
+
 - **Command**: `make -f Makefile.user release`
+
 - **Behavior**: Shaders use compile-time constants (`#define`)
+
 - **Advantages**:
   - GPU driver optimizes away unused branches
+
   - Better performance (reduced branching overhead)
+
 - **Use case**: Production builds, performance benchmarking
 
 ## Manual CMake Configuration
@@ -47,15 +65,19 @@ make help-user
 If you prefer direct CMake commands:
 
 ```bash
+
 # Debug mode
+
 cd build
 cmake -DENABLE_SHADER_OPTIMIZATION=OFF ..
 make -j$(nproc)
 
 # Release mode
+
 cd build
 cmake -DENABLE_SHADER_OPTIMIZATION=ON ..
 make -j$(nproc)
+
 ```
 
 ## Verification
@@ -64,7 +86,9 @@ To verify which mode is active, check the startup logs:
 
 ```bash
 ./build/app 2>&1 | grep "BUILD OPTION"
+
 ```
 
 - **Debug mode**: No output
+
 - **Release mode**: `BUILD OPTION: Compiling OPTIMIZED shader...`

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -7,13 +7,15 @@ This document explains the available build targets and the debugging process use
 The project uses a hybrid Makefile + CMake system for convenience and performance.
 
 | Target | Build Type | Flags | Description |
-| :--- | :--- | :--- | :--- |
+| :----- | :--------- | :---- | :---------- |
+
 | `make` | Debug | `-O0 -g` | Default dev build. Full symbols, no optimization. |
 | `make release` | Release | `-O3 -march=native -ffast-math` | **Ultra Release**. Uses **Unity Build** (compile as single unit). Stripped. |
+
 | `make debug-release`| RelWithDebInfo | `-O3 -march=native -g` | Release speed + Debug symbols. Not stripped. Use this for debugging performance issues or crashes. |
 | `make small` | MinSizeRel | `-Os` | Focused on binary size (~192K). |
-| `make asan`  | Debug          | `-fsanitize=address` | Fast runtime error detection. |
-| `make memcheck` | Release      | Valgrind        | **Default** deep leak analysis. |
+| `make asan` | Debug | `-fsanitize=address` | Fast runtime error detection. |
+| `make memcheck` | Release | Valgrind | **Default** deep leak analysis. |
 
 ### 🔍 Memory & Error Checking
 
@@ -25,7 +27,9 @@ Recommended for thorough leak hunting and identifying "still reachable" blocks.
 
 ```bash
 make memcheck         # Runs Valgrind on a Release build (Local Default)
+
 make test-integration # Runs full UI scenario under Valgrind
+
 ```
 
 #### 2. AddressSanitizer (ASan / Performance)
@@ -34,7 +38,9 @@ Best for fast runtime error detection (overflows, use-after-free) and used by **
 
 ```bash
 make asan             # Build with ASan instrumentation
+
 make memcheck-asan    # Run ASan-instrumented binary (CI Default)
+
 ```
 
 ## The SIMD Segfault Story: A Technical Deep-Dive
@@ -45,9 +51,11 @@ When enabling `-march=native` with `-O3`, the application initially suffered fro
 
 The debugging followed a three-step deduction process:
 
-* **Localization (The "Last Words")**: By adding granular `LOG_INFO` traces, we observed the crash happened immediately after "Starting app_init_instancing" but before any further logs. This narrowed the "crime scene" to the first few lines of that function.
-* **The `-march=native` Clue**: The crash *only* occurred when the compiler was allowed to use native CPU instructions. This strongly suggested that the compiler was generating specialized high-speed instructions (AVX/AVX2) that the standard build wasn't using.
-* **AddressSanitizer's Testimony**: Running the app with `ENABLE_ASAN=ON` reported `Conditional jump or move depends on uninitialised value(s)` (or similar memory access errors) during matrix operations. In the context of highly optimized code, this often indicates that a SIMD instruction (like `VMOVAPS`) tried to access an address it couldn't handle.
+- **Localization (The "Last Words")**: By adding granular `LOG_INFO` traces, we observed the crash happened immediately after "Starting app_init_instancing" but before any further logs. This narrowed the "crime scene" to the first few lines of that function.
+
+- **The `-march=native` Clue**: The crash _only_ occurred when the compiler was allowed to use native CPU instructions. This strongly suggested that the compiler was generating specialized high-speed instructions (AVX/AVX2) that the standard build wasn't using.
+
+- **AddressSanitizer's Testimony**: Running the app with `ENABLE_ASAN=ON` reported `Conditional jump or move depends on uninitialised value(s)` (or similar memory access errors) during matrix operations. In the context of highly optimized code, this often indicates that a SIMD instruction (like `VMOVAPS`) tried to access an address it couldn't handle.
 
 ### 2. Root Cause: Alignment Violation
 
@@ -56,12 +64,15 @@ High-performance SIMD instructions (Single Instruction Multiple Data) like those
 The problem was twofold:
 
 1. **Stack Alignment**: The `App` struct was initially on the stack. Most compilers only guarantee 16-byte alignment for the stack, but AVX needs 32 or 64.
+
 2. **Heap Alignment**: Standard `malloc` only guarantees 8 or 16-byte alignment. When we allocated arrays of structs, if the first element wasn't aligned to 64 bytes, every vectorized write to it caused an immediate hardware exception (Segfault).
 
 ### 3. The Fix: Enforced Alignment
 
 We resolved this by ensuring the CPU always finds its data where it expects:
 
-* **Aligned Allocation**: Replaced stack and standard `malloc` allocation with `posix_memalign((void**)&ptr, SIMD_ALIGNMENT, size)`. This forces the operating system to give us a memory block starting at a perfectly aligned address.
-* **Struct Padding**: Added `__attribute__((aligned(SIMD_ALIGNMENT)))` to `SphereInstance` and `PBRMaterial`. This tells the compiler to pad these structures so that their size is always a multiple of 64, ensuring that elements in an array (`data[1]`, `data[2]`, etc.) stay aligned.
-* **Consistency**: Centralized `SIMD_ALIGNMENT 64` in `gl_common.h`. 64 bytes is chosen as it is both AVX-512 safe and matches the L1 cache line size of most modern CPUs, providing a secondary performance benefit by preventing "cache line splitting".
+- **Aligned Allocation**: Replaced stack and standard `malloc` allocation with `posix_memalign((void**)&ptr, SIMD_ALIGNMENT, size)`. This forces the operating system to give us a memory block starting at a perfectly aligned address.
+
+- **Struct Padding**: Added `__attribute__((aligned(SIMD_ALIGNMENT)))` to `SphereInstance` and `PBRMaterial`. This tells the compiler to pad these structures so that their size is always a multiple of 64, ensuring that elements in an array (`data[1]`, `data[2]`, etc.) stay aligned.
+
+- **Consistency**: Centralized `SIMD_ALIGNMENT 64` in `gl_common.h`. 64 bytes is chosen as it is both AVX-512 safe and matches the L1 cache line size of most modern CPUs, providing a secondary performance benefit by preventing "cache line splitting".

--- a/Justfile
+++ b/Justfile
@@ -402,11 +402,36 @@ format:
     @echo "Formatting Python scripts..."
     @{{distrobox}} ruff format scripts/trace_analyze.py .github/workflows/scripts/test_trace_analyze.py
 
+# Format documentation files (Markdown) using Prettier
+format-docs:
+    @echo "Formatting Markdown documentation..."
+    @npx prettier --write "docs/**/*.md" "*.md"
+
+# Ensure generated headers are ready for linting
+lint-deps:
+    @if [ ! -d {{build_dir}} ]; then just configure; fi
+    @{{distrobox}} cmake --build {{build_dir}} --target glad-generate-files --parallel {{nprocs}}
+
+# Clean lint cache
+lint-clean:
+    @echo "Cleaning lint cache..."
+    @rm -rf .lint_cache*
+
 # Lint code using clang-tidy and ruff
-lint:
+lint: lint-deps
     @if [ ! -f {{build_dir}}/compile_commands.json ]; then {{distrobox}} cmake -B {{build_dir}} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON; fi
     @{{distrobox}} python3 {{justfile_directory()}}/scripts/lint_incremental.py {{build_dir}}
     @{{distrobox}} ruff check scripts/trace_analyze.py .github/workflows/scripts/test_trace_analyze.py
+
+# Lint documentation files (Markdown)
+lint-docs:
+    @if command -v pre-commit >/dev/null 2>&1; then \
+        pre-commit run --all-files markdownlint; \
+    else \
+        echo "❌ Error: pre-commit not found. Please install it to run markdownlint."; \
+        exit 1; \
+    fi
+
 
 # Full linting with all features enabled (Tracy, SSBO, etc.)
 lint-full:

--- a/README.md
+++ b/README.md
@@ -13,26 +13,40 @@
 [🌐 **Documentation & Reports Portal**](https://yoyonel.github.io/suckless-ogl/)
 
 ## 🚀 Features
+
 - **Minimalism**: Lightweight architecture focused on performance and readability.
+
 - **Modern Rendering**: Support for Skyboxes, IcoSpheres, textures, and Phong lighting.
+
 - **Dynamic Shaders**: Loading and compilation of GLSL files (vertex/fragment).
+
 - **Shader Optimization**: Static (Release) or dynamic (Debug) compilation to balance flexibility and performance. [See Documentation](docs/shader_optimization.md).
+
 - **Isolated Environment**: Native `distrobox` support to guarantee a reproducible build environment.
+
 - **Quality & Testing**: Unit testing suite, code coverage, and static analysis via `clang-tidy`.
 
 ## 🛠️ Compilation and Usage
 
 The project uses a `Makefile` wrapper that drives `CMake` to simplify interactions.
+
 ### Compilation Flags & Environment
+
 The build is configured with the following settings:
+
 - **Optimization**: `-Wall -Wextra -O2` for clean and performant code.
+
 - **POSIX Standard**: `-D_POSIX_C_SOURCE=199309L` for `clock_gettime` support.
+
 - **Static Analysis**: `clang-tidy` integration with strict header filters.
+
 - **Containerization**: Default use of `distrobox` with the `clang-dev` image to isolate dependencies.
 
 ### Main Commands
+
 | Command | Action |
-| :--- | :--- |
+| :------ | :----- |
+
 | `make all` | Compiles the project (generates GLAD and the `app` binary). |
 | `make debug` | Compiles in DEBUG mode (dynamic shaders, ideal for dev). |
 | `make release` | Compiles in RELEASE mode (statically optimized shaders). |
@@ -48,27 +62,41 @@ The build is configured with the following settings:
 The pipeline is structured to optimize the build while guaranteeing maximum quality:
 
 1. **Test & Coverage**: Instrumented compilation and test execution under **Xvfb** (virtual X server). A coverage report is generated and saved as an artifact.
+
 2. **Lint & Format Check**:
    - Verifies that the code is formatted. If `make format` modifies a file, the CI fails.
+
    - Runs `make lint` to validate CERT compliance and security.
+
 3. **Build & Release**:
    - Triggers on `master` or `v*` tags.
+
    - Packages the `app` binary with `assets/` and `shaders/` directories.
+
    - Compresses everything into a `.tar.gz` archive and creates an automatic **GitHub Release**.
 
 ## 📁 Project Structure
+
 - `src/` & `include/`: Engine core (Log, App, Shader, Texture, Icosphere).
+
 - `shaders/`: GLSL sources (Phong, Background/Skybox).
+
 - `assets/`: HDR resources and textures.
+
 - `tests/`: Unit tests (Icosphere, Shader, Skybox, Texture, Log).
+
 - `docs/`: In-depth technical documentation.
 
 ## 📦 Docker / Podman
+
 To test the application in a container with X11 forwarding:
+
 ```bash
 make docker-build
 make docker-run
+
 ```
+
 (Requires a local X server and configured xhost permissions).
 
 📄 License

--- a/docs/FXAA.md
+++ b/docs/FXAA.md
@@ -88,6 +88,7 @@ digraph FXAAOverview {
     EndTest -> Offset [label="yes — distance ratio", color="#9ece6a", fontcolor="#9ece6a"];
     Offset -> Final;
 }
+
 ```
 
 FXAA is a single-pass, post-processing anti-aliasing technique that reduces jagged edges (aliasing) by analyzing the contrast between pixels (Luma).
@@ -101,8 +102,9 @@ FXAA is a single-pass, post-processing anti-aliasing technique that reduces jagg
 
 FXAA runs inside the single-pass postprocess uber-shader (`postprocess.frag`). The pipeline order within the fragment shader is:
 
-```
+```text
 Motion Blur → Chromatic Aberration → FXAA → DoF → Bloom → Tone mapping → ...
+
 ```
 
 Because MB and CA are applied before FXAA in the same draw call, there is **no intermediate texture** containing the MB/CA result — only the raw scene texture (`screenTexture`) is available for neighbor sampling. FXAA therefore operates on the raw scene for all luma comparisons and final color reads. The `colorInput` parameter (post-MB/CA) is only used for the **early exit** path (no edge detected → return the processed color as-is).
@@ -111,9 +113,10 @@ Because MB and CA are applied before FXAA in the same draw call, there is **no i
 
 Two paths exist, selected at compile time via `#ifdef USE_TRANSPARENT_BILLBOARDS`:
 
-| Mode | Alpha channel | Luma computation | Cost |
-| :---| :---|:---|:---|
+| Mode                                       | Alpha channel     | Luma computation | Cost                     |
+| :----------------------------------------- | :---------------- | :--------------- | :----------------------- |
 | **Legacy** (`!USE_TRANSPARENT_BILLBOARDS`) | Pre-computed luma | `texture(...).a` | Fastest — 0 ALU for luma |
+
 | **Transparent** (`USE_TRANSPARENT_BILLBOARDS`) | Opacity data | `dot(rgb, vec3(0.299, 0.587, 0.114))` per sample | ~1 dot product per sample |
 
 The current build defines `USE_TRANSPARENT_BILLBOARDS` (see `app_settings.h`), so the transparent path is active.
@@ -177,6 +180,7 @@ digraph FXAADataFlow {
     FXAA -> Rest [label="color"];
     Rest -> Output;
 }
+
 ```
 
 ## Key Optimizations
@@ -189,6 +193,7 @@ digraph FXAADataFlow {
 float FxaaLuma(vec3 rgb) {
     return dot(rgb, vec3(0.299, 0.587, 0.114));
 }
+
 ```
 
 This is the standard FXAA 3.11 approach. A previous implementation used `dot(sqrt(rgb), ...)` to approximate perceptual (gamma) luma, but this added **up to 18 `sqrt` calls per pixel** (8 neighbors + up to 10 in the search loop) with no measurable quality improvement. The linear luma is sufficient for edge detection contrast ratios.
@@ -203,6 +208,7 @@ vec2 screenTexelSize;  // = 1.0 / vec2(width, height)
 
 // In FXAA
 vec2 inverseScreenSize = screenTexelSize;  // Free — just a UBO read
+
 ```
 
 Updated on resize only (`postprocess_resize()` sets `ubo_dirty = true`).
@@ -218,11 +224,17 @@ All luma comparisons (center, cardinal neighbors, corners, search loop endpoints
 ## Algorithm Steps
 
 1. **Center + 4 cardinal lumas** — `textureOffset()` for N/S/E/W, `texture()` for center
+
 2. **Early exit** — If contrast `range < max(thresholdMin, rangeMax × threshold)`, return `colorInput` (post-MB/CA)
+
 3. **4 corner lumas** — `textureOffset()` for NW/NE/SW/SE
+
 4. **Edge orientation** — Sobel-like gradient to determine horizontal vs vertical edge
+
 5. **Sub-pixel offset** — Smoothstep-based blending for single-pixel artifacts
+
 6. **Iterative search** — Walk along the edge in both directions with variable steps until contrast exceeds `gradientScaled`
+
 7. **Final blend** — Read `screenTexture` at the offset UV; take the maximum of edge offset and sub-pixel offset
 
 ## Configuration
@@ -232,24 +244,28 @@ Settings are controlled via the `PostProcessUBO`:
 ```glsl
 // UBO Layout (std140)
 float fxaaQualitySubpix;            // Default: 0.75 (Range 0.0 - 1.0)
+
 float fxaaQualityEdgeThreshold;     // Default: 0.125
 float fxaaQualityEdgeThresholdMin;  // Default: 0.063
+
 ```
 
-| Parameter | Effect | Lower | Higher |
-| :---| :---|:---|:---|
-| `subpix` | Sub-pixel AA strength | Sharper, more noise | Blurrier, less noise |
-| `edgeThreshold` | Minimum contrast for AA | More edges processed | Only strong edges |
+| Parameter          | Effect                    | Lower                | Higher                   |
+| :----------------- | :------------------------ | :------------------- | :----------------------- |
+| `subpix`           | Sub-pixel AA strength     | Sharper, more noise  | Blurrier, less noise     |
+| `edgeThreshold`    | Minimum contrast for AA   | More edges processed | Only strong edges        |
 | `edgeThresholdMin` | Absolute minimum contrast | Catches subtle edges | Skips low-contrast areas |
 
 ## Debugging
 
 Enable `enableFXAADebug` via the UI or `app_settings.h` to visualize:
 
-| Color | Meaning |
-| :---| :---|
+| Color   | Meaning                     |
+| :------ | :-------------------------- |
 | **Red** | Pixels displaced by edge AA |
+
 | **Blue** | Pixels displaced by sub-pixel blending |
+
 | **Dark gray** | Unaffected pixels (no edge detected) |
 
 ## Changelog

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,13 +9,13 @@ The monolithic `app.c` has been split into several specialized modules to improv
 ### Modules
 
 | Module | Responsibility |
-| :--- | :--- |
+| :----- | :------------- |
+
 | `app.c` / `app.h` | Orchestrator: Initialization, main loop, high-level render pass management. |
 | `app_ui.c` / `app_ui.h` | UI Rendering: Overlays, help screens, debug text, histograms, and loading spinners. |
 | `app_input.c` / `app_input.h` | Input Handling: Keyboard callbacks, mouse/scroll events, and post-process feature toggles. |
 | `app_env.c` / `app_env.h` | Environment & IBL: HDR file scanning, asynchronous loading, and the IBL state machine. |
 | `app_scene.c` / `app_scene.h` | Scene Rendering: Billboard groups, instanced groups, and procedural geometry updates. |
-
 
 ## Architecture Diagram
 
@@ -89,6 +89,7 @@ digraph Architecture {
   AppScene -> PBR [label="Draws"];
   AppScene -> Skybox [label="Draws"];
 }
+
 ```
 
 ## Data Ownership
@@ -96,8 +97,11 @@ digraph Architecture {
 The `App` struct (defined in `app.h`) remains the central state container. Most modules take a pointer to `App` as their first argument.
 
 To avoid cyclic dependencies:
+
 - Core struct definitions (`App`, `Camera`, `AsyncRequest`) use named structs instead of anonymous ones to support forward declarations.
+
 - Module headers are included at the **end** of `app.h` to ensure they can see the full `App` definition if necessary (though they primarily use pointers).
+
 - Specialized source files (`.c`) include `app.h` and the required renderer headers directly.
 
 ## Build System
@@ -107,4 +111,5 @@ The `CMakeLists.txt` has been updated to include the new source files. The `app`
 ## Performance Impact
 
 - **Compilation**: Parallel compilation is now more effective as changes to UI don't require re-compiling the IBL logic.
+
 - **Runtime**: Zero overhead, as functions are simply moved into separate translation units. Inlining is still possible for performance-critical functions if they were moved to headers (though not currently required).

--- a/docs/async_loader.md
+++ b/docs/async_loader.md
@@ -12,27 +12,33 @@ The **Async Loader** decouples the **Disk I/O and CPU decompression** steps from
 
 The system consists of several main components working together to ensure zero-stall loading:
 
-1.  **Async Loader Module** (`src/async_loader.c`)
-    *   Manages a background worker thread.
-    *   Handles heavy I/O and SIMD format conversion.
-    *   Implements the `WAITING_FOR_PBO` protocol to interact with the main thread.
+1. **Async Loader Module** (`src/async_loader.c`)
 
-2.  **Async Coordinator** (`src/async/async_coordinator.h`)
-    *   Manages double-buffered PBOs on the main thread.
-    *   Handles the mapping and provision of GPU memory to the worker.
+- Manages a background worker thread.
 
-3.  **Environment Manager** (`src/env_manager.c`)
-    *   Orchestrates the multi-step loading process over several frames.
+- Handles heavy I/O and SIMD format conversion.
+
+- Implements the `WAITING_FOR_PBO` protocol to interact with the main thread.
+
+1. **Async Coordinator** (`src/async/async_coordinator.h`)
+
+- Manages double-buffered PBOs on the main thread.
+
+- Handles the mapping and provision of GPU memory to the worker.
+
+1. **Environment Manager** (`src/env_manager.c`)
+
+- Orchestrates the multi-step loading process over several frames.
 
 ### Data Flow (PBO-based)
 
 The loading process follows a specialized "handshake" to avoid shared contexts:
 
-1.  **Main Thread**: Calls `async_loader_request(path)`.
-2.  **Worker Thread**: Loads the file from disk and decodes it into a CPU float buffer. Transitions to `ASYNC_WAITING_FOR_PBO`.
-3.  **Main Thread**: Detects the waiting state during `poll()`. It maps a PBO and provides the pointer to the worker.
-4.  **Worker Thread**: Converts the float data directly into the mapped PBO memory using SIMD instructions. Transitions to `ASYNC_READY`.
-5.  **Main Thread**: Detects `ASYNC_READY`. It unmaps the PBO and performs a `glTexSubImage2D` (DMA transfer) to the GPU texture.
+1. **Main Thread**: Calls `async_loader_request(path)`.
+1. **Worker Thread**: Loads the file from disk and decodes it into a CPU float buffer. Transitions to `ASYNC_WAITING_FOR_PBO`.
+1. **Main Thread**: Detects the waiting state during `poll()`. It maps a PBO and provides the pointer to the worker.
+1. **Worker Thread**: Converts the float data directly into the mapped PBO memory using SIMD instructions. Transitions to `ASYNC_READY`.
+1. **Main Thread**: Detects `ASYNC_READY`. It unmaps the PBO and performs a `glTexSubImage2D` (DMA transfer) to the GPU texture.
 
 This architecture ensures that the **Main Thread never touches the pixel data** and the **Worker Thread never touches the OpenGL context**.
 
@@ -83,6 +89,7 @@ sequenceDiagram
     M->>G: glTexSubImage2D (Fast DMA)
     M->>G: glGenerateMipmap
     M->>M: Start Progressive IBL
+
 ```
 
 ### The 3-Step Integration
@@ -90,8 +97,11 @@ sequenceDiagram
 To further reduce frame spikes, the final GPU integration is split across frames:
 
 - **Step 1: Upload**: data is moved from PBO to a pre-allocated texture.
+
 - **Step 2: Mipmaps**: `glGenerateMipmap` is called (allocated on first use).
+
 - **Step 3: IBL Start**: The `IBLCoordinator` begins slicing the map for irradiance and pre-filtering.
 
 ### Detailed PBO Strategy
+
 For more technical details on the PBO implementation, see [Async PBO Upload](async_pbo.md).

--- a/docs/async_pbo.md
+++ b/docs/async_pbo.md
@@ -7,7 +7,9 @@ This document details the implementation of the asynchronous high-resolution tex
 Uploading large 4K HDR textures (approx. 64MB) to the GPU is a heavy operation.
 
 - **Direct Upload (`glTexImage2D`)**: Blocks the driver and main thread until the copy is complete (~50ms+), causing massive frame drops.
-- **Naive PBO**: Using a single PBO allows asynchronous DMA transfer, but the *mapping* of that PBO (`glMapBufferRange`) can still block if the GPU is currently reading from it (Implicit Synchronization).
+
+- **Naive PBO**: Using a single PBO allows asynchronous DMA transfer, but the _mapping_ of that PBO (`glMapBufferRange`) can still block if the GPU is currently reading from it (Implicit Synchronization).
+
 - **Monolithic Upload**: Even with PBOs, performing all GPU work (texture storage allocation, data upload, mipmap generation) in a single frame creates a ~60ms spike.
 
 ## Architecture Overview
@@ -31,52 +33,64 @@ sequenceDiagram
     participant GPU as GPU / Driver
 
     Note over Main: Frame N - PBO Setup
+
     Main->>GPU: texture_ensure_pbo() + texture_map_pbo()
     Main->>Worker: async_loader_provide_pbo(mapped_ptr)
 
     Note over Main: Frame N+1 - VRAM Pre-allocation
+
     Main->>GPU: texture_preallocate_hdr()<br/>glTexImage2D(level 0, NULL)
     Note over GPU: Allocate ~64MB base level only
 
     Note over Worker: Frames N..N+M - Background Conversion
+
     Worker->>Worker: float32 -> float16 (SIMD)<br/>directly into mapped PBO
 
     Note over Main: Frame N+M - Upload & Mipmaps
+
     Main->>GPU: glUnmapBuffer(PBO)
     Main->>GPU: glTexSubImage2D(from PBO)
     Main->>GPU: glGenerateMipmap()
     Note over GPU: DMA transfer + mipmap chain
+
 ```
 
 ## The Solution: Double-Buffered Persistent PBOs
 
-To ensure the Main Thread *never* waits for the GPU, we use a **Ping-Pong** strategy with two persistent PBOs.
+To ensure the Main Thread _never_ waits for the GPU, we use a **Ping-Pong** strategy with two persistent PBOs.
 
 ### Architecture
 
 1. **Async Worker Thread**:
-    - Loads the HDR file from disk (I/O).
-    - Decodes to float buffer.
-    - **Waits** for the Main Thread to provide a mapped GPU pointer.
-    - Converts Float -> Half-Float (FP16) *directly* into the mapped memory.
+   - Loads the HDR file from disk (I/O).
+
+   - Decodes to float buffer.
+
+   - **Waits** for the Main Thread to provide a mapped GPU pointer.
+
+   - Converts Float -> Half-Float (FP16) _directly_ into the mapped memory.
 
 2. **Main Thread (`app_update`)**:
-    - Checks if the worker is waiting.
-    - Selects the **next available PBO** (index `frame % 2`).
-    - **Maps** the PBO with `GL_MAP_UNSYNCHRONIZED_BIT`.
-    - Passes the pointer to the worker.
-    - When worker finishes, **Unmaps** and calls `glTexSubImage2D`.
+   - Checks if the worker is waiting.
+
+   - Selects the **next available PBO** (index `frame % 2`).
+
+   - **Maps** the PBO with `GL_MAP_UNSYNCHRONIZED_BIT`.
+
+   - Passes the pointer to the worker.
+
+   - When worker finishes, **Unmaps** and calls `glTexSubImage2D`.
 
 ### Key Optimizations
 
 #### 1. Double Buffering & Unsynchronized Mapping
 
 By alternating between `upload_pbo[0]` and `upload_pbo[1]`, we guarantee that while the GPU is reading from PBO 0 (for the previous texture), we are mapping and writing to PBO 1.
-This allows us to use `GL_MAP_UNSYNCHRONIZED_BIT`, which tells the driver: *"I promise I am not overwriting data you are currently using, so don't check, just give me the pointer immediately."*
+This allows us to use `GL_MAP_UNSYNCHRONIZED_BIT`, which tells the driver: _"I promise I am not overwriting data you are currently using, so don't check, just give me the pointer immediately."_
 
 #### 2. Persistent Allocation (No Orphaning)
 
-Previously, we used `glBufferData(NULL)` (Orphaning) to force the driver to give us a new memory chunk. While this avoids synchronization, the *allocation itself* for 64MB took ~26-40ms on certain drivers.
+Previously, we used `glBufferData(NULL)` (Orphaning) to force the driver to give us a new memory chunk. While this avoids synchronization, the _allocation itself_ for 64MB took ~26-40ms on certain drivers.
 **Current Approach**: We allocate the PBOs once (or resize only if larger textures are loaded). We reuse the existing VRAM storage, eliminating allocation overhead.
 
 #### 3. 2-Step Upload
@@ -84,8 +98,11 @@ Previously, we used `glBufferData(NULL)` (Orphaning) to force the driver to give
 Instead of fully converting on the specific thread and then copying, we:
 
 1. **Load** (Worker)
+
 2. **Map** (Main Thread)
+
 3. **Convert & Write** (Worker, directly into PBO)
+
 4. **Upload** (Main Thread, DMA)
 
 This prevents the Main Thread from ever touching the pixel data on the CPU, and prevents the Worker from needing a GL context.
@@ -97,12 +114,14 @@ This prevents the Main Thread from ever touching the pixel data on the CPU, and 
 Even with the PBO strategy above, the upload frame still caused a ~60ms spike because all GPU-heavy operations were concentrated in a single frame:
 
 | Operation | Approx. Cost | Cause |
-| :--- | :---: | :--- |
+| :-------- | :----------: | :---- |
+
 | `glTexStorage2D` (13 mip levels) | ~15-20ms | VRAM allocation of ~85MB |
 | `glUnmapBuffer` | ~1-3ms | Flush DMA write-combine |
 | `glTexSubImage2D` | ~10-15ms | DMA transfer PBO → texture |
 | `glGenerateMipmap` | ~10-15ms | GPU compute on 13 levels |
 | `glGetError` × 3 | ~5-10ms | **GPU sync points** (pipeline stalls) |
+
 | **Total** | **~45-65ms** | Single frame spike |
 
 ### The Strategy: Spread Work Across 3 Frames
@@ -120,8 +139,11 @@ gantt
 
     section After (3 frames)
     Frame N  - PBO Setup & Map        :active, 0, 5
+
     Frame N+1 - TexPrealloc (level 0) :active, 8, 15
+
     Frame N+M - Upload + Mipmap       :active, 18, 38
+
 ```
 
 #### Frame N: PBO Setup (`ASYNC_WAITING_FOR_PBO`)
@@ -130,11 +152,13 @@ gantt
 // app_update() — ASYNC_WAITING_FOR_PBO branch
 texture_ensure_pbo(&app->upload_pbo[idx], &app->upload_pbo_size[idx], size);
 void* ptr = texture_map_pbo(app->upload_pbo[idx], size);
+
 async_loader_provide_pbo(app->async_loader, ptr, app->upload_pbo[idx]);
 
 // Schedule deferred pre-allocation for NEXT frame
 app->pending_prealloc_w = req.width;
 app->pending_prealloc_h = req.height;
+
 ```
 
 **Cost**: ~1-5ms (PBO reuse, no allocation)
@@ -149,12 +173,15 @@ if (app->pending_prealloc_w > 0) {
         app->recycled_hdr_tex);
     app->pending_prealloc_w = 0;
 }
+
 ```
 
 Key decisions:
 
 - **`glTexImage2D` instead of `glTexStorage2D`**: Allocates only level 0 (~64MB) instead of 13 mip levels (~85MB). The mipmap chain is created later by `glGenerateMipmap`.
+
 - **No `glGetError()`**: Avoids forcing a GPU sync point. Errors are caught by the `GL_DEBUG_OUTPUT_SYNCHRONOUS` callback.
+
 - **Texture reuse**: If `recycled_hdr_tex` already matches dimensions and format, the pre-allocation is a **no-op** (zero-cost path).
 
 **Cost**: ~5-15ms first load, ~0ms on subsequent loads with same dimensions
@@ -167,6 +194,7 @@ Key decisions:
 glUnmapBuffer(PBO);
 glTexSubImage2D(..., 0);   // DMA from PBO offset 0
 glGenerateMipmap();        // Generates mip chain (also allocates mip levels)
+
 ```
 
 **Cost**: ~20-30ms (irreducible GPU work)
@@ -192,23 +220,32 @@ glGenerateMipmap();        // Generates mip chain (also allocates mip levels)
 flowchart TD
     A["app_update() called"] --> B{"pending_prealloc_w > 0?"}
     B -- Yes --> C["texture_preallocate_hdr()"]
+
     C --> D{"recycled_hdr_tex matches?"}
     D -- Yes --> E["Zero-cost reuse (OK)"]
+
     D -- No --> F["glTexImage2D(level 0, NULL)"]
+
     F --> G["Store in app->recycled_hdr_tex"]
     B -- No --> H["async_loader_poll()"]
+
     E --> H
     G --> H
     H --> I{"req.state?"}
     I -- WAITING_FOR_PBO --> J["PBO Setup & Map"]
+
     J --> K["Schedule pending_prealloc_w/h"]
     I -- ASYNC_READY --> L["texture_upload_hdr_from_pbo()"]
+
     L --> M{"reuse_tex matches?"}
     M -- Yes --> N["Skip glTexStorage2D (OK)"]
+
     M -- No --> O["Fallback: glTexStorage2D"]
+
     N --> P["glUnmapBuffer + glTexSubImage2D"]
     O --> P
     P --> Q["glGenerateMipmap"]
+
 ```
 
 ## Sync Point Removal (`glGetError` Audit)
@@ -242,6 +279,7 @@ sequenceDiagram
     GPU-->>CmdQueue: Done
     CmdQueue-->>CPU: GL_NO_ERROR
     Note over CPU: Can finally continue
+
 ```
 
 ### The Safety Net: `GL_DEBUG_OUTPUT_SYNCHRONOUS`
@@ -251,18 +289,23 @@ The application enables OpenGL debug output in synchronous mode (`gl_debug.c`):
 ```c
 glEnable(GL_DEBUG_OUTPUT);
 glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+
 ```
 
 This means **every GL error is already reported immediately** via the debug callback, making `glGetError()` calls redundant for error detection.
 
 ### Audit Results
 
-| Location | Context | Action | Rationale |
-| :---| :---|:---|:---|
+| Location              | Context         | Action   | Rationale                       |
+| :-------------------- | :-------------- | :------- | :------------------------------ |
 | `ssbo_rendering.c:24` | After SSBO init | **Kept** | Init-time only, negligible cost |
+
 | `texture.c` (was line 206) | Sticky error clear | **Removed** | Redundant with debug callback |
+
 | `texture.c` (was line 260) | After `glTexStorage2D` | **Debug-only** (`#ifndef NDEBUG`) | Fallback path, useful for debugging |
+
 | `texture.c` (was line 289) | After `glTexSubImage2D` | **Removed** | Hot path, debug callback catches errors |
+
 | `texture.c` (was line 309) | After `glGenerateMipmap` | **Removed** | Hot path, debug callback catches errors |
 
 ## Evolution of the Implementation
@@ -296,9 +339,13 @@ We implemented `upload_pbo[2]`.
 We split texture initialization across 3 frames and removed `glGetError()` sync points.
 
 - **PBO Setup** in Frame N (~1-5ms)
+
 - **VRAM Pre-allocation** deferred to Frame N+1 (~5-15ms, or 0ms with reuse)
+
 - **Upload + Mipmaps** in Frame N+M (~20-30ms)
+
 - **3 `glGetError()` sync points removed** from the upload path
+
 - **`glTexImage2D(level 0)` replaces `glTexStorage2D(13 levels)`**: lighter allocation, mip chain deferred
 
 **Result**: Worst-case frame spike reduced from ~60ms to ~20-30ms. With texture reuse (same dimensions), the pre-allocation frame is a no-op.
@@ -317,10 +364,14 @@ We use **Double-Buffered PBOs + Sync Fences**:
 
 1. **Trigger Phase (Frame N)**:
    - Call `glGetTexImage` into `pbo[idx]`.
+
    - Insert a fence: `sync[idx] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)`.
+
 2. **Read Phase (Frame N+1)**:
    - Check the fence: `glClientWaitSync(sync[!idx], ..., 0)`.
+
    - If `GL_ALREADY_SIGNALED` or `GL_CONDITION_SATISFIED`, map the PBO and read.
+
    - If not signaled, **skip the update** for this frame. This prevents the CPU from ever stalling at the cost of 1 extra frame of latency for HUD values.
 
 **Result**: Exposure calculation and histogram extraction cost **< 0.05ms** on the CPU, regardless of scene complexity.
@@ -328,7 +379,11 @@ We use **Double-Buffered PBOs + Sync Fences**:
 ## Code References
 
 - **`src/app.c`**: Manages the PBO array loop and deferred pre-allocation in `app_update`. Fields: `pending_prealloc_w`, `pending_prealloc_h`.
+
 - **`src/texture.c`**: `texture_ensure_pbo` (sizing), `texture_map_pbo` (flags), `texture_preallocate_hdr` (VRAM pre-allocation), `texture_upload_hdr_from_pbo` (upload pipeline).
+
 - **`src/async_loader.c`**: Handles the threading state machine (`WAITING_FOR_PBO`).
+
 - **`include/app.h`**: `App` struct holds `recycled_hdr_tex`, `pending_prealloc_w/h`, `upload_pbo[2]`.
+
 - **`src/gl_debug.c`**: Configures `GL_DEBUG_OUTPUT_SYNCHRONOUS`.

--- a/docs/auto_exposure_debug_histogram.md
+++ b/docs/auto_exposure_debug_histogram.md
@@ -9,8 +9,11 @@ The Auto Exposure Debug view provides a real-time visualization of the scene's l
 ### Key Features
 
 - **Real-time Histogram**: Displays the distribution of luminance across 256 buckets.
+
 - **PBO Integration**: Uses Pixel Buffer Objects (PBOs) for asynchronous readback from VRAM to RAM, minimizing CPU stalls.
+
 - **Continuity Caching**: Implements a cache to ensure the histogram display remains stable even when the GPU is slow to update the data.
+
 - **Independence from AE State**: The histogram calculation and rendering are automatically triggered when the debug view is active, even if the actual Auto Exposure effect is disabled.
 
 ## Technical Implementation
@@ -26,6 +29,7 @@ Before the histogram can be calculated, the scene is downsampled to a 64x64 text
 Instead of a direct `glGetTexImage` (which is a blocking operation), the readback is requested at the end of the post-processing pass and collected in subsequent frames.
 
 - **Double Buffering**: Two PBOs (`histogram_pbo[2]`) are used to alternate between request and readback frames.
+
 - **Sync Objects**: `glFenceSync` is used to track when the GPU has finished writing to the PBO.
 
 ### 3. Caching & Continuity Logic
@@ -34,17 +38,24 @@ To avoid the UI flickering when a frame's readback isn't ready, the system keeps
 
 - **Cache Fields** (`PostProcess` struct):
   - `last_buckets[256]`
+
   - `last_min_lum`
+
   - `last_max_lum`
+
   - `last_histogram_updated` (flag)
 
 When `postprocess_compute_luminance_histogram` is called:
 
 1. It checks if the current PBO sync object is signaled.
+
 2. If signaled:
    - It maps the PBO and zeros out the `last_buckets` cache.
+
    - It re-calculates the histogram from the new data.
+
    - It unmaps the PBO and updates the cache timestamp/flag.
+
 3. It always returns the contents of the cache if `last_histogram_updated` is true, providing a seamless visual experience.
 
 ## Testing Strategy
@@ -54,7 +65,9 @@ A dedicated test suite `tests/test_auto_exposure_debug.c` ensures the robustness
 ### Test Cases
 
 - **`test_histogram_caching_and_continuity`**: Verifies that the cache correctly provides data when the sync object is not yet signaled, and updates correctly when it is.
+
 - **`test_histogram_auto_trigger_when_ae_off`**: Confirms that enabling `POSTFX_EXPOSURE_DEBUG` automatically triggers the `fx_auto_exposure_render` pass inside `postprocess_end`, ensuring live data is available even if Auto Exposure is OFF.
+
 - **`test_histogram_cache_no_accumulation`**: Ensures that the `last_buckets` cache is properly cleared before being filled with new data, preventing values from "climbing" or stagnating over time.
 
 ## Visual Verification

--- a/docs/banding.md
+++ b/docs/banding.md
@@ -27,6 +27,7 @@ digraph BandingFlow {
     B -> C; B -> D; B -> E; B -> F; B -> G;
     C -> H; D -> H; E -> H; F -> H; G -> H;
 }
+
 ```
 
 ---
@@ -34,15 +35,23 @@ digraph BandingFlow {
 ## 🎨 Les 5 Styles Artistiques
 
 ### 1. Pop Art (Linear)
+
 Le mode le plus simple. Il divise l'espace colorimétrique en paliers égaux.
+
 - **Usage** : Pour un look "Cel-shaded" ou "Comic book".
+
 - **Maths** :
+
 \f[ result = \frac{\lfloor color \cdot levels \rfloor}{levels} \f]
 
 ### 2. Retro Computing (Dithered)
+
 Utilise une matrice de **Bayer 4x4** pour simuler des nuances intermédiaires via une grille de seuils.
+
 - **Usage** : Style Macintosh, GameBoy ou vieux moniteurs CGA.
+
 - **Principe** :
+
 ```graphviz
 digraph DitherFlow {
     rankdir=TD;
@@ -58,20 +67,29 @@ digraph DitherFlow {
 
     P -> Add -> Q -> Out;
 }
+
 ```
 
 ### 3. Analog (Perceptual)
+
 Applique une courbe de gamma avant la quantisation pour préserver plus de détails dans les zones sombres.
+
 - **Usage** : Look "capteur vidéo vintage".
+
 - **Avantage** : Évite les aplats noirs massifs dans les ombres.
+
 \f[ result = \left( \frac{\lfloor color^{\gamma} \cdot levels \rfloor}{levels} \right)^{\frac{1}{\gamma}} \f]
 
 ### 4. CGA/VGA Style (Channel)
+
 Réduit la précision de chaque canal RGB indépendamment.
+
 - **Usage** : Simuler des palettes matérielles limitées (ex: 8 niveaux de rouge, 8 de vert, 4 de bleu).
 
 ### 5. Blueprint (Luminance)
+
 Quantise la luminance perçue de l'image, puis applique une teinte colorée.
+
 - **Usage** : Schémas techniques, hologrammes, interfaces futuristes.
 
 ---
@@ -79,7 +97,8 @@ Quantise la luminance perçue de l'image, puis applique une teinte colorée.
 ## ⚙️ Paramètres (PostProcessPreset)
 
 | Paramètre | Description |
-| :--- | :--- |
+| :-------- | :---------- |
+
 | `mode` | Sélecteur du style (0 à 4). |
 | `levels` | Nombre de niveaux de couleurs (ex: 2.0 = Noir/Blanc). |
 | `dither_strength` | Intensité du grain (Mode 1 uniquement). |
@@ -107,4 +126,5 @@ digraph TechnicalFlow {
     C -> U [label="Update"];
     U -> S [label="Uniforms"];
 }
+
 ```

--- a/docs/billboard_optimization.md
+++ b/docs/billboard_optimization.md
@@ -23,8 +23,11 @@ We solve this problem in 2D, independently for the X (width) and Y (height) axes
 Consider the top-down view (XZ plane) shown in the diagram above:
 
 - **O**: Camera Origin at $(0,0)$.
+
 - **C**: Sphere Center at $(C_x, C_z)$.
+
 - **r**: Sphere Radius.
+
 - **d**: Distance from Origin to Center ($d = \|C\|$).
 
 We want to find the tangent lines $T_1$ and $T_2$.
@@ -38,9 +41,9 @@ We can find the normal vectors of the tangent lines using simple 2D vector rotat
 The tangent lines are rotated relative to the center vector $\vec{C}$ by the angle $\alpha$.
 By observing the similar triangles, we can derive the tangent direction vectors directly from $C$, $r$, and $L$:
 
-$$ n_{x1} = \frac{C_x \cdot L - C_z \cdot r}{d^2} $$
+$$ n\_{x1} = \frac{C_x \cdot L - C_z \cdot r}{d^2} $$
 
-$$ n_{z1} = \frac{C_z \cdot L + C_x \cdot r}{d^2} $$
+$$ n\_{z1} = \frac{C_z \cdot L + C_x \cdot r}{d^2} $$
 
 (And symmetrically for the second tangent).
 
@@ -51,9 +54,10 @@ Once we have the normal vector $(n_x, n_z)$ of a tangent line (which represents 
 For a standard perspective projection matrix $P$:
 
 - $P_{00}$ scales X (based on Field of View).
+
 - We project by dividing $x$ by $-z$ (since OpenGL looks down -Z).
 
-$$ x_{ndc} = P_{00} \cdot \frac{n_x}{-n_z} $$
+$$ x*{ndc} = P*{00} \cdot \frac{n_x}{-n_z} $$
 
 This gives us the exact screen-space coordinate of the edge of the sphere. We calculate the min/max of both tangents to find the AABB width. The same logic applies to the Y axis.
 
@@ -62,7 +66,9 @@ This gives us the exact screen-space coordinate of the edge of the sphere. We ca
 This method provides a **pixel-perfect bounding box**:
 
 - **0% Overdraw** outside the sphere's actual screen footprint (excluding the corner areas of the quad).
+
 - **Correct Perspective**: Handles elliptical distortion at screen edges perfectly.
+
 - **Efficient**: Uses only square roots and basic arithmetic, avoiding expensive trigonometric functions (`acos`, `atan`).
 
 ## Robustness Handling
@@ -83,6 +89,7 @@ p1 = sign(nx1) * 10000.0;
 
 // ✅ After: explicit ternary, no zero case
 p1 = (nx1 >= 0.0 ? 1.0 : -1.0) * 10000.0;
+
 ```
 
 This singularity occurs when the tangent line is exactly axis-aligned ($n_x = 0$), which is geometrically possible for a sphere centered on the view axis.
@@ -99,6 +106,7 @@ Spheres located entirely behind the camera can mathematically project to valid s
 
 // ✅ After: volume-aware test — only cull when entirely behind
 } else if (viewPos.z > sphereRadius) {
+
 ```
 
 The previous test `viewPos.z > 0.0` only checked the sphere **center**. A sphere whose center is behind the camera ($z > 0$) but whose volume extends in front (e.g. center at $z = +0.5$, radius $= 2.0$) was incorrectly culled. The corrected test `viewPos.z > sphereRadius` ensures the **nearest point** of the sphere ($z_{center} - r$) is behind the camera before culling.
@@ -111,13 +119,16 @@ The previous test `viewPos.z > 0.0` only checked the sphere **center**. A sphere
   │  │  C  │  center behind (z=0.5)
   │  │  ●  │  but sphere extends in front
   │  │     │  nearest point = z - r = -1.5
+
   │  └─────┘
+
 ```
 
 ### 3. Conservative Depth
 
 To ensure correct Z-buffering when the sphere intersects other geometry (e.g. a wall or floor passing through it), the billboard quad is positioned at the sphere's **frontmost plane** ($Z_{nearest} = Z_{view} + R$) rather than its center.
-This ensures the quad is drawn *before* any intersecting geometry that might be inside the sphere, safeguarding against incorrect occlusion. The Fragment Shader then outputs the precise per-pixel depth (`gl_FragDepth`) to carve out the true spherical shape.
+
+This ensures the quad is drawn _before_ any intersecting geometry that might be inside the sphere, safeguarding against incorrect occlusion. The Fragment Shader then outputs the precise per-pixel depth (`gl_FragDepth`) to carve out the true spherical shape.
 
 The nearest Z is clamped to stay in front of the near plane. The near plane distance is now **derived dynamically** from the projection matrix instead of being hardcoded:
 
@@ -127,7 +138,9 @@ nearestZ = min(nearestZ, -0.11);
 
 // ✅ After: extracted from the projection matrix
 float zNear = projection[3][2] / (projection[2][2] - 1.0);
+
 nearestZ = min(nearestZ, -(zNear + 0.01));
+
 ```
 
 For a standard OpenGL perspective matrix:
@@ -160,7 +173,7 @@ By default, OpenGL performs perspective-correct interpolation. Even if all four 
 
 Using `flat out` in the Vertex Shader and `flat in` in the Fragment Shader ensures bit-perfect consistency by disabling interpolation. Instead, the value is taken from a single vertex (the **Provoking Vertex**), guaranteeing "ISO" rendering results identical to geometric spheres.
 
-- **See also**: [Flat Interpolation (Khronos Wiki)](https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Interpolation_qualifiers) and [Provoking Vertex (Khronos Wiki)](https://www.khronos.org/opengl/wiki/Primitive#Provoking_vertex).
+- **See also**: [Flat Interpolation (Khronos Wiki)](<https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Interpolation_qualifiers>) and [Provoking Vertex (Khronos Wiki)](https://www.khronos.org/opengl/wiki/Primitive#Provoking_vertex).
 
 ### 5. Inside-Sphere Epsilon Robustness
 
@@ -172,14 +185,15 @@ if (distSq <= r2 * 1.005)
 
 // ✅ After: additive floor ensures a minimum absolute margin
 if (distSq <= r2 + max(r2 * 0.005, 1e-4))
+
 ```
 
 | Sphere Radius | Old Margin ($r^2 \times 0.005$) | New Margin ($\max(r^2 \times 0.005,\; 10^{-4})$) |
-| :---: | :---: | :---: |
-| $r = 10.0$ | $0.5$ | $0.5$ |
-| $r = 1.0$ | $0.005$ | $0.005$ |
-| $r = 0.01$ | $5 \times 10^{-7}$ | $10^{-4}$ ✅ |
-| $r = 0.001$ | $5 \times 10^{-9}$ | $10^{-4}$ ✅ |
+| :-----------: | :-----------------------------: | :----------------------------------------------: |
+|  $r = 10.0$   |              $0.5$              |                      $0.5$                       |
+|   $r = 1.0$   |             $0.005$             |                     $0.005$                      |
+|  $r = 0.01$   |       $5 \times 10^{-7}$        |                   $10^{-4}$ ✅                   |
+|  $r = 0.001$  |       $5 \times 10^{-9}$        |                   $10^{-4}$ ✅                   |
 
 For large spheres, the multiplicative term dominates. For very small spheres (e.g. particle systems), the additive floor $10^{-4}$ prevents false-negative detection caused by float32 precision limits.
 
@@ -192,12 +206,15 @@ The projection matrix diagonal elements `sx = projection[0][0]` and `sy = projec
 When comparing this optimized billboard rendering to a traditional triangle-based sphere (Reference), a "diff map" will often show persistent colored rings around the silhouettes. This is **expected** and proves the accuracy of the mathematical approach:
 
 1. **Perfect Silhouette:** The billboard computes a mathematically perfect curve for every pixel. An icosphere, regardless of subdivision, is an approximation made of flat triangles. The rings represent the areas where the triangle edges deviate from the perfect sphere.
+
 2. **Anti-Aliasing Clash:** Our shader uses **Analytical Edge Smoothing** (Soft Edges). Standard mesh rendering uses hardware rasterization. The transition from 100% to 0% opacity differs slightly, producing residuals in difference maps.
+
 3. **Normal Continuity:** Ray-casted normals are perfectly continuous, while mesh normals (even when smoothed) depend on the underlying vertex interpolation.
 
 ## References
 
-- **Mara, M., McGuire, M., & Luebke, D. (2013).** *2D Polyhedral Bounds of a Clipped, Perspective-Projected 3D Sphere*. Journal of Computer Graphics Techniques (JCGT).
+- **Mara, M., McGuire, M., & Luebke, D. (2013).** _2D Polyhedral Bounds of a Clipped, Perspective-Projected 3D Sphere_. Journal of Computer Graphics Techniques (JCGT).
+
   [PDF Reference](https://jcgt.org/published/0002/02/05/)
 
 See `shaders/pbr_ibl_billboard.vert` for the GLSL implementation.
@@ -217,9 +234,15 @@ The following image (from Mara et al.) demonstrates how the spherical projection
 Five corrections applied to `projection_utils.glsl` following a mathematical audit of `computeBillboardSphere`:
 
 | # | Severity | Fix | Section |
+
 | --- | ---------- | ----- | --------- |
+
 | 1 | **Bug** | Behind-camera cull: `viewPos.z > 0.0` → `viewPos.z > sphereRadius` — spheres straddling the camera plane are no longer incorrectly culled | §2 |
+
 | 2 | **Robustness** | Near plane clamp derived from projection matrix instead of hardcoded `-0.11` — decoupled from CPU-side `NEAR_PLANE` | §3 |
+
 | 3 | **Robustness** | `sign(nx)` → `(nx >= 0.0 ? 1.0 : -1.0)` — prevents `sign(0)=0` bound collapse | §1 |
+
 | 4 | **Quality** | Inside-sphere epsilon: `r² × 1.005` → `r² + max(r² × 0.005, 1e-4)` — robust at all sphere scales | §5 |
+
 | 5 | **Style** | `sx`/`sy` hoisted before branch chain, removing duplication | §6 |

--- a/docs/bloom_debug.md
+++ b/docs/bloom_debug.md
@@ -10,11 +10,16 @@ The Bloom effect is constructed through multiple stages (Prefilter, Downsample c
 
 - **SHIFT + 'B'**: Cycles through the construction stages.
   - **Final Map**: The final reconstructed bloom texture (Level 0).
+
   - **Prefilter**: The result of the high-pass filter.
+
   - **Downsample**: Visualization of a specific level in the downsampling chain.
+
   - **Upsample**: Visualization of the progressive blending.
+
 - **ALT + 'B'**: Cycles through **Mip Levels** (0 to 4).
   - In **Downsample** mode: Shows the output of each downscaling pass.
+
   - In **Upsample** mode: Shows the result of the blending at different resolutions.
 
 ## Implementation Details
@@ -24,10 +29,13 @@ The Bloom effect is constructed through multiple stages (Prefilter, Downsample c
 When `POSTFX_BLOOM_DEBUG` is active in the `active_effects` bitmask:
 
 1. `fx_bloom_render` executes only up to the requested `debug_step`.
+
 2. The pipeline uses `goto end_bloom` to bypass unnecessary work.
+
 3. The `postprocess.frag` shader detects the debug flag and outputs the sampled `bloomTexture` directly, bypassing other effects (Film Grain, Vignette, etc.) for a clean visualization.
 
 ### UI Integration
 
 The current state is displayed in the **Status Overlay** (toggle with F1):
+
 `Bloom Debug: [Stage] | Mip: [N]`

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,9 +5,13 @@ This project uses **CMake** for build automation and dependency management. To f
 ## Build Requirements
 
 - **CMake** 3.14 or higher
+
 - **Clang** or **GCC** (C99 support)
+
 - **Python 3** (required by GLAD for code generation)
+
 - **GLFW 3** (system library)
+
 - **Pkg-config**
 
 ## Distrobox Integration
@@ -17,14 +21,23 @@ The project is optimized for a container named `clang-dev`. A `Makefile` wrapper
 ### Common Commands
 
 - `make`: Configures and builds the project inside the container.
+
 - `make debug`: Builds with dynamic shaders (Dev mode).
+
 - `make release`: Builds with optimized static shaders (Production mode).
+
 - `make run`: Builds and executes the application (Debug).
+
 - `make run-release`: Builds and executes the application (Release).
+
 - `make rebuild`: Performs a clean build from scratch (useful when dependencies change).
+
 - `make format`: Formats all C source and header files using **clang-format**.
+
 - `make lint`: Performs static analysis across the codebase using **clang-tidy** (Guaranteed **0 warnings**).
+
 - `make docs`: Builds MkDocs + Doxygen documentation.
+
 - `make clean-all`: Nukes the `build/` directory.
 
 ## Offline Build Support
@@ -32,26 +45,37 @@ The project is optimized for a container named `clang-dev`. A `Makefile` wrapper
 For development without an internet connection, you can cache dependencies locally.
 
 ### 1. Preparation (Online)
+
 Run the following command while you have an active internet connection:
+
 ```bash
 make deps-setup
+
 ```
+
 This script will clone `cglm`, `glad`, `stb`, `unity`, `cjson` into a local `deps/` directory (automatically ignored by Git).
 
 ### 2. Building (Offline)
+
 Once the `deps/` directory is populated, CMake will automatically detect it and use the local sources instead of trying to download them. Simply run:
+
 ```bash
 make
+
 ```
 
 To remove the local cache, use `make deps-clean`.
 
 ### 3. Testing the Offline Mode
+
 To verify that the build truly doesn't reach the network, you can run it in a simulated offline environment:
+
 ```bash
 make offline-test
+
 ```
-*Note: This command sets `http_proxy` to a non-existent local address to block network access. This method is used instead of `unshare -rn` to ensure compatibility with Distrobox/Podman.*
+
+_Note: This command sets `http_proxy` to a non-existent local address to block network access. This method is used instead of `unshare -rn` to ensure compatibility with Distrobox/Podman._
 
 ## Dependency Management
 
@@ -60,28 +84,35 @@ Dependencies are automatically managed via CMake's `FetchContent` module. No man
 ### cglm (OpenGL Mathematics for C)
 
 - **Source**: [recp/cglm](https://github.com/recp/cglm)
+
 - **Configuration**: Built as a **static library** (`CGLM_STATIC=ON`).
+
 - **Automation**: Fetched at configuration time.
 
 ### GLAD (OpenGL Loader Generator)
 
 - **Source**: [Dav1dde/glad](https://github.com/Dav1dde/glad)
+
 - **Configuration**: Programmatically generates headers and source for **OpenGL 4.4 Core**.
+
 - **Automation**: The generator script is fetched and executed during the CMake configuration phase.
 
 ### GLFW
 
 - **Source**: System library.
+
 - **Automation**: Located using `pkg-config`. Ensure `glfw-devel` (or equivalent) is installed in your development container.
 
 ### Unity
 
 - **Source**: [ThrowTheSwitch/Unity](https://github.com/ThrowTheSwitch/Unity)
+
 - **Automation**: Fetched at configuration time.
 
 ### cJSON
 
 - **Source**: [DaveGamble/cJSON](https://github.com/DaveGamble/cJSON)
+
 - **Automation**: Fetched at configuration time.
 
 ## Security Hardening
@@ -89,8 +120,11 @@ Dependencies are automatically managed via CMake's `FetchContent` module. No man
 The project enforces strict security flags during compilation to mitigate memory corruption vulnerabilities:
 
 - **Stack Protection**: `-fstack-protector-strong` adds stack canaries to detect buffer overflows.
+
 - **Format Security**: `-Wformat -Wformat-security` prevents format string attacks.
+
 - **Fortify Source**: `_FORTIFY_SOURCE=2` adds runtime checks for common string/memory functions.
+
 - **Linker Hardening**: RELRO, NOW, and NoExecStack are enabled to protect the GOT and prevent stack execution.
 
 ## Fast Parallel Builds
@@ -98,11 +132,15 @@ The project enforces strict security flags during compilation to mitigate memory
 The build is optimized for speed using parallel compilation:
 
 ```bash
+
 # Via the Makefile wrapper
+
 make all  # Executes cmake --build build --parallel
 
 # Directly via CMake
+
 cmake --build build -j$(nproc)
+
 ```
 
 ## Logging System
@@ -110,7 +148,9 @@ cmake --build build -j$(nproc)
 The application uses a structured logging system to facilitate development and monitoring.
 
 - **INFO Level**: Asset loading, GPU info, user state changes.
+
 - **ERROR Level**: Shader compilation failures, allocation errors, window creation failure.
+
 - **WARN Level**: Detects non-critical anomalies.
 
 **Format**: `2026-01-13 10:05:10,133 - module - LEVEL - message`
@@ -120,17 +160,27 @@ The application uses a structured logging system to facilitate development and m
 Thanks to `FetchContent`, the following libraries are managed without manual intervention:
 
 1. **cglm**: Compiled as a static library optimized for your CPU.
+
 2. **GLAD**: Generated on the fly to target exactly the OpenGL 4.4 Core profile.
+
 3. **stb_image**: Automation via FetchContent. The implementation is isolated in `src/stb_image_impl.c` to guarantee perfectly clean linting on the remaining source files.
+
 4. **unity**: Automation via FetchContent.
+
 5. **cjson**: Automation via FetchContent.
 
 ## Folder Structure
 
 - `CMakeLists.txt`: Core of the build system.
+
 - `Makefile`: Shortcuts for Docker/Distrobox and fast builds.
+
 - `docs/`: Full engine documentation.
+
 - `src/log.c`: Core of the logging system.
+
 - `assets/`: Folder containing assets.
+
 - `assets/env.hdr`: Source environment texture (Equirectangular).
+
 - `deps/`: Folder containing external dependencies.

--- a/docs/cicd_pipeline.md
+++ b/docs/cicd_pipeline.md
@@ -12,17 +12,26 @@ The workflow is triggered automatically events:
 
 - **Push to `master` or `main`**:
   - Triggers the full pipeline (Lint, Test, Docs, Build).
+
   - Updates the **Nightly Release**.
+
   - Deploys the latest documentation to GitHub Pages.
+
 - **Pull Requests**:
   - Runs quality checks (Lint, Format).
+
   - Runs unit tests and visual regression tests.
+
   - Generates a documentation preview (deployed to Surge.sh).
+
 - **Tags (`v*`)**:
   - Triggers a **Stable Release** build.
+
   - Creates a GitHub Release with the corresponding version number.
+
 - **Schedule (Cron)**:
   - Runs daily at **01:00 UTC**.
+
   - Ensures a fresh **Nightly Build** is generated every day from the latest code.
 
 ## Workflow Jobs
@@ -30,64 +39,91 @@ The workflow is triggered automatically events:
 ### 1. `lint-and-format` (Quality)
 
 - **Goal**: Ensure code style and quality.
+
 - **Tools**: `clang-format`, `clang-tidy`, `ruff` (Python).
+
 - **Checks**:
   - Fails if `make format` results in file changes (enforces code style).
+
   - Runs `make lint` for static analysis.
 
 ### 2. `test-and-coverage` (Validation)
 
 - **Goal**: Verify functionality and prevent regressions.
+
 - **Environment**: Runs under **Xvfb** (Virtual Framebuffer) to simulate a display server for OpenGL tests.
+
 - **Steps**:
   - Runs Python tests (`pytest`).
+
   - Runs C Unit Tests with Code Coverage (`llvm-cov`).
+
   - **Visual Regression**: Captures 6 rendered views (cube faces) and compares them against PNG reference images.
+
   - **Dynamic Reporting**: A Python script generates an interactive HTML index and a Markdown PR comment with hover-comparisons for all 6 faces.
 
 ### 3. `documentation` (Docs)
 
 - **Goal**: Generate and publish technical documentation.
+
 - **Tools**: Doxygen, Graphviz, MkDocs.
+
 - **Outputs**:
   - Combines manual Markdown docs and auto-generated C API docs.
+
   - **Pull Requests**: Deploys a preview link to [Surge.sh](https://surge.sh).
+
   - **Master/Main**: Prepares artifacts for GitHub Pages deployment.
 
 ### 4. `build-production` (Compilation)
 
 - **Goal**: Compile optimized binaries for users.
+
 - **Configurations**:
   - **Release**: Standard optimized build (`-O2` / `-O3`).
+
   - **Profiling**: Includes symbols and profiling markers.
+
   - **UltraRelease**: Aggressive optimizations (`-DENABLE_UNITY_BUILD`, `-march=native`, `-ffast-math`).
+
 - **Artifacts**: Binaries are saved for the Release step.
 
 ### 5. Script Organization
 
 - **Location**: `.github/workflows/scripts/`
+
 - **Core Scripts**:
   - `generate_visual_report.py`: Handles dynamic report generation.
+
   - `run_test_with_xvfb.sh`: Wrapper for OpenGL tests in headless environments.
+
   - `test_trace_analyze.py`: Python unit tests for the trace analyzer.
 
 ### 6. `deploy-pages` (Web)
 
 - **Goal**: Update the official documentation site.
+
 - **Trigger**: Only on `master` or `main` push.
+
 - **Action**: Deploys the content of the `documentation` job to GitHub Pages.
 
 ### 7. `release` (Distribution)
 
 - **Goal**: Publish binaries and source code.
+
 - **Logic**:
   - **Nightly**:
     - Triggered by push to `master/main` OR daily schedule.
+
     - Updates the `nightly` git tag to the current commit.
+
     - Overwrites the "Nightly Build" release with new assets.
+
     - **NOT a Draft**: Immediately available.
+
   - **Stable (Tagged)**:
     - Triggered by pushing a tag like `v1.0.0`.
+
     - Creates a new standard release titled with the version name.
 
 ## Release Artifacts
@@ -95,6 +131,9 @@ The workflow is triggered automatically events:
 Each release (Nightly or Stable) contains:
 
 - `app-Release`: The main executable.
+
 - `app-Profiling`: Version for performance analysis.
+
 - `app-UltraRelease`: Experimental high-performance build.
+
 - Source code archives (`zip`, `tar.gz`).

--- a/docs/cpu_profiling_flamegraph.md
+++ b/docs/cpu_profiling_flamegraph.md
@@ -7,34 +7,47 @@ This guide provides a comprehensive, step-by-step methodology for CPU profiling 
 
 ---
 
-## 📋 Table of Contents
+## Table of Contents
 
-1. [Prerequisites & Installation](#prerequisites-installation)
+1. [Prerequisites & Installation](#prerequisites--installation)
+
 2. [Build Configuration](#build-configuration)
+
 3. [Recording Performance Data](#recording-performance-data)
+
 4. [Analyzing with perf report](#analyzing-with-perf-report)
+
 5. [Generating FlameGraphs](#generating-flamegraphs)
+
 6. [Interpreting Results](#interpreting-results)
+
 7. [Real-World Example: test_app](#real-world-example-test_app)
+
 8. [Troubleshooting](#troubleshooting)
 
 ---
 
-## 📦 Prerequisites & Installation
+## Prerequisites & Installation
 
 ### Debian-based Systems (Debian, Ubuntu, Linux Mint, etc.)
 
 ```bash
+
 # Install perf (Linux performance counters)
+
 sudo apt update
 sudo apt install linux-perf
 
 # Install FlameGraph tools
+
 cd ~/tools  # or any directory you prefer
+
 git clone https://github.com/brendangregg/FlameGraph.git
 
 # Add to PATH (add to ~/.bashrc for persistence)
+
 export PATH="$HOME/tools/FlameGraph:$PATH"
+
 ```
 
 ### Bazzite / Fedora Atomic / immutable systems
@@ -42,62 +55,80 @@ export PATH="$HOME/tools/FlameGraph:$PATH"
 Bazzite uses `rpm-ostree` for system packages. For development tools, use a container (toolbox/distrobox):
 
 ```bash
+
 # Create a development container
+
 distrobox create --name dev-box --image fedora:latest
 
 # Enter the container
+
 distrobox enter dev-box
 
 # Inside the container:
+
 sudo dnf install perf
 
 # Clone FlameGraph
+
 cd ~/tools
 git clone https://github.com/brendangregg/FlameGraph.git
 export PATH="$HOME/tools/FlameGraph:$PATH"
+
 ```
 
 **Alternative (host install via rpm-ostree)**:
 
 ```bash
+
 # On Bazzite host (not recommended for dev tools)
+
 rpm-ostree install perf
 sudo systemctl reboot  # Required for atomic layering
+
 ```
 
 ### Verification
 
 ```bash
+
 # Check perf is installed
+
 perf --version
 
 # Check FlameGraph scripts
+
 ls ~/tools/FlameGraph/*.pl
+
 ```
 
 Expected output:
 
-```
+```text
 perf version 6.x.x
 flamegraph.pl  stackcollapse-perf.pl  (and others)
+
 ```
 
 ---
 
-## 🔧 Build Configuration
+## Build Configuration
 
 For optimal profiling results, build with **debug symbols** and **optimizations**:
 
 ### CMake Projects
 
 ```bash
+
 # Option 1: RelWithDebInfo (Recommended)
+
 cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build -j$(nproc)
 
 # Option 2: Profiling build type (if available)
+
 cmake -B build-prof -DCMAKE_BUILD_TYPE=Profiling
 cmake --build build-prof -j$(nproc)
+
 ```
 
 ### Makefile Projects
@@ -106,35 +137,45 @@ For this project:
 
 ```bash
 make build-prof  # Uses Profiling build type
+
 ```
 
 **Key compiler flags**:
 
 - `-O3` or `-O2`: Enable optimizations (realistic performance)
+
 - `-g`: Include debug symbols (function names, line numbers)
+
 - `-fno-omit-frame-pointer`: Preserve stack frames for accurate call graphs
 
 ---
 
-## 📊 Recording Performance Data
+## Recording Performance Data
 
 ### Basic Recording
 
 ```bash
+
 # Record with default settings (99 Hz sampling)
+
 perf record -g ./build/tests/test_app
 
 # Record with custom frequency (e.g., 1000 Hz for finer granularity)
+
 perf record -F 1000 -g ./build/tests/test_app
 
 # Record with call-graph (DWARF unwinding, recommended)
+
 perf record -g --call-graph dwarf ./build/tests/test_app
+
 ```
 
 **Flags explained**:
 
 - `-g`: Enable call-graph (stack) recording
+
 - `-F <freq>`: Sampling frequency in Hz (default: 99)
+
 - `--call-graph dwarf`: Use DWARF debug info for unwinding (more accurate)
 
 ### Recording Xvfb Tests (Headless)
@@ -143,6 +184,7 @@ For tests running in Xvfb:
 
 ```bash
 perf record -g xvfb-run -a -s "-screen 0 1024x768x24" ./build/tests/test_app
+
 ```
 
 ### Output
@@ -151,50 +193,66 @@ This creates a `perf.data` file in the current directory (~10-50 MB depending on
 
 ---
 
-## 📈 Analyzing with perf report
+## Analyzing with perf report
 
 ### Interactive TUI
 
 ```bash
 perf report
+
 ```
 
 **Navigation**:
 
 - `↑`/`↓`: Navigate functions
+
 - `Enter`: Expand call stack
+
 - `a`: Annotate selected function (assembly view)
+
 - `q`: Quit
 
 ### Text Report
 
 ```bash
+
 # Summary report (top functions by sample count)
+
 perf report --stdio | head -50
 
 # Detailed call graph
+
 perf report --stdio --call-graph --show-nr-samples | less
+
 ```
 
 ### Sample Output
 
-```
+```text
+
 # Overhead  Command     Shared Object       Symbol
+
 #  21.60%   test_app    libGL.so.1          [.] glTexImage2D
+
 #  17.80%   test_app    libGL.so.1          [.] glTexSubImage2D
+
 #  11.70%   test_app    test_app            [.] shader_compile
+
 #   9.40%   test_app    test_app            [.] icosphere_generate
+
 ```
 
 **Interpretation**:
 
 - `Overhead`: % of samples in this function
+
 - `Symbol`: Function name (if symbols available)
+
 - `[.]`: Userspace code, `[k]`: Kernel code
 
 ---
 
-## 🔥 Generating FlameGraphs
+## Generating FlameGraphs
 
 FlameGraphs provide an intuitive visual representation of call stacks.
 
@@ -202,40 +260,48 @@ FlameGraphs provide an intuitive visual representation of call stacks.
 
 ```bash
 perf script | stackcollapse-perf.pl > perf-folded.txt
+
 ```
 
 - `perf script`: Converts `perf.data` to text format
+
 - `stackcollapse-perf.pl`: Aggregates identical stack traces
 
 ### Step 2: Generate SVG
 
 ```bash
 flamegraph.pl perf-folded.txt > flamegraph.svg
+
 ```
 
 ### One-Liner
 
 ```bash
 perf script | stackcollapse-perf.pl | flamegraph.pl > flamegraph.svg
+
 ```
 
 ### Viewing
 
 ```bash
+
 # Open in browser
+
 xdg-open flamegraph.svg
 
 # Or copy to artifact directory
+
 cp flamegraph.svg /path/to/artifacts/
+
 ```
 
 ---
 
-## 🔍 Interpreting Results
+## Interpreting Results
 
 ### FlameGraph Anatomy
 
-```
+```text
 ┌────────────────────────────────────────────────────────────┐
 │                       main (100%)                          │  ← Entry point
 ├────────────┬───────────────────────────────┬───────────────┤
@@ -247,54 +313,71 @@ cp flamegraph.svg /path/to/artifacts/
                        └─────────────┴────────────────────────
                               ▲
                          Width = CPU time
+
 ```
 
 - **X-axis (width)**: Proportion of total CPU time
+
 - **Y-axis (height)**: Call stack depth (caller → callee)
+
 - **Color**: Random (for visual separation only)
 
 ### Identification of Bottlenecks
 
 1. **Wide boxes**: Functions consuming significant CPU time
+
 2. **Patterns**:
    - **Plateau**: CPU bound (good utilization)
+
    - **Tower**: Deep call chains (potential overhead)
+
    - **Fragmentation**: Many small calls (cache/branch issues)
 
 ### Example Analysis (test_app)
 
 From today's profiling session (2026-02-11):
 
-```
+```text
 Total samples: 4800
 Total time: 17.01 seconds
 
 Top hotspots:
+
 1. Texture Loading (HDR): 6.7s (39%)
+
    - glTexImage2D: 3.7s
+
    - glTexSubImage2D: 3.0s
 
 2. Rendering & Capture: 3.8s (22%)
+
    - app_render: 2.5s
+
    - glReadPixels: 1.3s
 
 3. Window/Context Init: 2.8s (16%)
+
    - glfwCreateWindow: 1.8s
+
    - GL initialization: 1.0s
 
 4. Shader Compilation: 2.0s (12%)
+
    - shader_compile_from_file: 2.0s
+
 ```
 
 **Optimization targets**:
 
 - Cache HDR texture (avoid reload)
+
 - Use PBO for async `glReadPixels`
+
 - Disable expensive GPU effects in tests
 
 ---
 
-## 🎯 Real-World Example: test_app
+## Real-World Example: test_app
 
 ### Context
 
@@ -303,56 +386,69 @@ Profiling the `test_app` integration test to identify slowness (17s execution).
 ### Commands Used
 
 ```bash
+
 # Build with profiling symbols
+
 cmake -B build -DCMAKE_BUILD_TYPE=Profiling
 cmake --build build --target test_app -j$(nproc)
 
 # Record execution
+
 perf record -F 1000 -g xvfb-run -a -s "-screen 0 1024x768x24" ./build/tests/test_app
 
 # Analyze interactively
+
 perf report
 
 # Generate flamegraph
+
 perf script | stackcollapse-perf.pl | flamegraph.pl > test_app_flamegraph.svg
+
 ```
 
 ### Key Findings
 
-| Bottleneck | Time | % | Solution Implemented |
-|------------|------|---|---------------------|
-| HDR texture upload | 6.7s | 39% | ✅ Cache texture between tests |
-| `glReadPixels` sync | 1.3s | 8% | ✅ Use PBO async readback |
-| Post-processing | 1.5s | 9% | ❌ Kept for ISO production |
-| IBL generation | 17s | Varies | ⚠️ Outside test scope |
+| Bottleneck          | Time | %      | Solution Implemented           |
+| ------------------- | ---- | ------ | ------------------------------ |
+| HDR texture upload  | 6.7s | 39%    | ✅ Cache texture between tests |
+| `glReadPixels` sync | 1.3s | 8%     | ✅ Use PBO async readback      |
+| Post-processing     | 1.5s | 9%     | ❌ Kept for ISO production     |
+| IBL generation      | 17s  | Varies | ⚠️ Outside test scope          |
 
 ### Results
 
 - **Before**: 17.0s
+
 - **After** (with optimizations): 22.7s (IBL variation)
+
 - **Test portion**: 3.8s → ~5.2s (with full GPU effects)
 
 > **Note**: The increase is due to IBL generation variability, not regression in test code.
 
 ---
 
-## 🛠️ Troubleshooting
+## Troubleshooting
 
 ### Permission Errors
 
-```
+```text
 Error: Access to performance monitoring and observability operations is limited
+
 ```
 
 **Solution** (on host, not in container):
 
 ```bash
+
 # Temporary
+
 sudo sysctl -w kernel.perf_event_paranoid=1
 
 # Permanent
+
 echo "kernel.perf_event_paranoid = 1" | sudo tee /etc/sysctl.d/99-perf.conf
 sudo sysctl --system
+
 ```
 
 ### Missing Symbols
@@ -362,27 +458,37 @@ If you see hex addresses instead of function names:
 **Check debug symbols**:
 
 ```bash
+
 # View information about object files.
+
 objdump -t ./build/tests/test_app | grep debug
+
 # List symbol names in object files.
+
 nm ./build/tests/test_app | head
+
 ```
 
 **Rebuild with symbols**:
 
 ```bash
 cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
 ```
 
 ### FlameGraph Scripts Not Found
 
 ```bash
+
 # Ensure FlameGraph is in PATH
+
 export PATH="$HOME/tools/FlameGraph:$PATH"
 
 # Or use absolute paths
+
 ~/tools/FlameGraph/stackcollapse-perf.pl
 ~/tools/FlameGraph/flamegraph.pl
+
 ```
 
 ### perf.data Too Large
@@ -391,29 +497,36 @@ Reduce sampling frequency:
 
 ```bash
 perf record -F 99 -g ./app  # Default
+
 perf record -F 49 -g ./app  # Half rate
+
 ```
 
 Or limit duration:
 
 ```bash
 perf record -g --duration 5000 ./app  # 5 seconds
+
 ```
 
 ---
 
-## 📚 Additional Resources
+## Additional Resources
 
 - **Brendan Gregg's Perf Examples**: <https://www.brendangregg.com/perf.html>
+
 - **FlameGraph Documentation**: <https://github.com/brendangregg/FlameGraph>
+
 - **Linux perf Wiki**: <https://perf.wiki.kernel.org/>
 
 ---
 
-## 🔗 Related Documentation
+## Related Documentation
 
 - [GPU Profiling System](gpu_profiling.md) - For GPU timeline profiling
+
 - [Profiling Guide](profiling_guide.md) - ApiTrace workflow for OpenGL calls
+
 - [Performance Monitoring](perf_profiling.md) - Quick reference for perf setup
 
 ---

--- a/docs/cubemap_seam_resolution.md
+++ b/docs/cubemap_seam_resolution.md
@@ -1,14 +1,16 @@
-
 # Cubemap Seam Resolution
 
 ## 🔍 Identified Problem
 
 The edges of the cubemap are visible as lines or artifacts. This can be caused by several factors:
 
-1.  **LOD too high**: A high `blur_lod` (4.0) uses low-resolution mipmap levels.
-2.  **Insufficient Resolution**: 512x512 might be too small.
-3.  **Filtering without seamless**: Transitions between faces are not smoothed.
-4.  **Edge Sampling**: Interpolation between faces is poorly handled.
+1. **LOD too high**: A high `blur_lod` (4.0) uses low-resolution mipmap levels.
+
+2. **Insufficient Resolution**: 512x512 might be too small.
+
+3. **Filtering without seamless**: Transitions between faces are not smoothed.
+
+4. **Edge Sampling**: Interpolation between faces is poorly handled.
 
 ## 🏁 Definitive Solution: Equirectangular Mapping
 
@@ -16,10 +18,13 @@ Although previous solutions (Seamless Cubemap, Increased Resolution) improved th
 
 ### Why?
 
-1.  **No more faces**: An equirectangular texture is a single continuous 2D rectangle. There are no longer "face edges" where seams can appear.
-2.  **Simplified Pipelines**: We go directly from the HDR image (panoramic) to rendering, without passing through a conversion compute shader.
-3.  **Less Memory**: No need to allocate an additional cubemap texture.
-4.  **Max Quality**: We sample the source data directly.
+1. **No more faces**: An equirectangular texture is a single continuous 2D rectangle. There are no longer "face edges" where seams can appear.
+
+2. **Simplified Pipelines**: We go directly from the HDR image (panoramic) to rendering, without passing through a conversion compute shader.
+
+3. **Less Memory**: No need to allocate an additional cubemap texture.
+
+4. **Max Quality**: We sample the source data directly.
 
 ### Visual Comparison
 
@@ -79,23 +84,27 @@ digraph CubemapVsEqui {
     Map -> Sample [label="Interpolated"];
   }
 }
+
 ```
 
 ### Comparison: Cubemap vs Equirectangular
 
-| Feature | Cubemap (Old) | Equirectangular (Current) |
-|---------|---------------|---------------------------|
-| Seams | Possible at edges | **Impossible** |
-| Complexity | High (Compute Shader) | **Low** (Direct) |
-| Artifacts | Mipmapping at corners | **None** (Continuous linear) |
-| Flexibility | Industry standard | Ideal for HDR visualizers |
+| Feature     | Cubemap (Old)         | Equirectangular (Current)    |
+| ----------- | --------------------- | ---------------------------- |
+| Seams       | Possible at edges     | **Impossible**               |
+| Complexity  | High (Compute Shader) | **Low** (Direct)             |
+| Artifacts   | Mipmapping at corners | **None** (Continuous linear) |
+| Flexibility | Industry standard     | Ideal for HDR visualizers    |
 
 ### Software Implementation
 
 Switching to equirectangular allowed removing:
--   The compute shader `equirect2cube.glsl`.
--   The functions `texture_create_env_cubemap` and `texture_build_env_cubemap`.
--   The complexity of managing 6 faces.
+
+- The compute shader `equirect2cube.glsl`.
+
+- The functions `texture_create_env_cubemap` and `texture_build_env_cubemap`.
+
+- The complexity of managing 6 faces.
 
 ### Conclusion
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -11,7 +11,9 @@ The engine initializes the OpenGL debug output synchronously if the context is c
 When the debug context is active, the system enters "High Sensitivity" mode. In this mode:
 
 - **All** debug messages are intercepted, including `GL_DEBUG_SEVERITY_NOTIFICATION`.
+
 - Synchronous output is enabled, meaning the callback is executed immediately when the driver generates the message (allowing for accurate stack traces in a debugger).
+
 - A deduplication mechanism prevents the log from being flooded with identical messages (e.g., inside a draw loop).
 
 ### Log Level Mapping
@@ -19,17 +21,24 @@ When the debug context is active, the system enters "High Sensitivity" mode. In 
 To avoid polluting the logs with excessive warnings, the system maps OpenGL message severities to application log levels as follows:
 
 | OpenGL Severity | OpenGL Type | Application Log Level | Description |
-| :--- | :--- | :--- | :--- |
+| :-------------- | :---------- | :-------------------- | :---------- |
+
 | `HIGH` | Any | **ERROR** | Critical errors that likely caused undefined behavior or crashes. |
+
 | Any | `ERROR` | **ERROR** | Any message explicitly flagged as an error type. |
+
 | `MEDIUM` | Any | **WARNING** | Major performance warnings, deprecated behavior, or undefined behavior usage. |
+
 | `LOW` | Any | **WARNING** | Minor performance warnings or redundancy. |
+
 | `NOTIFICATION` | Any | **INFO** | Informational messages, resource creation details, or specific driver implementation details. |
 
 ### Interpretation
 
 - **[ERROR]**: Needs immediate attention.
+
 - **[WARNING]**: Should be investigated. Often points to non-optimal usage (e.g., "Buffer object usage hint is STATIC_DRAW but is being updated frequently").
+
 - **[INFO]**: Generally safe to ignore unless you are debugging a specific resource issue (e.g., "Texture object 4 created").
 
 ## Performance Debugging with ApiTrace
@@ -41,11 +50,13 @@ The engine is integrated with **ApiTrace** to detect GPU-side performance bottle
 Performance verification is automated and integrated into the build system:
 
 - **`just test-apitrace`**: Runs the unit test suite under ApiTrace and fails if any "performance issue" or "stall" warnings are detected in the command stream.
+
 - **`just test-integration-apitrace`**: Launches the main application, executes a full user scenario (Page Up/Down, F-keys, camera move), and analyzes the resulting trace for regressions.
 
 ### Interpreting Stalls
 
 The automation looks for specific driver warnings, such as:
+
 > `api performance issue 1: memory mapping a busy "buffer" BO stalled and took 1.379 ms.`
 
 If such an error occurs, it means the CPU is waiting for the GPU before it can continue, which kills the framerate. Fixes usually involve double-buffering resources or using `GLsync` fences (see [GPU Synchronization Guide](./gpu-rendering-synchronization.md)).
@@ -55,4 +66,5 @@ If such an error occurs, it means the CPU is waiting for the GPU before it can c
 If the automated tests fail, you can investigate the trace manually:
 
 1. `make qapitrace`: Launches the ApiTrace GUI to inspect the offending frame and command.
+
 2. `make replay`: Replays the trace to verify visual consistency.

--- a/docs/diagram_index.md
+++ b/docs/diagram_index.md
@@ -1,6 +1,6 @@
 # Index des Diagrammes
 
-*Cette page est générée automatiquement. **Survolez les titres** pour voir un aperçu du diagramme.*
+_Cette page est générée automatiquement. **Survolez les titres** pour voir un aperçu du diagramme._
 
 <style>
 .diagram-item { position: relative; display: block; padding: 12px 0; border-bottom: 1px solid var(--md-code-bg-color); }
@@ -76,16 +76,17 @@ M->>M: Unmap PBO
 M->>G: glTexSubImage2D (Fast DMA)
 M->>G: glGenerateMipmap
 M->>M: Start Progressive IBL
+
 ```
 
   </div>
 </div>
 
-
 ## [Asynchronous Texture Upload Strategy](../async_pbo/)
 
 <div class="diagram-item">
   <a href="../async_pbo/#architecture-overview" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">Architecture Overview</a> : <span style="opacity: 0.6; font-size: 0.85em;">- Monolithic Upload: Even with PBOs, performing all GPU work (texture storage allocation, data upload, mipmap generation) in a single frame creates a ~60ms spike.</span>
+
   <div class="mermaid-preview">
 
 ```mermaid
@@ -106,18 +107,23 @@ participant Main as Main Thread
 participant Worker as Async Worker
 participant GPU as GPU / Driver
 Note over Main: Frame N - PBO Setup
+
 Main->>GPU: texture_ensure_pbo() + texture_map_pbo()
 Main->>Worker: async_loader_provide_pbo(mapped_ptr)
 Note over Main: Frame N+1 - VRAM Pre-allocation
+
 Main->>GPU: texture_preallocate_hdr()<br/>glTexImage2D(level 0, NULL)
 Note over GPU: Allocate ~64MB base level only
 Note over Worker: Frames N..N+M - Background Conversion
+
 Worker->>Worker: float32 -> float16 (SIMD)<br/>directly into mapped PBO
 Note over Main: Frame N+M - Upload & Mipmaps
+
 Main->>GPU: glUnmapBuffer(PBO)
 Main->>GPU: glTexSubImage2D(from PBO)
 Main->>GPU: glGenerateMipmap()
 Note over GPU: DMA transfer + mipmap chain
+
 ```
 
   </div>
@@ -136,8 +142,11 @@ section Before (1 frame)
 PBO Setup + TexStorage + Upload + Mipmap + 3×glGetError :done, 0, 60
 section After (3 frames)
 Frame N  - PBO Setup & Map        :active, 0, 5
+
 Frame N+1 - TexPrealloc (level 0) :active, 8, 15
+
 Frame N+M - Upload + Mipmap       :active, 18, 38
+
 ```
 
   </div>
@@ -166,23 +175,32 @@ Frame N+M - Upload + Mipmap       :active, 18, 38
 flowchart TD
 A["app_update() called"] --> B{"pending_prealloc_w > 0?"}
 B -- Yes --> C["texture_preallocate_hdr()"]
+
 C --> D{"recycled_hdr_tex matches?"}
 D -- Yes --> E["Zero-cost reuse (OK)"]
+
 D -- No --> F["glTexImage2D(level 0, NULL)"]
+
 F --> G["Store in app->recycled_hdr_tex"]
 B -- No --> H["async_loader_poll()"]
+
 E --> H
 G --> H
 H --> I{"req.state?"}
 I -- WAITING_FOR_PBO --> J["PBO Setup & Map"]
+
 J --> K["Schedule pending_prealloc_w/h"]
 I -- ASYNC_READY --> L["texture_upload_hdr_from_pbo()"]
+
 L --> M{"reuse_tex matches?"}
 M -- Yes --> N["Skip glTexStorage2D (OK)"]
+
 M -- No --> O["Fallback: glTexStorage2D"]
+
 N --> P["glUnmapBuffer + glTexSubImage2D"]
 O --> P
 P --> Q["glGenerateMipmap"]
+
 ```
 
   </div>
@@ -216,11 +234,11 @@ CmdQueue->>GPU: Execute TexSubImage...
 GPU-->>CmdQueue: Done
 CmdQueue-->>CPU: GL_NO_ERROR
 Note over CPU: Can finally continue
+
 ```
 
   </div>
 </div>
-
 
 ## [Environment Transitions](../env_transitions/)
 
@@ -242,11 +260,11 @@ fade_out --> fade_in : Alpha >= 1.0 (Swap Textures)
 fade_in --> idle : Alpha <= 0.0
 idle --> wait_ibl : Initial Startup
 wait_ibl --> fade_in : IBL Done (Initial Load)
+
 ```
 
   </div>
 </div>
-
 
 ## [Aggressive test with ASan](../fullscreen_deadlock/)
 
@@ -295,6 +313,7 @@ GLFW->>Main: framebuffer_size_callback()
 Main->>GPU: glDeleteTextures / glGenTextures
 Note over GPU,Driver: GPU blocked by pending swap
 Note over Main,GPU: (DEADLOCK)
+
 ```
 
   </div>
@@ -336,6 +355,7 @@ participant GLFW as GLFW
 participant Driver as NVIDIA Driver
 participant GPU as GPU Pipeline
 Main->>GPU: glFinish() - drain pipeline
+
 GPU-->>Main: All commands complete
 Main->>GLFW: glfwSetWindowMonitor()
 GLFW->>Driver: Mode switch request
@@ -347,12 +367,13 @@ GLFW-->>Main: glfwSetWindowMonitor() returns
 Note over Main: Next frame begins...
 Main->>Main: app_run: resize_pending? YES
 Main->>GPU: postprocess_resize() - safe context
+
 GPU-->>Main: FBOs recreated (OK)
+
 ```
 
   </div>
 </div>
-
 
 ## [Global Illumination (1-Bounce)](../global_illumination/)
 
@@ -386,11 +407,11 @@ deactivate Worker
 Main->>GPU: Upload des données SH vers le SSBO (glBufferSubData)
 Main->>GPU: Appel de dessin (Instanced ou SSBO)
 Note over GPU: Les fragments échantillonnent l'irradiance des 8 sondes adjacentes (Trilinear Filtering)
+
 ```
 
   </div>
 </div>
-
 
 ## [Analyse de l'implémentation du Motion Blur](../motion_blur_analysis/)
 
@@ -402,13 +423,16 @@ Note over GPU: Les fragments échantillonnent l'irradiance des 8 sondes adjacent
 graph TD
 V[Velocity Buffer] --> T[Tile Max Velocity Compute]
 T -->|Réduction à 16x16 via Shared Memory| TTex(Texture RG16F - Tile Max)
+
 TTex --> N[Neighbor Max Velocity Compute]
 N -->|textureGather sur un Voisinage 3x3| NTex(Texture RG16F - Neighbor Max)
+
 C[Color Buffer Raw] --> M(Passe Motion Blur Finale)
 D[Depth Buffer] --> M
 V --> M
 NTex --> M
 M -->|Échantillonnage de 8 frames \n+ Interleaved Gradient Noise \n+ Depth Weighting| O[Color Buffer Flouté]
+
 ```
 
   </div>
@@ -416,22 +440,24 @@ M -->|Échantillonnage de 8 frames \n+ Interleaved Gradient Noise \n+ Depth Weig
 
 <div class="diagram-item">
   <a href="../motion_blur_analysis/#4-lexemple-de-street-fighter-6-re-engine" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">4. L'Exemple de Street Fighter 6 (RE Engine)</a> : <span style="opacity: 0.6; font-size: 0.85em;">Contrairement à du flou Linéaire standard (« je prends un vecteur et je trace une ligne droite »), le moteur de Capcom stocke l'information de l'accélération en plus de la vitesse. L'échantillonnage de Flou est ainsi &quot;courbé&quot; dans l'espace afin de simuler la trajectoire radiale des membres et poings.</span>
+
   <div class="mermaid-preview">
 
 ```mermaid
 graph LR
 A[Flou Linéaire \nStandard Suckless OGL] -->|Crée des lignes droites et des artefacts| B(Trajectoire d'un coup de poing)
 C[Flou Courbe \nRE Engine / SF6] -->|Échantillonnage le long d'un arc de cercle| D(Flou stylisé style Anime/Manga)
+
 ```
 
   </div>
 </div>
 
-
 ## [Performance Mode & Notifications](../perf_and_notifications/)
 
 <div class="diagram-item">
   <a href="../perf_and_notifications/#architecture" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">Architecture</a> : <span style="opacity: 0.6; font-size: 0.85em;">2.  Native: Fallback using Linux scheduling syscalls (`schedsetscheduler`, `setpriority`).</span>
+
   <div class="mermaid-preview">
 
 ```mermaid
@@ -462,8 +488,10 @@ class NativeBackend {
 +setpriority_nice
 }
 App *-- PerfModeContext
+
 PerfModeContext ..> GameModeBackend : Tries_First
 PerfModeContext ..> NativeBackend : Fallback
+
 ```
 
   </div>
@@ -471,6 +499,7 @@ PerfModeContext ..> NativeBackend : Fallback
 
 <div class="diagram-item">
   <a href="../perf_and_notifications/#design" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">Design</a> : <span style="opacity: 0.6; font-size: 0.85em;">-   FIFO Replacement: If the buffer is full, the oldest active notification is overwritten.</span>
+
   <div class="mermaid-preview">
 
 ```mermaid
@@ -493,11 +522,11 @@ ActionNotifier->>ActionNotifier: Increase lifetime, deactivate if expired
 AppInput->>ActionNotifier: action_notifier_draw(ui_ctx)
 ActionNotifier->>UI: ui_draw_text_ex(...)
 end
+
 ```
 
   </div>
 </div>
-
 
 ## [Platform Abstraction Layer (PAL)](../portability_pal/)
 
@@ -533,11 +562,11 @@ E -.-> G
 E -.-> H
 F -.-> G
 F -.-> H
+
 ```
 
   </div>
 </div>
-
 
 ## [Progressive & Asynchronous IBL Architecture](../progressive_ibl/)
 
@@ -583,6 +612,7 @@ style Mip0 fill:#414868,stroke:#f7768e
 style Mip1 fill:#414868,stroke:#f7768e
 style Mip2 fill:#414868,stroke:#9ece6a
 style Tail fill:#414868,stroke:#9ece6a
+
 ```
 
   </div>
@@ -621,11 +651,11 @@ Note right of GPU: Work queued, no stall
 end
 CPU->>GPU: glMemoryBarrier(IMAGE_ACCESS_BIT)
 Note right of GPU: Single flush before sampling
+
 ```
 
   </div>
 </div>
-
 
 ## [Synchronization & Asynchrony Overview](../synchronization_overview/)
 
@@ -659,21 +689,26 @@ participant W as Worker Threads
 participant G as GPU
 Note over M: Frame N starts
 M->>M: 1. Poll Async Loader (5ms)
+
 M->>M: 2. Update IBL Slice (10ms)
+
 par Parallel Execution
 W->>W: Background I/O & SH Projection
 M->>G: 3. Upload GI Probes (5ms)
+
 end
 M->>G: 4. Render Scene (15ms)
+
 M->>G: 5. Swap Buffers (5ms)
+
 Note over M: Frame N ends (~40ms)
 Note over M: Frame N+1 starts
 M->>M: Poll & Process...
+
 ```
 
   </div>
 </div>
-
 
 ## [UI Visual Parameters Reference](../ui_visual_parameters/)
 
@@ -686,8 +721,11 @@ graph LR
 A[Mouse over Key] --> B[Target Dim: 0.3]
 B --> C{Mouse leaves?}
 C -- Yes --> D[Wait 150ms]
+
 D -- Still Empty --> E[Target Dim: 1.0]
+
 D -- Enters New Key --> B
+
 ```
 
   </div>

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,6 +5,7 @@ This project includes a containerized build and runtime environment for consiste
 ## Prerequisites
 
 - **Docker** or **Podman** installed (auto-detected by Makefile)
+
 - BuildKit support enabled (default in modern Docker/Podman)
 
 ## Quick Start
@@ -13,18 +14,22 @@ This project includes a containerized build and runtime environment for consiste
 
 ```sh
 make docker-build
+
 ```
 
 This creates an optimized container image with:
 
 - Multi-stage build (builder + minimal runtime)
+
 - CMake build cache persistence
+
 - Xvfb for headless OpenGL rendering
 
 ### Run the Application
 
 ```sh
 make docker-run
+
 ```
 
 Runs the application in a container with X11 forwarding to your host display.
@@ -38,8 +43,11 @@ The [`Dockerfile`](https://github.com/yoyonel/suckless-ogl/blob/main/Dockerfile)
 #### Stage 1: Builder (fedora:41)
 
 - Full development toolchain (clang, cmake, ninja, git)
+
 - **BuildKit cache mount** on `/src/build` for incremental builds
+
 - Compiles in Release mode with parallel build
+
 - Copies only the final binary to `/tmp/app`
 
 ```dockerfile
@@ -49,6 +57,7 @@ RUN --mount=type=cache,target=/src/build \
     -DCMAKE_C_COMPILER=clang \
     && cmake --build build --parallel \
     && cp build/app /tmp/app
+
 ```
 
 > [!TIP]
@@ -58,16 +67,23 @@ RUN --mount=type=cache,target=/src/build \
 
 - Minimal runtime dependencies only:
   - `glfw` - Window and input handling
+
   - `mesa-*` - OpenGL drivers
+
   - `mesa-*` - OpenGL drivers
+
   - `xorg-x11-server-Xvfb` - Virtual framebuffer for headless rendering
+
   - `gamemode` - Runtime library for Performance Mode
+
 - Non-root user (`appuser`) for security
+
 - Contains only: binary, assets, shaders, entrypoint script
 
 **Image size comparison:**
 
 - Builder stage: ~1.2 GB (with full toolchain)
+
 - Final runtime image: ~400 MB (minimal dependencies)
 
 ### Headless Rendering with Xvfb
@@ -79,38 +95,51 @@ The [`entrypoint.sh`](https://github.com/yoyonel/suckless-ogl/blob/main/entrypoi
 set -e
 
 # Start Xvfb in background
+
 Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &
 XVFB_PID=$!
 
 # Wait for Xvfb to start
+
 sleep 2
 
 # Set DISPLAY
+
 export DISPLAY=:99
 
 # Run the application
+
 ./app
 
 # Cleanup
+
 kill $XVFB_PID 2>/dev/null || true
+
 ```
 
 This enables:
 
 - **CI/CD testing** without physical display
+
 - **Headless rendering** for automated screenshots/validation
+
 - **Consistent environment** across different systems
 
 ### Build Cache Optimization
 
 The `.dockerignore` file excludes unnecessary files from the build context:
 
-```
+```text
 build/          # Build artifacts
+
 build-*/        # Coverage/debug builds
+
 .git/           # Git history
+
 docs/           # Documentation
+
 *.md            # Markdown files
+
 ```
 
 This reduces context size and speeds up `docker build`.
@@ -119,19 +148,19 @@ This reduces context size and speeds up `docker build`.
 
 ### Build Targets
 
-| Target | Description | `make` | `just` |
-|--------|-------------|--------|--------|
-| Build Image | Build image with layer caching | `docker-build` | `docker-build` |
-| Build No Cache | Force full rebuild | `docker-build-no-cache` | `docker-build-no-cache` |
-| Run App | Run with X11 forwarding | `docker-run` | `docker-run` |
+| Target         | Description                    | `make`                  | `just`                  |
+| -------------- | ------------------------------ | ----------------------- | ----------------------- |
+| Build Image    | Build image with layer caching | `docker-build`          | `docker-build`          |
+| Build No Cache | Force full rebuild             | `docker-build-no-cache` | `docker-build-no-cache` |
+| Run App        | Run with X11 forwarding        | `docker-run`            | `docker-run`            |
 
 ### Maintenance Targets
 
-| Target | Description | `make` | `just` |
-|--------|-------------|--------|--------|
-| Clean Dangling | Remove dangling images | `docker-clean` | `docker-clean` |
-| Clean All | Prune all images and cache | `docker-clean-all` | `docker-clean-all` |
-| Disk Usage | Show disk usage stats | `docker-usage` | `docker-usage` |
+| Target         | Description                | `make`             | `just`             |
+| -------------- | -------------------------- | ------------------ | ------------------ |
+| Clean Dangling | Remove dangling images     | `docker-clean`     | `docker-clean`     |
+| Clean All      | Prune all images and cache | `docker-clean-all` | `docker-clean-all` |
+| Disk Usage     | Show disk usage stats      | `docker-usage`     | `docker-usage`     |
 
 ## Advanced Usage
 
@@ -141,12 +170,14 @@ The Makefile auto-detects Docker or Podman:
 
 ```makefile
 CONTAINER_ENGINE := $(shell command -v docker 2> /dev/null || echo podman)
+
 ```
 
 To force a specific engine:
 
 ```sh
 CONTAINER_ENGINE=podman make docker-build
+
 ```
 
 ### Incremental Builds
@@ -154,12 +185,17 @@ CONTAINER_ENGINE=podman make docker-build
 Thanks to BuildKit cache mounts, subsequent builds are fast:
 
 ```sh
+
 # First build: ~2-3 minutes (fetch deps, compile everything)
+
 make docker-build
 
 # Modify src/shader.c
+
 # Second build: ~10-20 seconds (recompile only changed files)
+
 make docker-build
+
 ```
 
 ### Running with Host X11
@@ -168,7 +204,9 @@ The `docker-run` target forwards X11:
 
 ```sh
 make docker-run
+
 # Equivalent to:
+
 docker run --rm -it \
     --cap-add=SYS_NICE \
     --ulimit rtprio=99 \
@@ -180,6 +218,7 @@ docker run --rm -it \
     -v /var/lib/dbus/machine-id:/var/lib/dbus/machine-id:ro \
     -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
     suckless-ogl /bin/bash -c "export DISPLAY=$DISPLAY && ./app"
+
 ```
 
 ### GameMode & Real-Time Priority
@@ -187,10 +226,10 @@ docker run --rm -it \
 To enable **Performance Mode** (SCHED_FIFO) and GameMode inside the container, specific permissions are required:
 
 - `--cap-add=SYS_NICE`: Allows the container to set real-time scheduling policies.
-- `--ulimit rtprio=99`: Allows the non-root `appuser` to request real-time priority.
-- **D-Bus Mounting**: Essential for `libgamemode` to communicate with the host's GameMode daemon.
 
-```
+- `--ulimit rtprio=99`: Allows the non-root `appuser` to request real-time priority.
+
+- **D-Bus Mounting**: Essential for `libgamemode` to communicate with the host's GameMode daemon.
 
 > [!WARNING]
 > X11 forwarding requires `xhost +local:` which temporarily disables access control. This is handled automatically by the Makefile.
@@ -202,10 +241,13 @@ To enable **Performance Mode** (SCHED_FIFO) and GameMode inside the container, s
 Ensure BuildKit is enabled:
 
 ```sh
+
 # Docker
+
 export DOCKER_BUILDKIT=1
 
 # Podman (enabled by default)
+
 ```
 
 ### Xvfb Fails to Start
@@ -214,8 +256,11 @@ Check if port :99 is available:
 
 ```sh
 docker run --rm -it suckless-ogl /bin/bash
+
 # Inside container:
+
 Xvfb :99 -screen 0 1920x1080x24
+
 ```
 
 ### X11 Permission Denied
@@ -225,6 +270,7 @@ Reset xhost permissions:
 ```sh
 xhost +local:
 make docker-run
+
 ```
 
 ## CI/CD Integration
@@ -233,14 +279,15 @@ Example GitHub Actions workflow:
 
 ```yaml
 - name: Build Docker Image
+
   run: make docker-build
 
 - name: Run Tests in Container
-  run: |
+
     docker run --rm suckless-ogl /bin/bash -c "
-      export DISPLAY=:99 &&
-      Xvfb :99 &
-      sleep 2 &&
-      ./app --test
+    export DISPLAY=:99 &&
+    Xvfb :99 &
+    sleep 2 &&
+    ./app --test
     "
 ```

--- a/docs/docs_staging_guide.md
+++ b/docs/docs_staging_guide.md
@@ -4,10 +4,13 @@ This project automatically generates and deploys a live preview of the Doxygen d
 
 ## How it Works
 
-1.  **Trigger**: Every push to a Pull Request triggers the `documentation` job in GitHub Actions.
-2.  **Generation**: Doxygen builds the HTML documentation.
-3.  **Deployment**: The documentation is deployed to [Surge.sh](https://surge.sh) using a unique domain per PR: `suckless-ogl-pr-[NUMBER].surge.sh`.
-4.  **Feedback**: A comment is automatically posted on the Pull Request with a link to the live preview.
+1. **Trigger**: Every push to a Pull Request triggers the `documentation` job in GitHub Actions.
+
+2. **Generation**: Doxygen builds the HTML documentation.
+
+3. **Deployment**: The documentation is deployed to [Surge.sh](https://surge.sh) using a unique domain per PR: `suckless-ogl-pr-[NUMBER].surge.sh`.
+
+4. **Feedback**: A comment is automatically posted on the Pull Request with a link to the live preview.
 
 ## Setup Instructions
 
@@ -19,17 +22,23 @@ If you haven't used Surge before, you can install it and generate a token via CL
 
 ```sh
 npx surge token
+
 ```
 
 - If you don't have an account, it will prompt you to create one.
+
 - Copy the provided token string.
 
 ### 2. Configure GitHub Secrets
 
 1. Navigate to your GitHub repository.
+
 2. Go to **Settings** > **Secrets and variables** > **Actions**.
+
 3. Create a **New repository secret**.
+
 4. Set the **Name** to `SURGE_TOKEN`.
+
 5. Paste your token into the **Value** field.
 
 ## Workflow Integration
@@ -38,11 +47,13 @@ The staging logic is defined in `.github/workflows/main.yml`. It uses the `mshic
 
 ```yaml
 - name: Comment Preview Link on PR
+
   if: github.event_name == 'pull_request'
   uses: mshick/add-pr-comment@v2
   with:
     message: |
       ## 📚 Documentation Preview
+
       The Doxygen documentation for this PR has been generated and is ready for review:
       🔗 **[Preview Link](${{ env.PREVIEW_URL }})**
 ```
@@ -50,11 +61,14 @@ The staging logic is defined in `.github/workflows/main.yml`. It uses the `mshic
 ## Maintenance
 
 ### Clearing Previews
+
 Surge.sh keeps the deployments indefinitely. Since the domains are reused per PR number, new pushes simply overwrite the previous version. If you need to manually tear down a preview:
 
 ```sh
 npx surge teardown suckless-ogl-pr-[NUMBER].surge.sh --token your_token
+
 ```
 
 ### Security
+
 The `SURGE_TOKEN` allows anyone with access to it to deploy sites to your Surge account. Keep it secret and only store it in GitHub Secrets.

--- a/docs/documentation_system.md
+++ b/docs/documentation_system.md
@@ -3,6 +3,7 @@
 This project uses a **Hybrid Documentation Model** that combines the best of both worlds:
 
 1. **MkDocs**: For narrative documentation, guides, and tutorials.
+
 2. **Doxygen**: For auto-generated API reference, dependency graphs, and call hierarchies.
 
 ## 🏗️ Architecture
@@ -10,14 +11,18 @@ This project uses a **Hybrid Documentation Model** that combines the best of bot
 The build system (`make docs`) generates both sites and merges them into a single static `site/` directory.
 
 | Component | Tool | Config File | Output Path |
-| :--- | :--- | :--- | :--- |
+| :-------- | :--- | :---------- | :---------- |
+
 | **Guides & UI** | [MkDocs](https://www.mkdocs.org/) | `mkdocs.yml` | `site/` |
+
 | **API Reference** | [Doxygen](https://www.doxygen.nl/) | `Doxyfile` | `site/doxygen/` |
 
 ### Integration
 
 - **MkDocs** creates the main website structure and navigation.
+
 - **Doxygen** runs as a subprocess and outputs its HTML to a subdirectory.
+
 - A **Custom Layout** (`docs/DoxygenLayout.xml`) adds a "Back to Docs" link in the Doxygen sidebar to ensure seamless navigation between the two.
 
 ## 🛠️ Tools & Libraries
@@ -27,9 +32,12 @@ The build system (`make docs`) generates both sites and merges them into a singl
 We use the **[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)** theme for its modern aesthetics and mobile responsiveness.
 
 - **Configuration**: `mkdocs.yml`
+
 - **Key Plugins**:
   - `mkdocs-kroki-plugin`: Renders diagrams (GraphViz, Mermaid, etc.).
+
   - `pymdown-extensions`: Adds advanced Markdown features (Admonitions, Tabbed code blocks).
+
   - [**MkDocs Hooks**](https://www.mkdocs.org/user-guide/configuration/#hooks): Custom Python scripts to extend MkDocs behavior.
 
 ### 2. Doxygen (The API)
@@ -37,9 +45,12 @@ We use the **[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
 We use the **[Doxygen Awesome CSS](https://github.com/jothepro/doxygen-awesome-css)** theme to make standard Doxygen output look modern and match the MkDocs style.
 
 - **Configuration**: `Doxyfile`
+
 - **Customization**:
   - `HTML_EXTRA_STYLESHEET` points to the `doxygen-awesome-css` files in `docs/doxygen-awesome-css/`.
+
   - `USE_MDFILE_AS_MAINPAGE` is set to `docs/api_index.md` to provide a clean landing page.
+
   - **Math Compatibility**: A Python input filter (`math_filter.py`) automatically translates standard Markdown math for Doxygen. See [Doxygen Customization](doxygen_customization.md) for details.
 
 ## 🚀 Workflow
@@ -50,7 +61,9 @@ To preview the full hybrid site locally:
 
 ```sh
 make docs-serve
+
 # Opens http://localhost:8000
+
 ```
 
 > **Note**: `make docs-dev` (or `mkdocs serve`) only previews the MkDocs part and will NOT show the API reference.
@@ -60,8 +73,11 @@ make docs-serve
 The GitHub Actions workflow (`.github/workflows/docs.yml`) automates the deployment:
 
 1. Installs system deps (`doxygen`, `graphviz`).
+
 2. Builds MkDocs (`mkdocs build`).
+
 3. Builds Doxygen (`doxygen Doxyfile`).
+
 4. Deploys the combined `site/` folder to the `gh-pages` branch.
 
 ## 🎨 Customization & Themes
@@ -75,12 +91,14 @@ theme:
   name: material
   palette:
     primary: indigo # Change this to 'red', 'blue', 'teal', etc.
+
     accent: deep purple
 ```
 
 To switch to a completely different MkDocs theme (e.g., `readthedocs`):
 
 1. Install the theme (e.g., `pip install mkdocs-readthedocs-theme`).
+
 2. Change `name: material` to `name: readthedocs` in `mkdocs.yml`.
 
 ### Updating the Doxygen Theme
@@ -88,9 +106,11 @@ To switch to a completely different MkDocs theme (e.g., `readthedocs`):
 To change the Doxygen look, you generally need to replace the CSS files.
 
 1. **Doxygen Awesome**: We include this as a git submodule (or vendored files) in `docs/doxygen-awesome-css`. To update it, `git pull` in that directory.
+
 2. **Switching Themes**:
-    - Comment out the `HTML_EXTRA_STYLESHEET` lines in `Doxyfile` to revert to default Doxygen style.
-    - Or download a new theme CSS, place it in `docs/`, and update `HTML_EXTRA_STYLESHEET`.
+   - Comment out the `HTML_EXTRA_STYLESHEET` lines in `Doxyfile` to revert to default Doxygen style.
+
+   - Or download a new theme CSS, place it in `docs/`, and update `HTML_EXTRA_STYLESHEET`.
 
 ## 🤖 Automated Diagram Indexing
 
@@ -101,8 +121,11 @@ To maintain a high-level overview of the engine's architecture, we use a custom 
 This script ([hooks/generate_diagram_index.py](file:///home/latty/Prog/__PERSO__/suckless-ogl/hooks/generate_diagram_index.py)) runs during the `on_config` event of the MkDocs build process.
 
 - **Scanning**: It parses all Markdown files in the `docs/` directory.
+
 - **Extraction**: It extracts `mermaid` code blocks along with their preceding paragraph as a description.
+
 - **Generation**: It creates [diagram_index.md](file:///home/latty/Prog/__PERSO__/suckless-ogl/docs/diagram_index.md).
+
 - **Interactive UI**: The index features a "Tokyo Night" themed CSS hover effect that reveals a live preview of the diagram without leaving the page.
 
 ### Configuration
@@ -112,6 +135,7 @@ The hook is registered in `mkdocs.yml`:
 ```yaml
 hooks:
   - hooks/generate_diagram_index.py
+
   - hooks/render_graphviz.py
 ```
 
@@ -124,7 +148,9 @@ Nous suivons une philosophie **zéro-dépendance externe**. La documentation doi
 Plutôt que d'utiliser des services en ligne, nous utilisons un hook Python personnalisé ([hooks/render_graphviz.py](file:///home/latty/Prog/__PERSO__/suckless-ogl/hooks/render_graphviz.py)) qui invoque directement le binaire `dot` local :
 
 1. **Rendu Local** : Le hook intercepte les blocs `graphviz` et appelle `/usr/bin/dot`.
+
 2. **Mise en Cache** : Les SVGs générés sont stockés dans `docs/assets/diagrams/` pour éviter des rendus inutiles.
+
 3. **Zéro Latence** : Pas de requêtes réseau, rendu instantané et privé.
 
 > [!TIP]
@@ -135,7 +161,7 @@ Plutôt que d'utiliser des services en ligne, nous utilisons un hook Python pers
 > ```
 >
 > Cette commande utilise `unshare -rn` pour isoler totalement le processus du réseau. Ces cibles enchaînent automatiquement `docs-clean` et `docs` pour garantir un rendu à partir de zéro sans internet.
-
+>
 > [!IMPORTANT]
 > L'installation de `graphviz` est requise sur la machine de build pour générer ces diagrammes. Si `dot` est absent, le build MkDocs échouera explicitement via une `RuntimeError`.
 
@@ -148,14 +174,21 @@ Les diagrammes Mermaid sont rendus directement par le navigateur via `mermaid.js
 We enforce documentation health through automated tests via `scripts/verify_docs.py`:
 
 - **Phase 1: Doxygen Diagrams**: Ensures `\dot` blocks are rendered as SVGs.
+
 - **Phase 2: HTML Sanitization**: Prevents raw HTML tags from appearing in navigation or escaped content.
+
 - **Phase 3: MkDocs Rendering**: Scans for unrendered Mermaid/Graphviz blocks in the static `site/` output.
+
 - **Link Validation**: [test_docs_links.py](file:///home/latty/Prog/__PERSO__/suckless-ogl/tests/test_docs_links.py) ensures no broken internal links.
 
 ## 🔗 Official Documentation Links
 
 - [MkDocs User Guide](https://www.mkdocs.org/user-guide/)
+
 - [MkDocs Hooks API](https://www.mkdocs.org/dev-guide/plugins/#events)
+
 - [Material for MkDocs Reference](https://squidfunk.github.io/mkdocs-material/reference/)
+
 - [Mermaid.js Documentation](https://mermaid.js.org/intro/)
+
 - [Doxygen Manual](https://www.doxygen.nl/manual/index.html)

--- a/docs/doxygen_customization.md
+++ b/docs/doxygen_customization.md
@@ -11,8 +11,11 @@ We use the [Doxygen-Awesome](https://github.com/jothepro/doxygen-awesome-css) li
 ### Integrated Components
 
 - **Dark Mode**: Toggle situated in the sidebar.
+
 - **Interactive TOC**: Floating table of contents for long pages.
+
 - **Copy Button**: One-click code extraction from fragments.
+
 - **Tabs**: Support for tabbed content in documentation.
 
 ---
@@ -27,6 +30,7 @@ The `Doxyfile` maps graphics-specific extensions to C++ for basic indexing, whil
 
 ```properties
 EXTENSION_MAPPING = glsl=C++ vert=C++ frag=C++ comp=C++
+
 ```
 
 ### 2. Indentation Preservation Fix
@@ -34,8 +38,11 @@ EXTENSION_MAPPING = glsl=C++ vert=C++ frag=C++ comp=C++
 Doxygen encodes code blocks as a series of `<div class="line">` elements, which often breaks standard syntax highlighters. We've added a custom JavaScript orchestrator in `header.html` that:
 
 1. **Extracts** the raw text from all `.line` divs.
+
 2. **Reconstructs** a standard `pre` > `code` block.
+
 3. **Preserves** original indentation and whitespace.
+
 4. **Triggers** `highlight.js` on the newly created block.
 
 **Theme**: `Tokyo Night Dark` (consistent with the wider project ecosystem).
@@ -51,6 +58,7 @@ Our Graphviz (DOT) diagrams have been overhauled to blend seamlessly with the da
 Defined in `Doxyfile`:
 
 - **Format**: `svg` (for crisp zoom and interactivity).
+
 - **Transparency**: `DOT_TRANSPARENT = YES` (removes harsh white/gray backgrounds).
 
 ### 2. Design Tokens
@@ -58,13 +66,16 @@ Defined in `Doxyfile`:
 Each diagram follows a strict "Ghost" style to ensure it feels like a native part of the page:
 
 - **Nodes**: `shape=rect, style="rounded"`. No fill color (`fillcolor="none"`) for a "see-through" aesthetic.
+
 - **Borders**: Vivid **Tokyo Night** colors with enhanced `penwidth=2`.
+
 - **Edges**: Refined grays (`#565f89`) with subtle arrowheads.
 
 **Example Token usage:**
 
 ```properties
 node [style="rounded", fillcolor="none", color="#414868", fontcolor="#c0caf5", penwidth=2];
+
 ```
 
 ---
@@ -83,6 +94,7 @@ The filter is registered using the `FILTER_PATTERNS` option:
 
 ```properties
 FILTER_PATTERNS = "*.md=python3 doxygen_resources/math_filter.py"
+
 ```
 
 #### 2. How the Filter Works
@@ -90,6 +102,7 @@ FILTER_PATTERNS = "*.md=python3 doxygen_resources/math_filter.py"
 The script uses regular expressions to perform a "Search & Replace" on the fly:
 
 - **Display Math**: Converts `$$ ... $$` to `\f[ ... \f]`.
+
 - **Inline Math**: Converts `$ ... $` to `\f$ ... \f$`.
 
 The regex logic is carefully crafted to avoid false positives (like escaped dollar signs `\$` or currency symbols) and ensures that the conversion only happens within the Doxygen pipeline. **The original Markdown files remain untouched**, preserving perfect rendering in the MkDocs interface.
@@ -99,7 +112,8 @@ The regex logic is carefully crafted to avoid false positives (like escaped doll
 ## 🔧 Core Configuration (Doxyfile)
 
 | Option | Value | Purpose |
-| :--- | :--- | :--- |
+| :----- | :---- | :------ |
+
 | `OPTIMIZE_OUTPUT_FOR_C` | `YES` | Adjusts terminology for C (e.g., "Files" vs "Classes"). |
 | `GENERATE_TREEVIEW` | `YES` | Enables the interactive sidebar navigation. |
 | `CALL_GRAPH` | `YES` | Automatically generates function call dependency diagrams. |
@@ -112,5 +126,7 @@ The regex logic is carefully crafted to avoid false positives (like escaped doll
 If you need to update the theme:
 
 1. Styles are located in `docs/doxygen-awesome-css/`.
+
 2. Global JS logic (including the highlighting fix) is in `docs/header.html`.
+
 3. Rebuild the documentation with `make docs`.

--- a/docs/effect_benchmark.md
+++ b/docs/effect_benchmark.md
@@ -77,20 +77,25 @@ digraph BenchOverview {
     Next -> Restore [label="non", color="#9ece6a", fontcolor="#9ece6a"];
     Restore -> Log;
 }
+
 ```
 
 ## Utilisation
 
-| Touche | Action |
-|--------|--------|
+| Touche | Action                                                      |
+| ------ | ----------------------------------------------------------- |
 | **8**  | Démarre le sweep (ou affiche "Already running" si en cours) |
 
 Le sweep dure environ **22 secondes** à 60 fps (8 phases × (30 + 120) frames ÷ 60).
 
 1. Lancer l'application
+
 2. Stabiliser la scène (ne pas bouger la caméra pendant le bench)
+
 3. Appuyer sur **8**
+
 4. Attendre la notification "FX Benchmark: Done (see log)"
+
 5. Lire les résultats dans la sortie log
 
 > ⚠️ **Important** : Ne pas interagir avec la scène ni toggle d'effets pendant
@@ -119,15 +124,19 @@ Exemple de sortie réelle (Intel Iris Xe, 1920×1080, scène IBL + 20 sphères) 
 ╠════════════════════╬═══════════╬═══════════╬════════╣
 ║ Sum of costs       ║  -0.0083 ║           ║        ║
 ╚════════════════════╩═══════════╩═══════════╩════════╝
+
 ```
 
 ### Colonnes
 
-| Colonne    | Signification |
-|------------|---------------|
+| Colonne    | Signification              |
+| ---------- | -------------------------- |
 | **Effect** | Nom de l'effet postprocess |
+
 | **Cost(ms)** | `baseline_mean - mean_with_effect_OFF`. Positif = l'effet coûte du temps GPU |
+
 | **StdDev** | Écart-type sur 120 échantillons. Indique la stabilité de la mesure |
+
 | **Status** | `ON` = testé (était actif), `OFF` = sauté (était déjà désactivé) |
 
 ### Interpréter les valeurs
@@ -143,20 +152,25 @@ Un coût négatif signifie que **désactiver l'effet ralentit le composite**.
 C'est contre-intuitif mais normal sur un iGPU. Causes possibles :
 
 1. **Bruit de mesure** — Si `|cost| < stddev`, la mesure est dans le bruit.
+
    Exemple : Grain coûte -0.0014 ms ± 0.0242 → le vrai coût est
    indistinguable de zéro.
 
 2. **Divergence de branches** — Le uber-shader utilise des `if (effect_enabled)`.
+
    Sur les GPUs à exécution SIMD (wavefronts/warps), le coût d'une branche
    dépend de la **cohérence** au sein du warp. Désactiver un seul effet peut
+
    modifier le pattern de divergence et paradoxalement ralentir les warps
    voisins.
 
 3. **Pression registres/cache** — Le compilateur GLSL peut réorganiser les
+
    registres quand le code mort est éliminé. Une configuration différente
    peut avoir une pression mémoire légèrement différente.
 
 4. **Ordonnancement ALU/TEX** — Sur iGPU Intel, les ALUs partagent la bande
+
    passante mémoire avec le CPU. Un calcul en moins peut laisser les TEX
    units en attente sans recouvrement ALU.
 
@@ -164,35 +178,42 @@ C'est contre-intuitif mais normal sur un iGPU. Causes possibles :
 
 La ligne "Sum of costs" sera rarement égale à `baseline_mean`. C'est attendu :
 les effets ne sont **pas additifs** car ils partagent les mêmes unités
+
 d'exécution (ALU, caches texture, bande passante). L'interaction entre effets
 crée des effets de masquage (latency hiding).
 
 ### Règles pratiques
 
-| Observation | Conclusion |
-|-------------|------------|
+| Observation                       | Conclusion                                      |
+| --------------------------------- | ----------------------------------------------- |
 | `cost > 0` et `cost > 2 × stddev` | L'effet a un coût **significatif** et mesurable |
+
 | `cost > 0` mais `cost < stddev` | Coût probable mais **non significatif** statistiquement |
+
 | `cost ≈ 0` (positif ou négatif) et `stddev` élevé | **Bruit** — relancer le bench en stabilisant la scène |
+
 | `cost < 0` et `|cost| > stddev` | Effet de **divergence/cache** — pas alarmant, inhérent au uber-shader |
+
 | Tous les coûts très faibles (<0.05 ms) | Le postprocess n'est **pas le goulot** — chercher ailleurs (geometry, lighting) |
 
 ## Effets benchmarkés
 
 Seuls les effets **fragment-shader** exécutés dans le draw call "Final Composite"
+
 sont mesurés par A/B toggle :
 
-| Effet | Bit | Macro |
-|-------|-----|-------|
-| FXAA | `1 << 12` | `POSTFX_FXAA` |
-| Chromatic Aberration | `1 << 3` | `POSTFX_CHROM_ABBR` |
-| Vignette | `1 << 0` | `POSTFX_VIGNETTE` |
-| Grain | `1 << 1` | `POSTFX_GRAIN` |
-| Color Grading | `1 << 5` | `POSTFX_COLOR_GRADING` |
-| Banding | `1 << 14` | `POSTFX_BANDING` |
-| Exposure | `1 << 2` | `POSTFX_EXPOSURE` |
+| Effet                | Bit       | Macro                  |
+| -------------------- | --------- | ---------------------- |
+| FXAA                 | `1 << 12` | `POSTFX_FXAA`          |
+| Chromatic Aberration | `1 << 3`  | `POSTFX_CHROM_ABBR`    |
+| Vignette             | `1 << 0`  | `POSTFX_VIGNETTE`      |
+| Grain                | `1 << 1`  | `POSTFX_GRAIN`         |
+| Color Grading        | `1 << 5`  | `POSTFX_COLOR_GRADING` |
+| Banding              | `1 << 14` | `POSTFX_BANDING`       |
+| Exposure             | `1 << 2`  | `POSTFX_EXPOSURE`      |
 
 Les effets **multi-pass** (Bloom, DoF, Auto Exposure, Motion Blur) ont déjà
+
 leur propre stage dans le GPU Profiler (`F1` pour afficher l'overlay) et ne
 nécessitent pas d'A/B testing.
 
@@ -202,13 +223,15 @@ nécessitent pas d'A/B testing.
 
 Les GPU timer queries (`GL_TIMESTAMP`) mesurent le temps entre deux draw calls.
 Or, tous les effets fragment-shader s'exécutent dans un **unique** fullscreen
+
 quad draw call ("Final Composite"). Il est impossible de placer des timers
-*à l'intérieur* d'un draw call.
+_à l'intérieur_ d'un draw call.
 
 La méthode A/B contourne cette limitation :
 
 ```text
 Coût(effet) = T(tous ON) − T(effet OFF)
+
 ```
 
 ### Machine à états
@@ -243,17 +266,21 @@ digraph BenchStateMachine {
     EFFECT -> DONE [label="tous testés\nrestaure state", color="#9ece6a", fontcolor="#9ece6a"];
     DONE -> IDLE [label="start()\n(nouveau sweep)", style=dashed];
 }
+
 ```
 
 ### Flux par frame
 
 `effect_benchmark_update()` est appelée **après** `gpu_profiler_begin_frame()`
+
 pour lire les résultats du frame N-1 (double-buffered timer queries) :
 
 1. **Warmup** (30 frames) — Les résultats sont ignorés. Laisse le driver/GPU
+
    stabiliser les caches et le pipeline après le changement d'état.
 
 2. **Accumulation** (120 frames) — Accumule `sum_ms` et `sum_sq_ms` pour
+
    calculer la moyenne et l'écart-type :
 
 $$
@@ -261,24 +288,27 @@ $$
 $$
 
 1. **Transition** — Calcule les stats, stocke le résultat, désactive l'effet
+
    suivant, remet le compteur à zéro.
 
 ### Fichiers
 
-| Fichier | Rôle |
-|---------|------|
+| Fichier                      | Rôle                                                                          |
+| ---------------------------- | ----------------------------------------------------------------------------- |
 | `include/effect_benchmark.h` | Types (`EffectBenchmark`, `BenchPhase`, `EffectBenchResult`), constantes, API |
-| `src/effect_benchmark.c` | Machine à états, accumulation, table d'effets, affichage résultats |
-| `include/app.h` | Champ `EffectBenchmark effect_bench` dans `App` |
-| `src/app.c` | `effect_benchmark_init()` au démarrage, `effect_benchmark_update()` par frame |
-| `src/app_input.c` | Binding touche `8` → `effect_benchmark_start()` |
+| `src/effect_benchmark.c`     | Machine à états, accumulation, table d'effets, affichage résultats            |
+| `include/app.h`              | Champ `EffectBenchmark effect_bench` dans `App`                               |
+| `src/app.c`                  | `effect_benchmark_init()` au démarrage, `effect_benchmark_update()` par frame |
+| `src/app_input.c`            | Binding touche `8` → `effect_benchmark_start()`                               |
 
 ### API
 
 ```c
 // Initialisation (une fois au démarrage)
 void effect_benchmark_init(EffectBenchmark* bench,
+
                            PostProcess* postprocess,
+
                            GPUProfiler* profiler);
 
 // Démarrer un sweep (retourne false si déjà en cours)
@@ -293,36 +323,41 @@ bool effect_benchmark_is_running(const EffectBenchmark* bench);
 
 // Afficher les résultats (appelé automatiquement à la fin)
 void effect_benchmark_log_results(const EffectBenchmark* bench);
+
 ```
 
 ### Paramètres de mesure
 
-| Constante | Valeur | Rôle |
-|-----------|--------|------|
-| `BENCH_WARMUP_FRAMES` | 30 | Frames ignorées après chaque changement d'état (stabilisation pipeline) |
-| `BENCH_MEASURE_FRAMES` | 120 | Frames échantillonnées par phase (≈2s à 60fps) |
-| `BENCH_MAX_EFFECTS` | 16 | Capacité maximale de la table d'effets |
+| Constante              | Valeur | Rôle                                                                    |
+| ---------------------- | ------ | ----------------------------------------------------------------------- |
+| `BENCH_WARMUP_FRAMES`  | 30     | Frames ignorées après chaque changement d'état (stabilisation pipeline) |
+| `BENCH_MEASURE_FRAMES` | 120    | Frames échantillonnées par phase (≈2s à 60fps)                          |
+| `BENCH_MAX_EFFECTS`    | 16     | Capacité maximale de la table d'effets                                  |
 
 ## Limites
 
 1. **Précision iGPU** — Sur GPU intégré (Intel Iris Xe), la résolution des
+
    timer queries est de l'ordre de 80 ns. Les effets très légers (< 0.01 ms)
    sont souvent dans le bruit.
 
 2. **Non-additivité** — Le coût d'un effet dépend des autres effets actifs
+
    (latency hiding, pression registres). La somme des coûts individuels ne
    sera pas égale au coût total.
 
 3. **Stabilité scène requise** — Bouger la caméra pendant le bench modifie
+
    la charge fragment (overdraw, fill rate) et fausse les mesures.
 
 4. **Divergence GPU** — Les branches `if` du uber-shader ont un coût qui
+
    dépend de la cohérence spatiale des pixels. L'A/B ne capture pas le coût
-   de divergence additionnel quand *plusieurs* effets sont actifs simultanément.
+   de divergence additionnel quand _plusieurs_ effets sont actifs simultanément.
 
 ## Changelog
 
-| Date | Changement |
-|------|-----------|
+| Date       | Changement                                                                  |
+| ---------- | --------------------------------------------------------------------------- |
 | 2026-02-07 | Création du module `effect_benchmark` (header, implémentation, intégration) |
-| 2026-02-08 | Ajout de la phase `BENCH_STABILIZE` et du Timeout (2s) pour la fiabilité |
+| 2026-02-08 | Ajout de la phase `BENCH_STABILIZE` et du Timeout (2s) pour la fiabilité    |

--- a/docs/env_transitions.md
+++ b/docs/env_transitions.md
@@ -12,17 +12,21 @@ When switching between High Dynamic Range (HDR) environment maps, the applicatio
 
 The Crossfade mode provides a smooth blend from the previous environment to the new one.
 
-* **Behavior**: As soon as the new environment (and its associated IBL textures) is ready, the application captures a snapshot of the current frame. It then swaps the environment and fades the snapshot over the new scene.
-* **Aesthetics**: Provides a high-end, seamless feel.
-* **Implementation**: Uses a framebuffer snapshot texture.
+- **Behavior**: As soon as the new environment (and its associated IBL textures) is ready, the application captures a snapshot of the current frame. It then swaps the environment and fades the snapshot over the new scene.
+
+- **Aesthetics**: Provides a high-end, seamless feel.
+
+- **Implementation**: Uses a framebuffer snapshot texture.
 
 ### 2. Black Screen
 
 The Black Screen mode provides a classic "fade to black" transition.
 
-* **Behavior**: The current environment remains interactive while the new one loads in the background (`TRANSITION_LOADING`). Once loading is complete, the application fades to black, swaps the textures, and then fades back in.
-* **Use Case**: Preferred for slower systems or when a clear visual break between environments is desired.
-* **Implementation**: Uses a dummy black texture as an overlay.
+- **Behavior**: The current environment remains interactive while the new one loads in the background (`TRANSITION_LOADING`). Once loading is complete, the application fades to black, swaps the textures, and then fades back in.
+
+- **Use Case**: Preferred for slower systems or when a clear visual break between environments is desired.
+
+- **Implementation**: Uses a dummy black texture as an overlay.
 
 ## State Machine
 
@@ -44,16 +48,20 @@ stateDiagram-v2
 
     idle --> wait_ibl : Initial Startup
     wait_ibl --> fade_in : IBL Done (Initial Load)
+
 ```
 
 ### Transition States (`TransitionState`)
 
-* `TRANSITION_IDLE`: No transition active.
+- `TRANSITION_IDLE`: No transition active.
 
-* `TRANSITION_LOADING`: Background loading of HDR/IBL textures while the old scene is visible.
-* `TRANSITION_WAIT_IBL`: Used during initial startup to keep the screen black until the first environment is ready.
-* `TRANSITION_FADE_OUT`: Scene is fading to black or snapshot.
-* `TRANSITION_FADE_IN`: Scene is fading in from black or snapshot.
+- `TRANSITION_LOADING`: Background loading of HDR/IBL textures while the old scene is visible.
+
+- `TRANSITION_WAIT_IBL`: Used during initial startup to keep the screen black until the first environment is ready.
+
+- `TRANSITION_FADE_OUT`: Scene is fading to black or snapshot.
+
+- `TRANSITION_FADE_IN`: Scene is fading in from black or snapshot.
 
 ## Implementation Details
 
@@ -71,20 +79,24 @@ Transitions can be configured via `include/app_settings.h` or controlled at runt
 
 ### Constants
 
-* `DEFAULT_ENV_TRANSITION_DURATION`: The time in seconds for a full fade.
+- `DEFAULT_ENV_TRANSITION_DURATION`: The time in seconds for a full fade.
 
-* `DEFAULT_ENV_TRANSITION_MODE`: The default mode (`ENV_TRANSITION_CROSSFADE` or `ENV_TRANSITION_BLACK_SCREEN`).
+- `DEFAULT_ENV_TRANSITION_MODE`: The default mode (`ENV_TRANSITION_CROSSFADE` or `ENV_TRANSITION_BLACK_SCREEN`).
 
 ### Runtime Controls
 
-* **`T` Key**: Toggles between Crossfade and Black Screen modes.
+- **`T` Key**: Toggles between Crossfade and Black Screen modes.
 
 ## Extending the Transition System
 
 To add a new transition type (e.g., "Radial Wipe" or "Pixelate"):
 
 1. **Enums**: Add your new mode to `EnvTransitionMode` in `app_settings.h`.
+
 2. **State Machine**: Update the logic in `app_process_ibl_state_machine` (in `src/app_env.c`) to initiate the correct state sequence for your new mode.
+
 3. **Shaders**: If the transition requires a special effect, create a new fragment shader or extend `debug_tex.frag`.
+
 4. **Rendering**: Update `app_render` in `src/app.c` to bind the necessary textures and set uniforms for your new shader effect when `app->env_transition_mode` matches your new enum value.
+
 5. **Unit Tests**: Add test cases to `tests/test_env_transition.c` to verify your new state flow.

--- a/docs/equirectangular_seam_fix.md
+++ b/docs/equirectangular_seam_fix.md
@@ -8,8 +8,9 @@ A faint, perfectly straight vertical line was visible in the environment reflect
 
 The issue was caused by two cooperative factors:
 
-1.  **Horizontal Wrap Mode**: The generated IBL textures (Irradiance Map and Prefiltered Specular Map) were initialized with `GL_CLAMP_TO_EDGE` for the `GL_TEXTURE_WRAP_S` parameter. When sampling near the $u=1.0$ or $u=0.0$ boundary, linear filtering would "clamp" to the edge pixel instead of blending with the other side of the equirectangular map.
-2.  **GPU Derivative Discontinuity**: When using the standard `texture()` function, the GPU calculates automatic MIP levels based on screen-space derivatives ($dFdx$ / $dFdy$). At the UV wrap-around point, the coordinate jumps from $1.0$ to $0.0$ (or vice versa) in a single pixel, creating an enormous gradient. This triggers the GPU to select the coarsest MIP level (highly blurred) for that specific pixel column, creating a "seam".
+1. **Horizontal Wrap Mode**: The generated IBL textures (Irradiance Map and Prefiltered Specular Map) were initialized with `GL_CLAMP_TO_EDGE` for the `GL_TEXTURE_WRAP_S` parameter. When sampling near the $u=1.0$ or $u=0.0$ boundary, linear filtering would "clamp" to the edge pixel instead of blending with the other side of the equirectangular map.
+
+2. **GPU Derivative Discontinuity**: When using the standard `texture()` function, the GPU calculates automatic MIP levels based on screen-space derivatives ($dFdx$ / $dFdy$). At the UV wrap-around point, the coordinate jumps from $1.0$ to $0.0$ (or vice versa) in a single pixel, creating an enormous gradient. This triggers the GPU to select the coarsest MIP level (highly blurred) for that specific pixel column, creating a "seam".
 
 ## Resolution
 
@@ -23,6 +24,7 @@ In `src/pbr.c`, the horizontal wrap mode for all equirectangular-mapped IBL text
 // src/pbr.c
 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
 ```
 
 This ensures that linear filtering correctly wraps around the "seam" of the sphere.
@@ -34,16 +36,21 @@ In `shaders/pbr_functions.glsl`, the sampling of the irradiance map (which is al
 ```glsl
 // shaders/pbr_functions.glsl
 vec3 irradiance = textureLod(irradianceMap, dirToUV(N), 0.0).rgb;
+
 ```
 
-For the specular prefiltered map, which *does* use MIP levels for roughness, the wrap mode fix in C is usually sufficient to hide the seam, as the derivatives only trigger the wrong MIP at the exact jump point, and `GL_REPEAT` allows `texture()` to handle wrap-around derivatives more gracefully on some hardware (though `textureLod` remains the safest choice for irradiance).
+For the specular prefiltered map, which _does_ use MIP levels for roughness, the wrap mode fix in C is usually sufficient to hide the seam, as the derivatives only trigger the wrong MIP at the exact jump point, and `GL_REPEAT` allows `texture()` to handle wrap-around derivatives more gracefully on some hardware (though `textureLod` remains the safest choice for irradiance).
 
 ## Verification
 
 The fix can be verified by:
+
 1. Enabling "Billboard" mode.
+
 2. Switching to PBR Debug Mode 6 ("Irradiance (Diff)").
+
 3. Rotating the camera to view the $X=0$ alignment where the seam previously appeared.
+
 4. Shading should now be perfectly continuous across the entire sphere.
 
 > [!NOTE]

--- a/docs/exposure_analysis.md
+++ b/docs/exposure_analysis.md
@@ -1,7 +1,6 @@
-
 # Global Exposure Management Analysis
-**Date: January 24, 2026**
 
+*Date: January 24, 2026*
 This analysis details how exposure is defined, managed, and applied in the application, covering both the CPU (management) and GPU (implementation and auto-exposure).
 
 ## 1. Definition and Data Structure
@@ -9,27 +8,38 @@ This analysis details how exposure is defined, managed, and applied in the appli
 Exposure is managed via two distinct, non-overlapping modes: **Manual** and **Automatic**.
 
 ### CPU Side (include/postprocess.h, src/postprocess.c)
+
 Parameters are stored in the `PostProcess` structure:
 
-*   **Manual Exposure**:
-    *   Struct: `ExposureParams`
-    *   Variable: `exposure` (float).
-    *   Default: `1.0` (Defined by `DEFAULT_EXPOSURE`).
-    *   Control: `postprocess_set_exposure()`.
+- **Manual Exposure**:
+  - Struct: `ExposureParams`
 
-*   **Automatic Exposure (Eye Adaptation)**:
-    *   Struct: `AutoExposureParams`
-    *   Variables:
-        *   `min_luminance` / `max_luminance`: Clamping range for scene luminance.
-        *   `speed_up` / `speed_down`: Adaptation speed (eye opens faster than it closes).
-        *   `key_value`: The target middle grey value (Exposure anchor).
-    *   Control: `postprocess_set_auto_exposure()`.
+  - Variable: `exposure` (float).
+
+  - Default: `1.0` (Defined by `DEFAULT_EXPOSURE`).
+
+  - Control: `postprocess_set_exposure()`.
+
+- **Automatic Exposure (Eye Adaptation)**:
+  - Struct: `AutoExposureParams`
+
+  - Variables:
+    - `min_luminance` / `max_luminance`: Clamping range for scene luminance.
+
+    - `speed_up` / `speed_down`: Adaptation speed (eye opens faster than it closes).
+
+    - `key_value`: The target middle grey value (Exposure anchor).
+
+  - Control: `postprocess_set_auto_exposure()`.
 
 ### GPU Side (Uniforms & Textures)
-*   **Manual**: Transmitted via the `exposure.exposure` uniform.
-*   **Automatic**:
-    *   `autoExposureTexture`: 1x1 `GL_RGBA32F` texture (Image Load/Store) storing the persistent exposure state.
-    *   `lumTexture`: 64x64 `GL_R16F` texture used as an intermediate step for average luminance calculation.
+
+- **Manual**: Transmitted via the `exposure.exposure` uniform.
+
+- **Automatic**:
+  - `autoExposureTexture`: 1x1 `GL_RGBA32F` texture (Image Load/Store) storing the persistent exposure state.
+
+  - `lumTexture`: 64x64 `GL_R16F` texture used as an intermediate step for average luminance calculation.
 
 ---
 
@@ -38,42 +48,64 @@ Parameters are stored in the `PostProcess` structure:
 The mode selection occurs in the render loop `postprocess_end()`.
 
 ### Mode A: Automatic Exposure (POSTFX_AUTO_EXPOSURE)
+
 If this flag is enabled, a pre-calculation pass is executed **before** the final render.
 
-1.  **Downsample (Luminance Reduction)**
-    *   **File**: `shaders/lum_downsample.frag`
-    *   **Action**: Takes the HDR scene (`scene_color_tex`) and reduces it to a 64x64 texture.
-    *   **Logic**:
-        *   Samples 4x4 blocks.
-        *   Calculates luminance: `dot(color, vec3(0.2126, 0.7152, 0.0722))`.
-        *   Converts to log: `log2(lum)`.
-        *   Averages valid values (ignoring pure blacks/infinite).
-    *   **Goal**: Prepare compact data for the Compute Shader.
+1. **Downsample (Luminance Reduction)**
 
-2.  **Adaptation (Compute Shader)**
-    *   **File**: `shaders/lum_adapt.comp`
-    *   **Action**: Calculates final exposure with temporal inertia.
-    *   **Logic** (Single Thread 1,1,1):
-        *   Reads the 64x64 texture and calculates global average Log Luminance.
-        *   Converts to Linear Scene Luminance: `exp2(avgLogLum)`.
-        *   Clamps luminance between `minLuminance` and `maxLuminance`.
-        *   Calculates target: `targetExposure = keyValue / sceneLum`.
-        *   **Interpolation**: Reads the *previous* exposure from the 1x1 image and interpolates towards the target using `deltaTime` and `speedUp`/`speedDown`.
-        *   Writes the new result to the 1x1 image.
+- **File**: `shaders/lum_downsample.frag`
 
-3.  **Final Application**
-    *   **File**: `shaders/postprocess/exposure.glsl` (included in `postprocess.frag`).
-    *   The `getCombinedExposure()` function detects auto-exposure is active.
-    *   It samples the 1x1 texture: `texture(autoExposureTexture, vec2(0.5)).r`.
+- **Action**: Takes the HDR scene (`scene_color_tex`) and reduces it to a 64x64 texture.
+
+- **Logic**:
+  - Samples 4x4 blocks.
+
+  - Calculates luminance: `dot(color, vec3(0.2126, 0.7152, 0.0722))`.
+
+  - Converts to log: `log2(lum)`.
+
+  - Averages valid values (ignoring pure blacks/infinite).
+
+- **Goal**: Prepare compact data for the Compute Shader.
+
+1. **Adaptation (Compute Shader)**
+
+- **File**: `shaders/lum_adapt.comp`
+
+- **Action**: Calculates final exposure with temporal inertia.
+
+- **Logic** (Single Thread 1,1,1):
+  - Reads the 64x64 texture and calculates global average Log Luminance.
+
+  - Converts to Linear Scene Luminance: `exp2(avgLogLum)`.
+
+  - Clamps luminance between `minLuminance` and `maxLuminance`.
+
+  - Calculates target: `targetExposure = keyValue / sceneLum`.
+
+  - **Interpolation**: Reads the *previous* exposure from the 1x1 image and interpolates towards the target using `deltaTime` and `speedUp`/`speedDown`.
+
+  - Writes the new result to the 1x1 image.
+
+1. **Final Application**
+
+- **File**: `shaders/postprocess/exposure.glsl` (included in `postprocess.frag`).
+
+- The `getCombinedExposure()` function detects auto-exposure is active.
+
+- It samples the 1x1 texture: `texture(autoExposureTexture, vec2(0.5)).r`.
 
 ### Mode B: Manual Exposure (POSTFX_EXPOSURE)
+
 Used if auto-exposure is disabled.
 
-1.  Downsample and Compute Shader passes are **skipped**.
-2.  **Final Application**:
-    *   `getCombinedExposure()` directly uses the `exposure.exposure` uniform.
+1. Downsample and Compute Shader passes are **skipped**.
+1. **Final Application**:
+
+- `getCombinedExposure()` directly uses the `exposure.exposure` uniform.
 
 ### Mode C: No Exposure
+
 If no effect is active, the value `1.0` is used.
 
 ---
@@ -82,32 +114,40 @@ If no effect is active, the value `1.0` is used.
 
 Exposure is applied at a specific stage in the final fragment shader:
 
-1.  Input (Scene Color).
-2.  Chrom. Aberration / Motion Blur.
-3.  Depth of Field.
-4.  Bloom (Added to color).
-5.  **>>> EXPOSURE <<<**: `color_val *= exposure_total`.
-6.  Color Grading & White Balance.
-7.  Tone Mapping (HDR to LDR).
-8.  Gamma Correction.
+1. Input (Scene Color).
+1. Chrom. Aberration / Motion Blur.
+1. Depth of Field.
+1. Bloom (Added to color).
+1. **>>> EXPOSURE <<<**: `color_val *= exposure_total`.
+1. Color Grading & White Balance.
+1. Tone Mapping (HDR to LDR).
+1. Gamma Correction.
 
 **Important Observation**: Exposure is applied as a simple scalar multiplier on the linear HDR signal. This is physically consistent (simulation of camera aperture/ISO) and correctly occurs before Tone Mapping.
 
 ## 4. Pre-calculation and Optimizations
 
-*   **Downsample 64x64**: Rather than performing a complex parallel reduction of the full 1080p/4k image, the image is drastically reduced via a very fast fragment shader (`lum_downsample.frag`) which performs an approximate average (4x4 Box Filter with stride). This massively reduces the load for the Compute Shader.
-*   **Single Compute Shader**: Adaptation launches only a single WorkGroup (1,1,1) as it processes only 4096 pixels (64x64). It is extremely lightweight.
-*   **Persistent Texture**: Using a 1x1 texture as storage allows retaining exposure state from one frame to the next without CPU-GPU roundtrips (no `glGetTexImage` needed for logic, everything stays on GPU).
+- **Downsample 64x64**: Rather than performing a complex parallel reduction of the full 1080p/4k image, the image is drastically reduced via a very fast fragment shader (`lum_downsample.frag`) which performs an approximate average (4x4 Box Filter with stride). This massively reduces the load for the Compute Shader.
+
+- **Single Compute Shader**: Adaptation launches only a single WorkGroup (1,1,1) as it processes only 4096 pixels (64x64). It is extremely lightweight.
+
+- **Persistent Texture**: Using a 1x1 texture as storage allows retaining exposure state from one frame to the next without CPU-GPU roundtrips (no `glGetTexImage` needed for logic, everything stays on GPU).
 
 ## Synthetic Summary
 
 | Aspect | Detail |
-| :--- | :--- |
+| :----- | :----- |
+
 | **State Storage** | 1x1 Float Texture (GPU) |
+
 | **Adaptation Logic** | Compute Shader (`lum_adapt.comp`) |
+
 | **Metric** | Log Average Luminance |
+
 | **Input Analysis** | 64x64 Downsampled Texture |
+
 | **Application** | Scalar Multiplication in `postprocess.frag` |
+
 | **Conflict** | Auto-Exposure overrides Manual Exposure |
 
 ### Adaptation Pipeline
@@ -166,6 +206,7 @@ digraph AutoExposure {
   History -> Final [label="Fetch"];
   Scene -> Final [color="#7aa2f7", penwidth=2.5, label="LDR Path"];
 }
+
 ```
 
 **[> Read the Auto Exposure Debug Histogram Documentation](auto_exposure_debug_histogram.md)**

--- a/docs/fix_async_loader_deadlock.md
+++ b/docs/fix_async_loader_deadlock.md
@@ -19,11 +19,13 @@ if (has_work) {
 
 pthread_mutex_lock(&request_mutex);     // (3) DEADLOCK — already held!
 has_pending_work = false;
+
 ```
 
 `async_handle_io()` internally re-acquires the mutex before returning (in all
 code paths: success, failure, cancel). Step (3) then tried to lock an already-held
 mutex — **undefined behavior** on POSIX default (non-recursive) mutexes, which on
+
 Linux manifests as a permanent deadlock.
 
 Once the worker thread deadlocked on itself, the main thread's `async_loader_poll()`
@@ -38,18 +40,24 @@ Made the re-lock conditional on whether `async_handle_io()` was called:
 if (has_work) {
     async_handle_io(path_to_load);
     /* Returns with mutex HELD — no re-lock needed */
+
 } else {
     /* No work dispatched, re-acquire for next iteration */
+
     pthread_mutex_lock(&request_mutex);
 }
 has_pending_work = false;
+
 ```
 
 ## Why It Appeared Intermittently
 
 The deadlock only triggers when:
+
 1. The worker thread finishes all internal work (IO + conversion)
+
 2. The main thread happens to call `async_loader_poll()` after the worker
+
    re-acquires the mutex at step (3)
 
 On faster GPUs/CPUs, timing differences could mask the bug. On Intel HD 4600

--- a/docs/fix_lint_bazzite_paths.md
+++ b/docs/fix_lint_bazzite_paths.md
@@ -9,12 +9,15 @@
 Bazzite (Fedora Atomic) uses `/var/home` as the physical home directory, with
 `/home` as a symlink:
 
-```
+```sh
 /home -> var/home
+
 ```
 
 This creates a path identity mismatch:
+
 - **Python / filesystem:** `os.path.abspath()` returns `/var/home/latty/...`
+
 - **CMake:** Writes `/home/latty/...` in `compile_commands.json`
 
 ## Problem 1: Lint Cache `Permission denied`
@@ -25,16 +28,19 @@ When `file_path` was an absolute `/var/home/...` path and CWD resolved different
 `os.makedirs()` to attempt creating directories outside the project.
 
 **Fix:** Changed to `os.path.relpath(file_path, src_root)` which always produces
+
 clean relative paths like `src/foo.c`.
 
 ## Problem 2: `run-clang-tidy` Finds 0 Files
 
 `run-clang-tidy` uses **string matching** against `compile_commands.json` entries.
+
 When the script passed `/var/home/latty/.../src/app.c` but the database contained
 `/home/latty/.../src/app.c`, it matched 0 files and exited successfully without
 linting anything.
 
 **Fix:** Added `detect_path_prefix()` which reads the first entry from
+
 `compile_commands.json` and compares it with the filesystem path. If a prefix
 mismatch is detected (e.g., `/var/home/latty/Prog/proj` vs `/home/latty/Prog/proj`),
 `normalize_path_for_clang_tidy()` remaps the prefix before passing paths to
@@ -43,4 +49,5 @@ mismatch is detected (e.g., `/var/home/latty/Prog/proj` vs `/home/latty/Prog/pro
 ## Backward Compatibility
 
 On systems where `/home` is **not** a symlink, `detect_path_prefix()` returns
+
 `(None, None)` and the normalization function is a no-op. No behavior change.

--- a/docs/fullscreen_deadlock.md
+++ b/docs/fullscreen_deadlock.md
@@ -10,16 +10,22 @@ The deadlock was caused by a synchronization conflict between the GLFW event loo
 
 ### The Problematic Sequence
 
-1.  **Toggle Triggered**: The user presses 'F', which calls `app_toggle_fullscreen()`.
-2.  **Synchronous Driver Call**: `app_toggle_fullscreen()` calls `glfwSetWindowMonitor()`. This is a synchronous operation that blocks until the window manager and driver acknowledge the mode switch.
-3.  **Nested Callback**: While blocked inside `glfwSetWindowMonitor()`, the window manager sends a resize event. GLFW dispatches this event immediately by calling `framebuffer_size_callback()`.
-4.  **Heavy GPU Work**: The callback invoked `postprocess_resize()`, which performed heavy GPU resource management:
-    *   Destroying existing Framebuffer Objects (FBOs) and textures.
-    *   Allocating new textures for Bloom, Depth of Field, etc.
-    *   Recompiling/re-linking shaders for some post-process effects.
-5.  **Circular Dependency (Deadlock)**:
-    *   The **Driver/Compositor** is waiting for the application to finish its current GPU work (like a pending `glfwSwapBuffers` or fence sync) to complete the mode switch.
-    *   The **Application** is blocked inside the resize callback, trying to allocate/delete GPU resources, but the driver's command queue is often locked or stalled during the mode switch handshake.
+1. **Toggle Triggered**: The user presses 'F', which calls `app_toggle_fullscreen()`.
+1. **Synchronous Driver Call**: `app_toggle_fullscreen()` calls `glfwSetWindowMonitor()`. This is a synchronous operation that blocks until the window manager and driver acknowledge the mode switch.
+1. **Nested Callback**: While blocked inside `glfwSetWindowMonitor()`, the window manager sends a resize event. GLFW dispatches this event immediately by calling `framebuffer_size_callback()`.
+1. **Heavy GPU Work**: The callback invoked `postprocess_resize()`, which performed heavy GPU resource management:
+
+- Destroying existing Framebuffer Objects (FBOs) and textures.
+
+- Allocating new textures for Bloom, Depth of Field, etc.
+
+- Recompiling/re-linking shaders for some post-process effects.
+
+1. **Circular Dependency (Deadlock)**:
+
+- The **Driver/Compositor** is waiting for the application to finish its current GPU work (like a pending `glfwSwapBuffers` or fence sync) to complete the mode switch.
+
+- The **Application** is blocked inside the resize callback, trying to allocate/delete GPU resources, but the driver's command queue is often locked or stalled during the mode switch handshake.
 
 ### Sequence Before (DEADLOCK)
 
@@ -65,6 +71,7 @@ sequenceDiagram
     Main->>GPU: glDeleteTextures / glGenTextures
     Note over GPU,Driver: GPU blocked by pending swap
     Note over Main,GPU: (DEADLOCK)
+
 ```
 
 ## Implementation: Deferred Resize
@@ -106,6 +113,7 @@ sequenceDiagram
     participant GPU as GPU Pipeline
 
     Main->>GPU: glFinish() - drain pipeline
+
     GPU-->>Main: All commands complete
     Main->>GLFW: glfwSetWindowMonitor()
     GLFW->>Driver: Mode switch request
@@ -117,7 +125,9 @@ sequenceDiagram
     Note over Main: Next frame begins...
     Main->>Main: app_run: resize_pending? YES
     Main->>GPU: postprocess_resize() - safe context
+
     GPU-->>Main: FBOs recreated (OK)
+
 ```
 
 ### 1. Lightweight Callback
@@ -126,7 +136,9 @@ The `framebuffer_size_callback` no longer performs any GPU resource allocation. 
 
 ```c
 void framebuffer_size_callback(GLFWwindow* window, int width, int height) {
+
     App* app = (App*)glfwGetWindowUserPointer(window);
+
     app->width = width;
     app->height = height;
     glViewport(0, 0, width, height);
@@ -136,6 +148,7 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height) {
     app->pending_height = height;
     app->resize_pending = 1;
 }
+
 ```
 
 ### 2. GPU Pipeline Drain
@@ -154,6 +167,7 @@ if (app->resize_pending) {
     postprocess_resize(&app->postprocess, app->pending_width, app->pending_height);
     app->resize_pending = 0;
 }
+
 ```
 
 ## Stress Testing
@@ -161,23 +175,32 @@ if (app->resize_pending) {
 A dedicated stress test was created to verify this fix: `scripts/test_stress_fullscreen.sh`.
 
 ### How it works
+
 - It uses `xdotool` to send 'F' keystrokes rapidly (e.g., 10ms-50ms intervals).
+
 - It monitors the application's **log output** rather than window visibility. A deadlocked application may still have a visible window, but it will stop logging "Switched to fullscreen/windowed".
+
 - If the expected log message doesn't appear within 5 seconds, it detects a hang, captures a full GDB stack trace of all threads, and terminates the app.
 
 ### Running the test
+
 ```bash
+
 # Standard test
+
 just stress-fullscreen
 
 # Aggressive test with ASan
+
 just stress-fullscreen-asan 200 10
+
 ```
 
 ## Summary of Changes
 
 | File | Change |
-| :--- | :--- |
+| :--- | :----- |
+
 | `include/app.h` | Added `resize_pending`, `pending_width`, `pending_height` fields. |
 | `src/app_input.c` | Updated `framebuffer_size_callback` to use flags; added `glFinish()` to toggle. |
 | `src/app.c` | Added deferred resize processing logic and state initialization. |

--- a/docs/global_illumination.md
+++ b/docs/global_illumination.md
@@ -37,19 +37,27 @@ sequenceDiagram
     Main->>GPU: Upload des données SH vers le SSBO (glBufferSubData)
     Main->>GPU: Appel de dessin (Instanced ou SSBO)
     Note over GPU: Les fragments échantillonnent l'irradiance des 8 sondes adjacentes (Trilinear Filtering)
+
 ```
 
 1. **Light Probe Grid (CPU)**:
    - Une grille 3D régulière de sondes est dimensionnée pour englober la scène entière.
+
    - Un thread dédié (`GI Probe Worker`) calcule l'irradiance de chaque sonde depuis chaque objet interactif de la scène, de manière totalement asynchrone.
+
 2. **Synchronisation vers GPU (SSBO)**:
    - Chaque frame, le thread principal vérifie (via un `trylock`) si un nouveau calcul de SH est disponible.
+
    - Si oui, les données sont envoyées au GPU via un **Shader Storage Buffer Object (SSBO)**, minimisant l'overhead CPU vers GPU.
+
 3. **Échantillonnage (Fragment Shader)**:
    - Lors de l'évaluation PBR, si la GI est activée, le fragment calcule sa position par rapport à la grille.
+
    - Deux méthodes d'échantillonnage sont disponibles :
      - **Textures 3D (Hardware)** : Utilise 7 textures 3D avec interpolation trilinéaire matérielle. C'est la méthode la plus performante.
+
      - **SSBO (Software)** : Accède directement au buffer de sondes et effectue l'interpolation trilinéaire manuellement dans le shader.
+
    - Le résultat est une irradiance douce et continue.
 
 ---
@@ -91,22 +99,26 @@ Cette factorisation massive élimine plusieurs instructions trigonométriques co
 ```c
 // Extrait depuis light_probes.c
 float ff = (radius * radius) / dist2; // dist2 = distance au carré
+
 float diffuse = (1.0f - sphere->metallic) * ff * GI_BOUNCE_SCALE;
+
 vec3 radiance;
 glm_vec3_scale((float*)sphere->albedo, diffuse, radiance);
+
 ```
 
-*(On observe également que les matériaux purs métaux (`metallic == 1.0f`) ne contribuent pas au rebond diffus, car les métaux n'ont pas de diffusion sous-surfacique par définition de la physique PBR).*
+_(On observe également que les matériaux purs métaux (`metallic == 1.0f`) ne contribuent pas au rebond diffus, car les métaux n'ont pas de diffusion sous-surfacique par définition de la physique PBR)._
 
 ### Seuils Limites (Bounding) et Prévention du SH Ringing
 
-Les Harmoniques Sphériques (SH) sont excellentes pour modéliser une illumination à très basse fréquence, mais elles échouent (provoquent du *ringing*, soit un dépassement des couleurs avec des valeurs négatives ou hyper-brillantes) sous des signaux très concentrés (Delta Function).
+Les Harmoniques Sphériques (SH) sont excellentes pour modéliser une illumination à très basse fréquence, mais elles échouent (provoquent du _ringing_, soit un dépassement des couleurs avec des valeurs négatives ou hyper-brillantes) sous des signaux très concentrés (Delta Function).
 
 De plus, si une sonde est positionnée **à l'intérieur** d'une surface, ou exactement sur sa surface, $d \rightarrow 0$ et le Form Factor diverge vers l'infini.
 
 Pour éviter ces artéfacts et optimiser l'algorithme, des seuils très stricts sont mis en place :
 
 1. **`GI_MIN_DIST_RADII` (1.05)** : Rejette toute contribution si la sonde est à moins de $1.05\times$ le rayon de l'émetteur. Ceci empêche l'auto-illumination aberrante et le Ringing des SH, tout en permettant à la surface de capter avec force la couleur de son plus proche voisin ($d \geq 1.05$).
+
 2. **`GI_MAX_DIST_RADII` (3.0)** : Culling spatial pur. Au-delà de $3\times$ le rayon, le Facteur de Forme est inférieur à $0.0025$, ce qui est indiscernable visuellement. On ignore la sphère et l'on gagne considérablement en performance CPU.
 
 ---
@@ -120,7 +132,9 @@ E(n) = \sum_{l=0}^{2} A_l \sum_{m=-l}^{l} L_{l}^{m} Y_{l}^{m}(n)
 $$
 
 - $Y_l^m$ : Fonctions de base réelles.
+
 - $L_l^m$ : Coefficients projetés (Stockés dans les 9 vecteurs des SSBO).
+
 - $A_l$ : Coefficients de Convolution Cosinus ($\pi$, $\frac{2\pi}{3}$, $\frac{\pi}{4}$).
 
 Le shader (`sh_probe.glsl`) et la partie mathématiques CPU (`sh_math.c`) évaluent ces coefficients de la même manière que la théorie originale formalisée par **Ramamoorthi et Hanrahan**.
@@ -134,13 +148,16 @@ Le système supporte deux modes de transfert et d'échantillonnage, commutables 
 Chacun des 9 coefficients est packé dans un ensemble de 7 textures 3D `RGBA16F`. Cela permet de déléguer l'interpolation trilinéaire à l'unité de texture du GPU.
 
 - **Avantage** : Performance maximale, interpolation gratuite.
+
 - **Inconvénient** : Nécessite un packing complexe CPU-side (7 textures).
 
 ```glsl
 // sh_probe.glsl
 uniform sampler3D u_SHTexture0; // ... à 6
 vec3 uvw = (local_pos * vec3(u_ProbeGridDim - 1) + 0.5) / vec3(u_ProbeGridDim);
+
 vec4 t0 = texture(u_SHTexture0, uvw); // ...
+
 ```
 
 #### 2. SSBO (Software Interpolation)
@@ -148,6 +165,7 @@ vec4 t0 = texture(u_SHTexture0, uvw); // ...
 Les données sont envoyées brutes dans un **Shader Storage Buffer Object (SSBO)**. Le shader effectue alors les 8 lectures et les interpolations `mix()` manuellement.
 
 - **Avantage** : Transfert immédiat sans packing, alignement `std430` simple.
+
 - **Inconvénient** : Plus coûteux en instructions shader et accès mémoire.
 
 ```glsl
@@ -155,6 +173,7 @@ Les données sont envoyées brutes dans un **Shader Storage Buffer Object (SSBO)
 layout(std430, binding = 3) readonly buffer ProbeBuffer {
  LightProbe probes[];
 };
+
 ```
 
 Chacun des 9 coefficients est stocké sous forme de `vec4` (16 bytes) pour satisfaire les prérequis d'alignement `std430`.
@@ -168,4 +187,5 @@ L'approche de la GI dans Suckless-OGL par sondes d'irradiance procure un ajout v
 **Raccourcis en cours d'exécution** :
 
 - `Y` : Cycle entre les modes de GI : **Textures 3D** -> **SSBO** -> **Désactivé**.
+
 - `Shift + Y` : Affiche les sondes de la grille sous la forme de sphères lumineuses de debug (Debug Probes Draw).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -7,43 +7,67 @@ Ce lexique regroupe les termes et expressions techniques utilisés dans le proje
 ## 🎨 Rendu & Physique (PBR / IBL)
 
 | Terme | Définition Logicielle / Théorique |
-| :--- | :--- |
-| **PBR** | *Physically Based Rendering*. Modèle de rendu basé sur les lois de la physique pour simulant l'interaction réelle de la lumière avec les matériaux. |
-| **IBL** | *Image Based Lighting*. Utilisation d'une image (cubemap HDR) pour simuler une illumination globale complexe. |
-| **BRDF** | *Bidirectional Reflective Distribution Function*. Fonction définissant comment un matériau réfléchit la lumière (modèle de Cook-Torrance). |
-| **NDF (GGX)** | *Normal Distribution Function*. Partie du PBR décrivant la micro-géométrie des surfaces (distribution des micro-facettes). |
+| :---- | :-------------------------------- |
+
+| **PBR** | _Physically Based Rendering_. Modèle de rendu basé sur les lois de la physique pour simulant l'interaction réelle de la lumière avec les matériaux. |
+
+| **IBL** | _Image Based Lighting_. Utilisation d'une image (cubemap HDR) pour simuler une illumination globale complexe. |
+
+| **BRDF** | _Bidirectional Reflective Distribution Function_. Fonction définissant comment un matériau réfléchit la lumière (modèle de Cook-Torrance). |
+
+| **NDF (GGX)** | _Normal Distribution Function_. Partie du PBR décrivant la micro-géométrie des surfaces (distribution des micro-facettes). |
+
 | **Split-Sum** | Approximation mathématique (Epic Games) permettant de calculer l'IBL spéculaire en temps réel via une pré-intégration (Prefiltered Map + BRDF LUT). |
+
 | **Irradiance / Radiance** | L'Irradiance est le flux lumineux incident total (diffus), la Radiance est le flux dans une direction précise (spéculaire). |
+
 | **Normal Mapping / TBN** | Simulation de détails via une texture. La matrice **TBN** (Tangent, Bitangent, Normal) transforme les vecteurs du "Tangent Space" vers le "World Space". |
 
 ## 📐 Optimisations de Projection (Sphères / Billboards)
 
 | Terme | Définition Logicielle |
-| :--- | :--- |
+| :---- | :-------------------- |
+
 | **Imposteurs** | Technique simulant une géométrie 3D complexe (sphère) sur un quad 2D via du ray-casting dans le shader. |
+
 | **Analytic AA** | Anti-Aliasing mathématique sur le bord de la sphère calculé à partir de la dérivée du discriminant (`fwidth`), offrant des contours parfaits. |
+
 | **Tangent Planes** | Méthode géométrique calculant la "bounding box" (AABB) parfaite d'une sphère à l'écran via les plans tangents passant par la caméra. |
+
 | **Conservative Depth** | Positionnement du quad au point le plus proche de la sphère pour garantir un Z-test correct avant l'écriture de `gl_FragDepth`. |
+
 | **Discriminant** | Valeur de l'équation Rayon-Sphère ($b^2 - ac$). Détermine si un pixel est à l'intérieur ($>0$) ou à l'extérieur ($<0$) de la sphère. |
+
 | **Perspective Distortion** | Déformation elliptique d'une sphère lorsqu'elle s'éloigne du centre de l'écran, gérée ici par la projection exacte des tangents. |
 
 ## ⚙️ API Graphique & Flux de Données (GPU)
 
 | Terme | Définition Logicielle |
-| :--- | :--- |
-| **PBO (Zero-Copy)** | *Pixel Buffer Object*. Utilisation de `GL_MAP_UNSYNCHRONIZED_BIT` pour uploader des données sans bloquer le CPU. |
+| :---- | :-------------------- |
+
+| **PBO (Zero-Copy)** | _Pixel Buffer Object_. Utilisation de `GL_MAP_UNSYNCHRONIZED_BIT` pour uploader des données sans bloquer le CPU. |
+
 | **Fence Sync** | Objet `glFenceSync` permettant de vérifier la complétion d'une tâche GPU sans forcer un vidage complet (stall) du pipeline. |
+
 | **Flat Interpolation** | Qualificateur `flat` empêchant l'interpolation entre sommets, crucial pour la stabilité numérique des calculs de silouhette sur les sphères. |
+
 | **Provoking Vertex** | Sommet dont la valeur est utilisée par l'ensemble de la primitive lors d'une interpolation `flat`. |
+
 | **Pipeline Stall** | Latence critique où le CPU attend le GPU (causée par une lecture synchrone ou un `glFinish`). |
 
 ## 🚀 Architecture & Système
 
 | Terme | Définition Logicielle |
-| :--- | :--- |
+| :---- | :-------------------- |
+
 | **Time Slicing** | Découpage d'opérations lourdes (IBL) en petites tranches réparties sur plusieurs frames pour maintenir un FPS constant. |
+
 | **Double Buffering (Pending)** | Préparation d'un nouvel état (ex: environnement) en arrière-plan pendant que l'ancien est toujours en cours d'affichage. |
+
 | **SIMD (AVX)** | Utilisation d'instructions processeur larges pour traiter plusieurs flottants simultanément (utilisé pour le tri des sphères). |
-| **PAL** | *Platform Abstraction Layer*. Couche isolant le code métier des spécificités système (Linux/Windows). |
+
+| **PAL** | _Platform Abstraction Layer_. Couche isolant le code métier des spécificités système (Linux/Windows). |
+
 | **MkDocs / Doxygen** | Outils de génération de documentation (Narrative vs API Reference). |
+
 | **Tracy** | Profileur hybride (CPU/GPU) utilisé pour analyser les performances en temps réel. |

--- a/docs/gpu-rendering-synchronization.md
+++ b/docs/gpu-rendering-synchronization.md
@@ -10,9 +10,10 @@ Investigation and resolution of rendering differences between Intel and NVIDIA G
 
 ## Visual Comparison
 
-| GPU | Before Fix | After Fix |
-|-----|------------|-----------|
+| GPU       | Before Fix                  | After Fix    |
+| --------- | --------------------------- | ------------ |
 | **Intel** | ✅ Clean edges, proper FXAA | ✅ Unchanged |
+
 | **NVIDIA** | ❌ White halos, buggy edges | ✅ Identical to Intel |
 
 ## Root Causes Identified
@@ -26,8 +27,11 @@ Investigation and resolution of rendering differences between Intel and NVIDIA G
 **Fix**: Use pre-calculated luma from alpha channel instead.
 
 ```diff
-- lumaEnd1 = FxaaLuma(texture(screenTexture, uv1).rgb);
-+ lumaEnd1 = texture(screenTexture, uv1).a;  // Pre-calculated in PBR shader
+
+* lumaEnd1 = FxaaLuma(texture(screenTexture, uv1).rgb);
+
+* lumaEnd1 = texture(screenTexture, uv1).a;  // Pre-calculated in PBR shader
+
 ```
 
 ### Issue 2: Derivative-Based Roughness Clamping
@@ -39,8 +43,8 @@ Investigation and resolution of rendering differences between Intel and NVIDIA G
 **Attempted Fixes**:
 
 1. ❌ Threshold 0.1 → 0.5: Reduced but didn't eliminate halos
-2. ❌ Saturation `min(maxVariation, 1.0)`: Still visible artifacts
-3. ✅ **Complete removal**: Achieved visual parity
+1. ❌ Saturation `min(maxVariation, 1.0)`: Still visible artifacts
+1. ✅ **Complete removal**: Achieved visual parity
 
 **Final Solution**: Disabled roughness clamping entirely.
 
@@ -51,13 +55,15 @@ float compute_roughness_clamping(vec3 N_val, float roughness_val)
     roughness_val = clamp(roughness_val, 0.0, 1.0);
     return roughness_val;
 }
+
 ```
 
 ## Why Derivatives Differ
 
-| Vendor | Implementation | Behavior |
-|--------|---------------|----------|
+| Vendor    | Implementation                           | Behavior                   |
+| --------- | ---------------------------------------- | -------------------------- |
 | **Intel** | Conservative 2x2 quad finite differences | Stable, predictable values |
+
 | **NVIDIA** | Optimized hardware units | Different rounding, can spike |
 
 **Result**: `pow(maxVariation, 0.1)` amplified vendor differences → white halos on NVIDIA.
@@ -67,13 +73,17 @@ float compute_roughness_clamping(vec3 N_val, float roughness_val)
 ### Lost
 
 - Geometric anti-aliasing on curved surfaces
+
 - Specular aliasing prevention on very smooth metals
 
 ### Gained
 
 - ✅ Cross-vendor consistency
+
 - ✅ Predictable behavior
+
 - ✅ Simplified shader code
+
 - ✅ Minor performance improvement
 
 **Verdict**: FXAA already provides excellent AA. Loss of hardware-dependent roughness clamping is compensated by a stable analytic minimum and sphere-specific curvature clamping.
@@ -83,10 +93,14 @@ float compute_roughness_clamping(vec3 N_val, float roughness_val)
 A key finding during this synchronization effort was the trade-off between using GLSL built-ins and custom analytic math.
 
 | Method | Built-in (`dFdx`, `fwidth`) | Analytic Curvature/Fade |
-| :--- | :--- | :--- |
+| :----- | :-------------------------- | :---------------------- |
+
 | **Vendor Consistency** | ❌ Poor (Driver/Hardware precision) | ✅ 100% (Mathematical) |
+
 | **Latency** | Medium (Quad-sync required) | Low (Pure ALU) |
+
 | **Logic Safety** | ❌ Fails in divergent branches | ✅ Branch-safe |
+
 | **Implementation** | Trivial (1 line) | Complex (Custom math per primitive) |
 
 **Cost Evaluation**: While analytic math uses more ALU cycles (approx. 5-10 more), it avoids the hardware synchronization latency of quads and ensures that regression maps between Intel, NVIDIA, and AMD remain dark (bit-perfect parity).
@@ -95,19 +109,22 @@ A key finding during this synchronization effort was the trade-off between using
 
 ### Visual Inspection
 
-```
+```text
 Before:  Intel ✅  |  NVIDIA ❌ (halos, buggy FXAA)
 After:   Intel ✅  |  NVIDIA ✅ (identical rendering)
+
 ```
 
 ### Reference Metrics (FXAA Synthetic Test)
 
 Target values based on correct Intel HD 4600 behavior (Sphere Pattern):
 
-| Metric | Reference Value (Intel) | NVIDIA (GTX 950M) | Pass Threshold |
-|--------|-------------------------|-------------------|----------------|
-| **Edge Noise (No AA)** | ~0.0026 | 0.0026 | N/A |
+| Metric                 | Reference Value (Intel) | NVIDIA (GTX 950M) | Pass Threshold |
+| ---------------------- | ----------------------- | ----------------- | -------------- |
+| **Edge Noise (No AA)** | ~0.0026                 | 0.0026            | N/A            |
+
 | **Edge Noise (FXAA)** | ~0.0015 | 0.0015 | < 0.0020 |
+
 | **Noise Reduction** | **~41.88%** | **41.85%** | > 10% |
 
 > **Conclusion**: NVIDIA rendering is now mathematically identical to Intel (delta < 0.1%), confirming the precision fix is successful.
@@ -115,6 +132,7 @@ Target values based on correct Intel HD 4600 behavior (Sphere Pattern):
 ## Files Modified
 
 - `shaders/postprocess/fxaa.glsl`
+
 - `shaders/pbr_functions.glsl`
 
 ## PBO Mapping Synchronization (Implicit vs. Explicit)
@@ -135,27 +153,30 @@ Instead of letting the driver guess, we use explicit synchronization:
 
 1. **Fence after Command**:
 
-   ```c
+```c
    glReadPixels(...);
    app->sync[idx] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-   ```
+```
 
-2. **Wait before Map**:
+1. **Wait before Map**:
 
-   ```c
+```c
    // Non-blocking wait (timeout 0)
    GLenum status = glClientWaitSync(app->sync[!idx], GL_SYNC_FLUSH_COMMANDS_BIT, 0);
    if (status != GL_TIMEOUT_EXPIRED) {
        void* ptr = glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+
        // ... process ...
        glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
    }
-   ```
+```
 
 By checking the fence with a zero timeout, we ensure that if the GPU is still busy, the CPU simply skips the logic for that frame instead of waiting. This is crucial for maintaining a high and stable frame rate.
 
 ## References
 
 - [shader-cross-gpu-compatibility.md](./shader-cross-gpu-compatibility.md) - General guidelines
+
 - [FXAA 3.11 Whitepaper](https://developer.nvidia.com/fxaa)
+
 - [OpenGL Derivatives](https://www.khronos.org/opengl/wiki/Derivative)

--- a/docs/gpu_profiling.md
+++ b/docs/gpu_profiling.md
@@ -6,24 +6,29 @@ The GPU profiling system in `suckless-ogl` provides high-precision timing for va
 
 ### Core Components
 
-* **`GPUProfiler`**: The main structure managing the collection of performance samples.
-* **`AdaptiveSampler`**: For each stage, maintains a history of samples to provide a smoothed "average" and filter out noise.
-* **Double Buffering**: Uses two sets of query buffers to allow the CPU to read results from the *previous* frame (N-1) while recording the *current* frame (N).
+- **`GPUProfiler`**: The main structure managing the collection of performance samples.
+
+- **`AdaptiveSampler`**: For each stage, maintains a history of samples to provide a smoothed "average" and filter out noise.
+
+- **Double Buffering**: Uses two sets of query buffers to allow the CPU to read results from the _previous_ frame (N-1) while recording the _current_ frame (N).
 
 ### Synchronized Timing (Blocking Wait)
 
 To ensure **no data is lost** (even when the GPU is heavily loaded or lagging), the profiler uses a **blocking wait** when retrieving results:
 
 1. At the start of Frame N, standard double-buffering would check if Frame N-1 results are ready.
+
 2. If not ready, standard approaches skip the data (causing gaps).
+
 3. **Our Approach**: We explicitly wait (`glGetQueryObjectui64v`), forcing the CPU to sync with the previous frame's completion. This guarantees a continuous, gap-free timeline even during performance spikes.
 
 ### Conditional Profiling (Zero Overhead)
 
 Since blocking waits impact performance, the system is **completely conditional**:
 
-* **Enabled**: When the Timeline UI is visible (F3), Metrics Logging is active (F4), or **Effect Benchmark** is running.
-* **Disabled**: Zero OpenGL queries are issued, and no synchronization checks are performed. The performance impact is effectively zero.
+- **Enabled**: When the Timeline UI is visible (F3), Metrics Logging is active (F4), or **Effect Benchmark** is running.
+
+- **Disabled**: Zero OpenGL queries are issued, and no synchronization checks are performed. The performance impact is effectively zero.
 
 ## Integration
 
@@ -36,15 +41,18 @@ Using the RAII macro simplifies code and ensures stages are closed correctly.
 
 ```c
 /* Start of frame (Controlled by App visibility) */
+
 gpu_profiler_begin_frame(&app->gpu_profiler, frame_index);
 
 /* ... */
 
 /* Record a specific stage using RAII */
+
 {
     GPU_STAGE_PROFILER(&app->gpu_profiler, "Geometry Pass", COLOR_HEX);
     // ... Rendering commands ...
 } // Stage ends automatically here
+
 ```
 
 **Manual Pattern:**
@@ -53,30 +61,42 @@ gpu_profiler_begin_frame(&app->gpu_profiler, frame_index);
 gpu_profiler_start_stage(&app->gpu_profiler, "Geometry Pass", COLOR_HEX);
     // ... Rendering commands ...
 gpu_profiler_end_stage(&app->gpu_profiler);
+
 ```
 
 ## Visualization
 
 Performance metrics are displayed in the application UI (Timeline Overlay):
 
-* **Bars**: Visual representation of execution duration relative to the total frame time.
-* **Hierarchy**: Nested stages are indented.
-* **Text**: Exact duration in milliseconds (right-aligned for readability).
+- **Bars**: Visual representation of execution duration relative to the total frame time.
+
+- **Hierarchy**: Nested stages are indented.
+
+- **Text**: Exact duration in milliseconds (right-aligned for readability).
 
 Controls:
 
-* **F3**: Toggle Timeline Visibility.
-* **SHIFT+F3**: Toggle Timeline Position (Top/Bottom).
-* **F4**: Toggle Console Metrics Logging.
+- **F3**: Toggle Timeline Visibility.
+
+- **SHIFT+F3**: Toggle Timeline Position (Top/Bottom).
+
+- **F4**: Toggle Console Metrics Logging.
 
 ## Changelog
 
-* **2026-02-08**:
-  * **RAII Support**: Added `GPU_STAGE_PROFILER` macro for automatic stage management (cleaner code, safer early returns).
-  * **Instrumentation**: Instrumented the **UI Overlay** stage to fill the last gap in the GPU timeline.
-  * **Robustness**: Fixed overlay disappearance during resize/stalls by indefinitely holding the last valid frame state.
-  * **Data Integrity**: Switched to **blocking** query retrieval for 100% data reliability even under load.
-  * **Performance**: Implemented **Conditional Profiling** to achieve zero overhead when hidden.
-  * **UI UX**: Right-aligned timing metrics in the timeline overlay for easier comparison.
-  * **Fixes**: Resolved OpenGL texture state warnings in the UI rendering backend.
-  * **Benchmark Integration**: Profiler now automatically enables itself when `effect_benchmark` is running to prevent stalls.
+- **2026-02-08**:
+  - **RAII Support**: Added `GPU_STAGE_PROFILER` macro for automatic stage management (cleaner code, safer early returns).
+
+  - **Instrumentation**: Instrumented the **UI Overlay** stage to fill the last gap in the GPU timeline.
+
+  - **Robustness**: Fixed overlay disappearance during resize/stalls by indefinitely holding the last valid frame state.
+
+  - **Data Integrity**: Switched to **blocking** query retrieval for 100% data reliability even under load.
+
+  - **Performance**: Implemented **Conditional Profiling** to achieve zero overhead when hidden.
+
+  - **UI UX**: Right-aligned timing metrics in the timeline overlay for easier comparison.
+
+  - **Fixes**: Resolved OpenGL texture state warnings in the UI rendering backend.
+
+  - **Benchmark Integration**: Profiler now automatically enables itself when `effect_benchmark` is running to prevent stalls.

--- a/docs/gpu_sorting.md
+++ b/docs/gpu_sorting.md
@@ -11,58 +11,84 @@ In computer graphics, transparency requires rendering fragments in **Back-to-Fro
 The **Bitonic Sort** is a "Sorting Network" algorithm. Unlike `qsort` or `std::sort`, it performs a fixed sequence of comparisons regardless of the data values.
 
 ### How it Works
-1.  **Bitonic Sequence**: A sequence $a_0, a_1, \dots, a_n$ is bitonic if it monotonically increases and then monotonically decreases (or can be circularly shifted to satisfy this).
-2.  **Bitonic Split**: If you have a bitonic sequence and compare $a_i$ with $a_{i+n/2}$, swapping them to put the smaller first, you get two smaller bitonic sequences where every element in the first is smaller than every element in the second.
-3.  **Recursion**: By recursively applying this split, you eventually reach individual sorted elements.
+
+1. **Bitonic Sequence**: A sequence $a_0, a_1, \dots, a_n$ is bitonic if it monotonically increases and then monotonically decreases (or can be circularly shifted to satisfy this).
+1. **Bitonic Split**: If you have a bitonic sequence and compare $a_i$ with $a_{i+n/2}$, swapping them to put the smaller first, you get two smaller bitonic sequences where every element in the first is smaller than every element in the second.
+1. **Recursion**: By recursively applying this split, you eventually reach individual sorted elements.
 
 ### Why it's Perfect for the GPU
--   **No Branching**: A GPU shader is like a factory line. If one worker (thread) has to do an "if" and another doesn't, the whole line slows down (Divergence). Bitonic sort has *zero* divergence because every thread performs exactly the same comparison pattern.
--   **Massive Parallelism**: With a complexity of $O(N \log^2 N)$, it does more total work than $O(N \log N)$ algorithms, but it does it **simultaneously** across thousands of GPU cores.
+
+- **No Branching**: A GPU shader is like a factory line. If one worker (thread) has to do an "if" and another doesn't, the whole line slows down (Divergence). Bitonic sort has _zero_ divergence because every thread performs exactly the same comparison pattern.
+
+- **Massive Parallelism**: With a complexity of $O(N \log^2 N)$, it does more total work than $O(N \log N)$ algorithms, but it does it **simultaneously** across thousands of GPU cores.
 
 ### Our Optimized "Proxy" Approach
+
 Initially, we swapped 128-byte `SphereInstance` structs. This was slow due to VRAM bandwidth.
--   **Solution**: We extract 8-byte **Proxy Entries** (4-byte float depth, 4-byte int index).
--   **Prepare Pass**: Compute depths once.
--   **Sort Pass**: Bitonic sort on 8-byte proxies (highly cache-efficient).
--   **Permute Pass**: Use sorted indices to copy the 128-byte structs to the final buffer in one single jump.
+
+- **Solution**: We extract 8-byte **Proxy Entries** (4-byte float depth, 4-byte int index).
+
+- **Prepare Pass**: Compute depths once.
+
+- **Sort Pass**: Bitonic sort on 8-byte proxies (highly cache-efficient).
+
+- **Permute Pass**: Use sorted indices to copy the 128-byte structs to the final buffer in one single jump.
 
 ## 3. Radix Sort (CPU Implementation)
 
 For the CPU, we implemented a **LSD (Least Significant Digit) Radix Sort**. This is a non-comparative algorithm that doesn't compare elements with each other.
 
 ### How it Works
-1.  **Bucketing**: Instead of comparing A with B, we look at the "digits" of the value. In our case, we treat a 32-bit float as four 8-bit "digits" (base 256).
-2.  **Passes**:
-    -   Pass 1: Sort by bits 0-7.
-    -   Pass 2: Sort by bits 8-15.
-    -   Pass 3: Sort by bits 16-23.
-    -   Pass 4: Sort by bits 24-31.
-3.  **Counting**: In each pass, we count how many items fall into each of the 256 "buckets", compute a prefix sum (offsets), and move items to a temporary buffer.
+
+1. **Bucketing**: Instead of comparing A with B, we look at the "digits" of the value. In our case, we treat a 32-bit float as four 8-bit "digits" (base 256).
+1. **Passes**:
+
+- Pass 1: Sort by bits 0-7.
+
+- Pass 2: Sort by bits 8-15.
+
+- Pass 3: Sort by bits 16-23.
+
+- Pass 4: Sort by bits 24-31.
+
+1. **Counting**: In each pass, we count how many items fall into each of the 256 "buckets", compute a prefix sum (offsets), and move items to a temporary buffer.
 
 ### The "IEEE-754 Float Trick"
+
 Sorting floats with Radix is tricky because negative floats' bit representations don't naturally sort in numerical order.
--   **The Solution**: We apply a transformation to the raw bits:
-    -   If the float is positive, we flip the sign bit.
-    -   If the float is negative, we flip *all* bits.
--   **Result**: This maps the floats into a 32-bit unsigned integer space where binary order matches numerical order. After sorting, we flip the bits back.
+
+- **The Solution**: We apply a transformation to the raw bits:
+  - If the float is positive, we flip the sign bit.
+
+  - If the float is negative, we flip _all_ bits.
+
+- **Result**: This maps the floats into a 32-bit unsigned integer space where binary order matches numerical order. After sorting, we flip the bits back.
 
 ### Performance
--   **Complexity**: $O(N \times K)$ where $K$ is the number of bits. Since $K$ is constant (32), this is effectively **$O(N)$**.
--   **Speed**: For 100,000 spheres, it is significantly faster than `qsort` because it avoids the overhead of function callbacks and pointer dereferencing for every comparison.
+
+- **Complexity**: $O(N \times K)$ where $K$ is the number of bits. Since $K$ is constant (32), this is effectively **$O(N)$**.
+
+- **Speed**: For 100,000 spheres, it is significantly faster than `qsort` because it avoids the overhead of function callbacks and pointer dereferencing for every comparison.
 
 ## 4. Comparison Table
 
 | Metric | CPU (qsort) | CPU (Radix) | GPU (Bitonic) |
-| :--- | :--- | :--- | :--- |
+| :----- | :---------- | :---------- | :------------ |
+
 | **Logic** | Comparison-based | Distribution-based | Network-based |
+
 | **Theoretical Complexity** | $O(N \log N)$ | $O(N)$ | $O(N \log^2 N)$ |
+
 | **Data Dependencies** | High | None | None |
+
 | **Implementation** | `qsort()` | Custom 4-pass | GLSL Compute |
+
 | **Best For** | < 1,000 items | 1,000 - 100,000 | > 10,000 or GPU-native data |
 
 ## 5. Summary
 
 We use **three** distinct paths:
-1.  **CPU Qsort**: Solid baseline, used for tests and reference.
-2.  **CPU Radix**: The "Golden Path" for high-performance sorting when data is already on the CPU.
-3.  **GPU Bitonic**: The "Scalability Path" for extreme counts or when we want to keep the CPU completely free for other tasks.
+
+1. **CPU Qsort**: Solid baseline, used for tests and reference.
+1. **CPU Radix**: The "Golden Path" for high-performance sorting when data is already on the CPU.
+1. **GPU Bitonic**: The "Scalability Path" for extreme counts or when we want to keep the CPU completely free for other tasks.

--- a/docs/ibl_architecture_ideas.md
+++ b/docs/ibl_architecture_ideas.md
@@ -3,41 +3,64 @@
 This document outlines architectural ideas for reducing the performance impact of environment map updates, specifically the long GPU stalls during Prefiltered Specular Map generation.
 
 ## 1. Problem Analysis
+
 Current metrics show that generating the Prefiltered Specular Map for a 4K environment takes ~350ms on integrated graphics. This causes a complete freeze of the rendering loop.
 
 ## 2. Proposed Solutions
 
 ### A. Progressive IBL (Temporal Amortization)
+
 Instead of calculating all mipmap levels in a single loop, process them incrementally.
+
 - **Mechanism**: Use a state machine in the `AsyncLoader` or `App` loop.
+
 - **Workflow**: `Frame N: Load HDR` -> `Frame N+1: Mip 0` -> `Frame N+2: Mip 1` ...
+
 - **Result**: Zero freezes. The user sees the environment "sharpen" or "blur" over a few frames.
 
 ### B. Adaptive Sample Counting
+
 Lower mip levels represent rougher surfaces where high-frequency details are already lost.
+
 - **Idea**: Use 1024 samples for Mip 0, but scale down to 512, 256, 128 for higher mips.
+
 - **Technique**: Pass `u_sample_count` as a uniform to the compute shader.
 
 ### C. Resolution Capping
+
 Directly processing a 4K texture for IBL is often overkill as reflexes are rarely pixel-perfect.
+
 - **Rule**: Cap the Prefiltered Specular Map resolution to **1024x512** regardless of the source HDR size.
+
 - **Benefit**: Quadrant reduction in complexity compared to 4K.
 
 ### D. Tiled Dispatching
+
 For very large mips, even a single `glDispatchCompute` can exceed a reasonable frame budget.
+
 - **Idea**: Split a single mipmap level into tiles (e.g., 4x4 grid).
+
 - **Mechanism**: Dispatch only a subset of tiles per frame until the level is complete.
 
 ### E. Instant Placeholder (The "Fast Path")
+
 Avoid waiting for any compute shader to show the new environment.
+
 - **Workflow**:
-    1. Load HDR to RAM.
-    2. Upload to VRAM.
-    3. `glCopyImageSubData` HDR to SpecMap Mip 0 (Instant).
-    4. Gradually replace mips as they are computed.
+  1. Load HDR to RAM.
+
+  2. Upload to VRAM.
+
+  3. `glCopyImageSubData` HDR to SpecMap Mip 0 (Instant).
+
+  4. Gradually replace mips as they are computed.
+
 - **Result**: Visual feedback is instantaneous.
 
 ## 3. Implementation Roadmap
+
 1. [ ] Implement **Resolution Capping** (Easiest, high ROI).
+
 2. [ ] Implement **Progressive Mip Generation** (Best user experience).
+
 3. [ ] Implement **Adaptive Samples** (Pure GPU optimization).

--- a/docs/ide_setup.md
+++ b/docs/ide_setup.md
@@ -5,15 +5,22 @@ This guide explains how to set up a robust development environment for **Suckles
 ## 1. Prerequisites
 
 ### Essential Tools
--   **CMake** (3.14+)
--   **Clang / GCC** (C11 support)
--   **Make** or **Ninja**
--   **clangd** (Language Server)
+
+- **CMake** (3.14+)
+
+- **Clang / GCC** (C11 support)
+
+- **Make** or **Ninja**
+
+- **clangd** (Language Server)
 
 ### Recommended Editor
+
 **VS Code** is highly recommended for its excellent `clangd` integration.
--   Install the **clangd** extension (`llvm-vs-code-extensions.vscode-clangd`).
--   *Optional*: **CodeLLDB** for debugging (`vadimcn.vscode-lldb`).
+
+- Install the **clangd** extension (`llvm-vs-code-extensions.vscode-clangd`).
+
+- _Optional_: **CodeLLDB** for debugging (`vadimcn.vscode-lldb`).
 
 ---
 
@@ -22,67 +29,94 @@ This guide explains how to set up a robust development environment for **Suckles
 This project uses a **hybrid build approach** to ensure headers are visible to both the build system (inside Distrobox/Docker) and your IDE (on the Host).
 
 ### Key Components
-1.  **CMake FetchContent**: We force `FetchContent` for third-party libraries (like GLFW) instead of using system packages (`pkg-config`).
-    -   *Why?* This downloads sources into `build/_deps/`, ensuring headers are physically present in the project folder.
-2.  **Compilation Database**: We generate `compile_commands.json` which tells `clangd` exactly where to look for headers.
+
+1. **CMake FetchContent**: We force `FetchContent` for third-party libraries (like GLFW) instead of using system packages (`pkg-config`).
+   - _Why?_ This downloads sources into `build/_deps/`, ensuring headers are physically present in the project folder.
+
+2. **Compilation Database**: We generate `compile_commands.json` which tells `clangd` exactly where to look for headers.
 
 ---
 
 ## 3. Configuration Steps
 
 ### Step 1: Generate Compilation Database
+
 Run this command once (or whenever you add new CMake targets). It works inside Distrobox or on a native Debian/Linux system.
 
 ```bash
+
 # Clean build (optional but recommended for fresh setup)
+
 rm -rf build/
 
 # Configure and generate compile_commands.json
+
 # Note: We configure in 'build/' but link the JSON to root for clangd
+
 cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 # Create symlink for clangd
+
 ln -sf build/compile_commands.json compile_commands.json
+
 ```
 
 **What this does:**
--   Downloads GLFW, cglm, stb, etc. into `build/_deps/`.
--   Generates `build/compile_commands.json` with absolute paths to those headers.
--   Links it to the root so your editor finds it.
+
+- Downloads GLFW, cglm, stb, etc. into `build/_deps/`.
+
+- Generates `build/compile_commands.json` with absolute paths to those headers.
+
+- Links it to the root so your editor finds it.
 
 ### Step 2: VS Code Configuration
+
 If you haven't already, accept the workspace recommendation to install `clangd`.
 
-1.  Open the project in VS Code.
-2.  If prompted, **Disable IntelliSense** for the Microsoft C/C++ extension (to allow `clangd` to take over).
-3.  Open `src/main.c`. You should be able to Ctrl+Click on functions like `glfwInit` or `app_run`.
+1. Open the project in VS Code.
+
+2. If prompted, **Disable IntelliSense** for the Microsoft C/C++ extension (to allow `clangd` to take over).
+
+3. Open `src/main.c`. You should be able to Ctrl+Click on functions like `glfwInit` or `app_run`.
 
 ---
 
 ## 4. Troubleshooting
 
 ### Headers not found (red squiggles)
+
 If `clangd` reports missing headers despite the build working:
 
-1.  **Check for `compile_commands.json`**: Ensure the symlink exists in the project root.
-2.  **Verify Include Paths**: Open `compile_commands.json` and search for `-I.../build/_deps/glfw-src/include`. If it's missing, re-run `cmake -B build`.
-3.  **Reload Window**: VS Code sometimes caches old paths. run `Ctrl+Shift+P` -> `Developer: Reload Window`.
-4.  **Rebuild**:
-    ```bash
+1. **Check for `compile_commands.json`**: Ensure the symlink exists in the project root.
+
+2. **Verify Include Paths**: Open `compile_commands.json` and search for `-I.../build/_deps/glfw-src/include`. If it's missing, re-run `cmake -B build`.
+
+3. **Reload Window**: VS Code sometimes caches old paths. run `Ctrl+Shift+P` -> `Developer: Reload Window`.
+
+4. **Rebuild**:
+
+```bash
     # Sometimes generating the headers (glad) requires a build
+
     make
-    ```
+```
 
 ### Distrobox vs Host Paths
+
 If you build inside a container but edit on the host:
--   **The Fix**: Our `CMakeLists.txt` forces local dependency builds (`FetchContent`). This avoids the issue where `pkg-config` points to `/usr/include` inside the container (which doesn't exist on the host).
--   **Validation**: Ensure you **DO NOT** use system-installed GLFW dev packages for the *build configuration* if you want IDE completions to work perfectly on the host.
+
+- **The Fix**: Our `CMakeLists.txt` forces local dependency builds (`FetchContent`). This avoids the issue where `pkg-config` points to `/usr/include` inside the container (which doesn't exist on the host).
+
+- **Validation**: Ensure you **DO NOT** use system-installed GLFW dev packages for the _build configuration_ if you want IDE completions to work perfectly on the host.
 
 ---
 
 ## 5. Debian / Native Linux Compatibility
+
 This setup is fully compatible with Debian 13 or any other distro without Distrobox.
--   **Requirement**: You need X11 development headers installed system-wide, as GLFW compiles from source.
-    ```bash
+
+- **Requirement**: You need X11 development headers installed system-wide, as GLFW compiles from source.
+
+```bash
     sudo apt install libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
-    ```
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,14 +17,23 @@
 ## 🚀 Features
 
 - **Minimalism**: Lightweight architecture focused on performance and readability.
+
 - **Modern Rendering**: Support for Skyboxes, IcoSpheres, textures, and Phong lighting.
+
 - **Dynamic Shaders**: Loading and compilation of GLSL files (vertex/fragment).
+
 - **Shader Optimization**: Static (Release) or dynamic (Debug) compilation to balance flexibility and performance. [See Documentation](shader_optimization.md).
+
 - **Stencil Buffer Masking**: Post-processing optimization to differentiate skybox from objects. [See Documentation](stencil_masking.md).
+
 - **Performance Mode**: Adaptive optimization (GameMode/Native) for maximum frame stability. [See Documentation](perf_and_notifications.md).
+
 - **Isolated Environment**: Native `distrobox` support to guarantee a reproducible build environment.
+
 - **Quality & Testing**: Unit testing suite, code coverage, static analysis, and [Standalone Mocking](standalone_testing_mocking.md).
+
 - **Interactive Keyboard Overlay**: Modern Cyberpunk UI with [Responsive Scaling](keyboard_system.md) and [Visual Parameter Reference](ui_visual_parameters.md).
+
 - **Post-Processing Pipeline**: Advanced stack including [Auto-Exposure](exposure_analysis.md), [Bloom](postprocess_optimizations_2026-02.md), [Bloom Debugging](bloom_debug.md), and [Debug Histograms](auto_exposure_debug_histogram.md).
 
 ## 🛠️ Compilation and Usage
@@ -37,14 +46,18 @@ For a modern alternative, seeing [Justfile Documentation](justfile.md).
 The build is configured with the following settings:
 
 - **Optimization**: `-Wall -Wextra -O2` for clean and performant code.
+
 - **POSIX Standard**: `-D_POSIX_C_SOURCE=199309L` for `clock_gettime` support.
+
 - **Static Analysis**: `clang-tidy` integration with strict header filters.
+
 - **Containerization**: Default use of `distrobox` with the `clang-dev` image to isolate dependencies.
 
 ### Main Commands
 
 | Command | Action |
-| :--- | :--- |
+| :------ | :----- |
+
 | `make all` | Compiles the project (generates GLAD and the `app` binary). |
 | `make debug` | Compiles in DEBUG mode (dynamic shaders, ideal for dev). |
 | `make release` | Compiles in RELEASE mode (statically optimized shaders). |
@@ -66,17 +79,24 @@ The pipeline is structured to optimize the build while guaranteeing maximum qual
 ### Quick Summary
 
 1. **Test & Coverage**: Instrumented compilation and test execution under **Xvfb**.
+
 2. **Lint & Format**: Enforces styling (`clang-format`) and static analysis (`clang-tidy`).
+
 3. **Automated Releases**:
    - **Nightly**: Built every night at 01:00 UTC and on every push to master.
+
    - **Stable**: Triggered by version tags (`v*`).
 
 ## 📁 Project Structure
 
 - `src/` & `include/`: Engine core (Log, App, Shader, Texture, Icosphere).
+
 - `shaders/`: GLSL sources (Phong, Background/Skybox).
+
 - `assets/`: HDR resources and textures.
+
 - `tests/`: Unit tests (Icosphere, Shader, Skybox, Texture, Log).
+
 - `docs/`: In-depth technical documentation.
 
 ## 📦 Docker / Podman
@@ -86,6 +106,7 @@ To test the application in a container with X11 forwarding:
 ```sh
 make docker-build
 make docker-run
+
 ```
 
 (Requires a local X server and configured xhost permissions).

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -9,14 +9,19 @@ To use `just`, you need to install it. Checks [Just Installation Guide](https://
 On most Linux distributions:
 
 ```bash
+
 # Ubuntu/Debian
+
 sudo apt install just
 
 # Fedora
+
 sudo dnf install just
 
 # Arch
+
 sudo pacman -S just
+
 ```
 
 ## Quick Start
@@ -25,8 +30,11 @@ To see all available commands, simply run:
 
 ```bash
 just
+
 # or
+
 just --list
+
 ```
 
 This will output a formatted list of all recipes with descriptions.
@@ -36,26 +44,46 @@ This will output a formatted list of all recipes with descriptions.
 Here is a mapping of common `make` commands to their `just` equivalents:
 
 | Task | Makefile | Justfile | Notes |
-| :--- | :--- | :--- | :--- |
+| :--- | :------- | :------- | :---- |
+
 | **Build** | `make` | `just build` | Builds debug version by default |
+
 | **Run** | `make run` | `just run` | Builds and runs the app |
+
 | **Clean** | `make clean` | `just clean` | CMake clean |
+
 | **Clean All** | `make clean-all` | `just clean-all` | Removes build directory completely |
+
 | **Test All** | `make test` | `just test` | Runs all tests |
+
 | **Test Specific** | `make test/<name>` | `just test <name>` | Runs matching tests |
+
 | **ApiTrace Unit** | `make test-apitrace` | `just test-apitrace` | Automated performance check |
+
 | **ApiTrace Integr** | `make test-integration-apitrace` | `just test-integration-apitrace` | Full app scenario check |
+
 | **Coverage** | `make coverage` | `just coverage` | Generates HTML report |
+
 | **Lint** | `make lint` | `just lint` | Runs clang-tidy and ruff |
+
 | **Format** | `make format` | `just format` | Runs clang-format and ruff |
+
 | **Docs** | `make docs` | `just docs` | Builds MkDocs + Doxygen |
+
 | **Docker Build** | `make docker-build` | `just docker-build` | Multi-stage production build |
+
 | **Docker Run** | `make docker-run` | `just docker-run` | Run with X11 forwarding |
+
 | **Docker Prune** | `make docker-clean-all` | `just docker-clean-all` | Clean all containers/images/cache |
+
 | **Windows Config** | `-` | `just configure-win` | Configure CMake for MinGW cross-compilation |
+
 | **Windows Build** | `-` | `just build-win` | Builds the application for Windows (.exe) |
+
 | **Windows Run** | `-` | `just run-win` | Runs the Windows application via Wine |
+
 | **Windows Test** | `-` | `just test-win` | Runs integration tests via Wine |
+
 | **Windows Unit Test** | `-` | `just test-win-unit` | Runs unit tests (CTest) via Wine |
 
 ## Advanced Usage
@@ -66,36 +94,49 @@ Run a specific test interactively with real-time logs:
 
 ```bash
 just test test_app
+
 ```
 
 Run a group of tests matching a pattern:
 
 ```bash
 just test shader
+
 ```
 
 This command automatically:
 
 1. Builds the test binary.
+
 2. If binary exists, runs it directly (via `xvfb` wrapper) for immediate output.
+
 3. If not found, falls back to `ctest` pattern matching.
 
 ### Build Variants
 
 - **Release**: `just release` / `just run-release`
+
 - **Small**: `just small` / `just run-small` (MinSizeRel)
+
 - **SSBO**: `just build-ssbo` / `just run-ssbo` (Shader Storage Buffer Objects)
+
 - **Sync Debug**: `just build-sync` / `just run-sync` (Check for GL errors synchronously)
+
 - **ASan**: `just asan` / `just memcheck-asan` (AddressSanitizer)
 
 ### Analysis & Tools
 
 - **Coverage**: `just coverage` - Builds with instrumentation and generates a report in `build-coverage/coverage_report/index.html`.
+
 - **Valgrind**: `just memcheck` - Runs the app under Valgrind.
+
 - **Perf**: `just perf` - Runs Linux `perf` profiler (requires privileges).
+
 - **ApiTrace Performance**:
   - `just test-apitrace`: Automated lightweight unit-test level check.
+
   - `just test-integration-apitrace`: Automated full application scenario check with user interaction.
+
   - `just trace-perf`: Legacy manual analysis of GPU trace.
 
 ### Dependency Management & Environment
@@ -103,12 +144,17 @@ This command automatically:
 The `Justfile` automatically detects your environment:
 
 - **Distrobox**: If you have `distrobox` and the `clang-dev` container, commands run inside it automatically.
+
 - **Python**: It detects `uv`, `.venv`, or system `python3` automatically (ISO Makefile logic).
+
 - **Deps**: `just deps-setup` downloads offline dependencies using the script.
 
 ## Why Just?
 
 - **Arguments**: Passing arguments is native (`just test pattern` vs `make test/pattern` or `make test-one TEST=pattern`).
+
 - **Variables**: Logic for variables like python runtime is cleaner.
+
 - **Shell**: Recipes are executed in `bash` by default, but can use others (e.g. `python`).
+
 - **Discovery**: `just --list` provides a self-documenting interface.

--- a/docs/keyboard_system.md
+++ b/docs/keyboard_system.md
@@ -7,6 +7,7 @@ This document describes the interactive keyboard help overlay and the underlying
 The help system provides a modern, interactive visualization of the application's key bindings. It consists of two main parts:
 
 1. **`AppBindingRegistry`**: A centralized data structure that stores all key metadata (key, modifiers, category, description).
+
 2. **Help Overlay UI**: A dynamic keyboard layout renderer that uses the registry to highlight active keys and show their functionality. It features a Cyberpunk aesthetic using pre-rendered PNGs and procedural SDF (Signed Distance Field) effects.
 
 ## Visual Design & Polish
@@ -14,10 +15,15 @@ The help system provides a modern, interactive visualization of the application'
 The help overlay utilizes an advanced hybrid rendering approach defined in `src/app_ui.c` and `shaders/ui.frag`:
 
 1. **Cyberpunk Textures**: The base panel UI frame and individual keys are rendered using high-quality PNG textures (`kbd_panel_frame.png` and `kbd_key_base.png`). Unbound keys sit quietly in the background, while bound keys are tinted via shader according to their binding type constraint (Toggle, Cycle, Combo).
+
 2. **Procedural Neon Bloom**: When a key is pressed, an intense, procedural SDF neon border glow is drawn directly by `ui.frag` (Mode `5.0`). The intensity of the glow follows a mathematically precise exponential decay for a crisp, luminous look.
+
 3. **Responsive UI Scaling**: The entire overlay scales dynamically based on the window height. A `ui_scale` factor is calculated relative to a reference resolution (1080p), ensuring the overlay remains perfectly proportioned and legible on any screen size (from 720p to 4K).
+
 4. **Scalable Text Rendering**: Uses `ui_draw_text_scaled()` to render Freetype glyphs with on-the-fly metric scaling (width, height, advance, and offsets). This allows text to scale perfectly with the UI shapes without requiring multiple font rasterization passes.
+
 5. **Spotlight Dimming & Hover Decay**: Activating or hovering over a key smoothly dims the rest of the keyboard. To prevent flickering when the mouse passes over gaps between keys, a **150ms Hover Decay** timer maintains the dimmed state for a smooth visual experience.
+
 6. **Smart Modifier Highlighting**: The overlay actively queries the binding registry to determine whether a combination of keys relies on a given modifier (e.g. `Shift`). Pressing physical modifier keys alone, or paired carelessly with non-modifier keys, won't artificially light up the Shift key unless the active function strictly demands it.
 
 ## Architecture
@@ -29,12 +35,17 @@ All bindings are defined in `src/app_binding.c`. The registry is owned by the ma
 ```c
 typedef struct {
     int key;                // GLFW_KEY_* constant
+
     int mods;               // GLFW_MOD_* bitmask
+
     const char* action;      // Short title (e.g., "Toggle Bloom")
+
     const char* desc;        // Detailed description
+
     BindingCategory category;// Movement, Visuals, PostFX, System
     BindingType type;        // Toggle, Cycle, Action
 } AppBinding;
+
 ```
 
 ### The "Dry-Run" Capture
@@ -42,7 +53,9 @@ typedef struct {
 When the help overlay is visible (`app->show_help == true`), the `key_callback` in `app_input.c` enters a **Dry-Run** mode:
 
 - It intercepts key presses.
+
 - It updates `app->help_pressed_key` and `app->help_pressed_mods`.
+
 - It **prevents** the actual command from executing, allowing the user to explore the keyboard safely.
 
 ## Maintaining Bindings
@@ -52,12 +65,15 @@ When the help overlay is visible (`app->show_help == true`), the `key_callback` 
 To add a new key binding to the help system:
 
 1. Open `src/app_binding.c`.
+
 2. Locate the `app_binding_registry_init` function.
+
 3. Use the `add_binding` helper macro:
 
 ```c
 add_binding(GLFW_KEY_X, 0, "My Action", "Extra detail about what X does.",
             BINDING_CAT_POSTFX, BINDING_TYPE_TOGGLE);
+
 ```
 
 ### Modifiers Support
@@ -67,6 +83,7 @@ The system supports key combinations (e.g., `Shift + Key`). To add one:
 ```c
 add_binding(GLFW_KEY_Y, GLFW_MOD_SHIFT, "Toggle Probes", "...",
             BINDING_CAT_VISUALS, BINDING_TYPE_TOGGLE);
+
 ```
 
 ### Categories & Colors
@@ -74,8 +91,11 @@ add_binding(GLFW_KEY_Y, GLFW_MOD_SHIFT, "Toggle Probes", "...",
 The UI automatically color-codes keys based on their `BindingType`:
 
 - **Cyan (`BINDING_TYPE_TOGGLE`)**: On/Off switches.
+
 - **Green (`BINDING_TYPE_CYCLE`)**: Actions that cycle through multiple states.
+
 - **Orange/Yellow (`GLFW_MOD_SHIFT`, `GLFW_MOD_ALT`)**: Combination keys.
+
 - **Blue (`BINDING_TYPE_ACTION`)**: One-shot actions (Reset, Screenshot, Exit).
 
 ### Status Bar Integration
@@ -89,7 +109,11 @@ The keyboard layout is defined in `include/app_ui.h` and is centered automatical
 The key positions and labels are stored in the `KEY_LAYOUT_QWERTY` array within `include/app_ui.h`. Each entry defines:
 
 - The `key` handled.
+
 - The `row` index.
+
 - The `xPos` relative to the row start.
+
 - The `width` of the key (unit: square key width).
+
 - The `label` displayed on the key cap.

--- a/docs/linting_strategy.md
+++ b/docs/linting_strategy.md
@@ -7,8 +7,11 @@ This document outlines the static analysis strategy for the `suckless-ogl` proje
 We use `clang-tidy` for static analysis. The configuration is defined in `.clang-tidy`, focusing on:
 
 - **Security**: Avoiding insecure buffer handling and deprecated APIs.
+
 - **Reliability**: Detecting narrowing conversions and uninitialized variables.
+
 - **Readability**: Enforcing consistent coding styles and removing "magic numbers".
+
 - **Portability**: Ensuring compliance with C standards (CERT, HICPP).
 
 ### Style Preferences
@@ -16,7 +19,9 @@ We use `clang-tidy` for static analysis. The configuration is defined in `.clang
 We prioritize "Suckless" philosophy:
 
 - Minimize external dependencies.
+
 - Avoid `NOLINT` comments unless absolutely necessary (e.g., global variables for test context).
+
 - Use `static const` or `enum` instead of magic numbers.
 
 ## Incremental Caching (Sentinel Files)
@@ -28,19 +33,28 @@ Originally, we explored `cltcache`. However, due to its overhead and specific re
 Instead of linting every file on every run, we use "Sentinel files" (`.linted`) to track the status of each source file.
 
 1. **Dependency Tracking**: Each `.linted` file in `.lint_cache/` depends on:
-    - The corresponding `.c` source file.
-    - The project's `.clang-tidy` configuration.
-    - The `compile_commands.json` database.
+   - The corresponding `.c` source file.
+
+   - The project's `.clang-tidy` configuration.
+
+   - The `compile_commands.json` database.
+
 2. **Date Comparison**: `make` natively compares the timestamp of the source vs. the sentinel. If the source is older than the sentinel, the file is skipped.
+
 3. **Updating**: If a file needs linting, `clang-tidy` is executed. On success, the sentinel file is updated using `touch`.
+
 4. **Dependencies**: Before linting, the system ensures that generated headers (like `glad/glad.h`) are ready by building the necessary targets.
+
 5. **Parallelization**: The process is parallelized using `make -j$(NPROCS)`, allowing simultaneous analysis of multiple files.
 
 ### Why this approach?
 
 - **Speed**: Subsequent runs are near-instantaneous (O(1) file stat check).
+
 - **Robustness**: If an analysis is interrupted, the sentinel isn't updated, ensuring it runs again on the next try.
+
 - **Simplicity**: No external Python dependencies or complex cache databases; it leverages the operating system's file system and standard build tools.
+
 - **Visibility**: The `Makefile` output clearly shows which file is being processed, providing immediate feedback.
 
 ## Maintenance
@@ -50,6 +64,7 @@ To clear the cache and force a full re-lint:
 ```bash
 make lint-clean
 make lint
+
 ```
 
 Training a new rule in `.clang-tidy` will also automatically invalidate the entire cache, ensuring project-wide compliance.

--- a/docs/memory_management_audit.md
+++ b/docs/memory_management_audit.md
@@ -15,6 +15,7 @@ Une copie superficielle de `GPUStage` entraînait le partage de la propriété d
 Le correctif introduit `gpu_stage_move`, qui :
 
 1. Copie les champs scalaires un par un.
+
 2. **Échange** (`swap`) les pointeurs des buffers des samplers au lieu de les copier.
 
 Cette approche garantit l'unicité du propriétaire pour chaque buffer alloué tout en réutilisant les emplacements mémoire existants dans le tableau `stages`.
@@ -23,9 +24,10 @@ Cette approche garantit l'unicité du propriétaire pour chaque buffer alloué t
 
 L'audit a porté sur les structures suivantes identifiées comme gérant de la mémoire dynamique :
 
-| Structure | Ressource Critique | État de Risque | Conclusion |
-|-----------|-------------------|----------------|------------|
-| `GPUStage` | `AdaptiveSampler.samples` | **Corrigé** | Risque maîtrisé par `gpu_stage_move`. |
+| Structure  | Ressource Critique        | État de Risque | Conclusion                            |
+| ---------- | ------------------------- | -------------- | ------------------------------------- |
+| `GPUStage` | `AdaptiveSampler.samples` | **Corrigé**    | Risque maîtrisé par `gpu_stage_move`. |
+
 | `AdaptiveSampler` | `samples` (buffer de données) | Bas | Initialisé par `init`, libéré par `cleanup`. Pas de copie détectée. |
 | `AsyncRequest` | `float_data`, `half_data` | Bas | Utilise un pattern de "transfert de propriété destructif" sécurisé dans `async_loader_poll`. |
 | `PBRMaterial` | `name` (tableau fixe) | Nul | Structure POD (Plain Old Data). Copie sûre. |
@@ -34,14 +36,18 @@ L'audit a porté sur les structures suivantes identifiées comme gérant de la m
 
 ### Points Particulièrement Examinés
 
-* **`sphere_sorting.c`** : Effectue des copies de `SphereInstance` lors du tri. C'est parfaitement sûr car `SphereInstance` ne contient que des types par valeur (mathématiques cglm).
-* **`async_loader.c`** : Le passage de `AsyncRequest` du thread worker au thread principal est sécurisé. Le loader met explicitement à `NULL` ses pointeurs internes après la copie vers le demandeur, évitant ainsi tout conflit de propriété.
+- **`sphere_sorting.c`** : Effectue des copies de `SphereInstance` lors du tri. C'est parfaitement sûr car `SphereInstance` ne contient que des types par valeur (mathématiques cglm).
+
+- **`async_loader.c`** : Le passage de `AsyncRequest` du thread worker au thread principal est sécurisé. Le loader met explicitement à `NULL` ses pointeurs internes après la copie vers le demandeur, évitant ainsi tout conflit de propriété.
 
 ## 4. Recommandations et Bonnes Pratiques
 
 1. **Privilégier les Tableaux Fixes pour les Strings** : Comme vu avec `PBRMaterial` et `GPUStage`, l'utilisation de `char name[N]` au lieu de `char* name` élimine les risques liés à la copie de structures.
+
 2. **Move Semantics en C** : Pour les structures complexes (comme `GPUStage`), implémenter systématiquement une fonction de "move" ou de "swap" au lieu d'utiliser l'opérateur `=`.
+
 3. **Documentation de l'Appartenance (`Ownership`)** : Documenter explicitement si une structure "possède" ses pointeurs ou si elle ne fait que les référencer.
+
 4. **Utilisation de l'Analyse Statique** : Continuer à utiliser `just lint-full` (clang-tidy) qui aide à détecter les utilisations après libération (`use-after-free`).
 
 ## 5. Conclusion de l'Évaluation

--- a/docs/mesa_f32_to_f16_analysis.md
+++ b/docs/mesa_f32_to_f16_analysis.md
@@ -5,24 +5,28 @@
 Profiling via [Tracy](profiling_tracy.md) revealed that `glTexSubImage2D` was a significant bottleneck during the resource loading phase, particularly for large HDR environment maps (4K resolution).
 
 - **Problem**: The OpenGL driver (Mesa) performs the `Float32 → Float16` conversion on the CPU using a **scalar** (single-value) path, leading to high CPU usage and stalling the main thread.
+
 - **Goal**: Understand why Mesa does not implement vectorized conversion (AVX2/F16C) for this path, and evaluate alternatives.
 
 ---
 
 ## Full Call Chain
 
-```
+```text
 glTexSubImage2D()                                    [src/mesa/main/teximage.c:4096]
   └─► st_TexSubImage()                               [src/mesa/state_tracker/st_cb_texture.c:2117]
         │
         ├─ 1. Fast path: texture_subdata (memcpy)     [line ~2162]
+
         │      → SKIPPED if source format ≠ dest format (GL_FLOAT ≠ GL_HALF_FLOAT)
         │      → Condition: _mesa_texstore_can_use_memcpy() must return true
         │
         ├─ 2. Blit-based path (GPU blit)              [line ~2198]
+
         │      → SKIPPED if _mesa_format_matches_format_and_type() fails
         │
         └─ 3. CPU FALLBACK: _mesa_store_texsubimage() [line ~2398]
+
               └─► store_texsubimage()                  [src/mesa/main/texstore.c:978]
                     └─► _mesa_texstore()               [src/mesa/main/texstore.c:1091]
                           └─► texstore_rgba()          [src/mesa/main/texstore.c:680]
@@ -37,6 +41,7 @@ glTexSubImage2D()                                    [src/mesa/main/teximage.c:4
                                       │
                                       └─ Otherwise (via float intermediate):
                                            └─► _mesa_pack_float_rgba_row() [format_pack.h:38]
+
 ```
 
 ---
@@ -52,6 +57,7 @@ _mesa_TexSubImage2D(GLenum target, GLint level,
                     GLint xoffset, GLint yoffset,
                     GLsizei width, GLsizei height,
                     GLenum format, GLenum type, const GLvoid *pixels)
+
 ```
 
 Dispatches to `ctx->Driver.TexSubImage` which points to `st_TexSubImage`.
@@ -74,6 +80,7 @@ if (pixels &&
     // ... direct memcpy via pipe->texture_subdata()
     return;
 }
+
 ```
 
 **Failure condition**: `_mesa_texstore_can_use_memcpy()` checks that the source format (GL_FLOAT) matches the texture format (HALF_FLOAT) **exactly**. It does not → **skipped**.
@@ -88,11 +95,13 @@ Creates an intermediate GPU texture, copies data via memcpy, then blits. But if 
 fallback:
    _mesa_store_texsubimage(ctx, dims, texImage, xoffset, yoffset, zoffset,
                            width, height, depth, format, type, pixels, unpack);
+
 ```
 
 ### 3. Fallback Texture Store — `src/mesa/main/texstore.c`
 
 **Line 978** — `store_texsubimage()`:
+
 Maps the texture into CPU memory, then calls `_mesa_texstore()` → `texstore_rgba()`.
 
 **Line 818** — `texstore_rgba()` calls `_mesa_format_convert()`:
@@ -102,20 +111,24 @@ _mesa_format_convert(dstSlices[img], dstFormat, dstRowStride,
                      src, srcMesaFormat, srcRowStride,
                      srcWidth, srcHeight,
                      needRebase ? rebaseSwizzle : NULL);
+
 ```
 
 ### 4. Format Conversion — `src/mesa/main/format_utils.c`
 
 **Line 278** — `_mesa_format_convert()`:
+
 When src and dst are both array formats (FLOAT RGBA and HALF RGBA), the code goes directly through:
 
 ```c
 _mesa_swizzle_and_convert(dst, dst_type, dst_num_channels,
                           src, src_type, src_num_channels,
                           src2dst, normalized, width);
+
 ```
 
 **Line 1417** — `_mesa_swizzle_and_convert()`:
+
 The switch on `dst_type` dispatches to `convert_half_float()`:
 
 ```c
@@ -123,6 +136,7 @@ case MESA_ARRAY_FORMAT_TYPE_HALF:
     convert_half_float(void_dst, num_dst_channels, void_src, src_type,
                        num_src_channels, swizzle, normalized, count);
     break;
+
 ```
 
 **Line 913** — `convert_half_float()`:
@@ -131,6 +145,7 @@ case MESA_ARRAY_FORMAT_TYPE_HALF:
 case MESA_ARRAY_FORMAT_TYPE_FLOAT:
     SWIZZLE_CONVERT(uint16_t, float, _mesa_float_to_half(src));
     break;
+
 ```
 
 ### 5. The Scalar Loop — `SWIZZLE_CONVERT_LOOP` Macro
@@ -150,6 +165,7 @@ for (s = 0; s < count; ++s) {           // for each pixel
     typed_src += SRC_CHANS;
     typed_dst += DST_CHANS;
 }
+
 ```
 
 For an RGBA 4K texture (4096×2048), this results in **4096 × 2048 × 4 = ~33 million** calls to `_mesa_float_to_half()`.
@@ -172,6 +188,7 @@ _mesa_float_to_half(float val)
 #endif
    return _mesa_float_to_half_slow(val);  // pure software fallback
 }
+
 ```
 
 **Even with F16C available**, the conversion is **scalar**: `vcvtps2ph` can convert 4 floats (XMM) or 8 floats (YMM/AVX2) in a single instruction, but here it converts only **one value** per call.
@@ -179,6 +196,7 @@ _mesa_float_to_half(float val)
 ### 7. Software Fallback — `src/util/half_float.c`
 
 **Line 57** — `_mesa_float_to_half_slow()`:
+
 Pure software conversion via bit manipulation (mantissa/exponent extraction, denorm/NaN/Inf handling, rounding). Even slower than the scalar F16C path.
 
 ---
@@ -187,13 +205,18 @@ Pure software conversion via bit manipulation (mantissa/exponent extraction, den
 
 ### Key Commits in Chronological Order
 
-| Date | Commit | Author | Description | MR |
-|------|--------|--------|-------------|-----|
+| Date       | Commit         | Author                     | Description                             | MR           |
+| ---------- | -------------- | -------------------------- | --------------------------------------- | ------------ |
 | 2014-07-11 | `d55f77b503ab` | **Jason Ekstrand** (Intel) | Created the `SWIZZLE_CONVERT` framework | _pre-GitLab_ |
+
 | 2014-09-12 | `418da979053d` | **Brian Paul** (VMware) | Refactored `SWIZZLE_CONVERT_LOOP` macro | _pre-GitLab_ |
+
 | 2014-09-12 | `cfeb394224f2` | **Brian Paul** (VMware) | Extracted `convert_half_float()` (compile time ÷4) | _pre-GitLab_ |
+
 | 2014-11-27 | `ea79ab3e8c37` | **Iago Toral Quiroga** (Igalia) | Replaced GL types → `MESA_ARRAY_FORMAT_TYPE_*` | _pre-GitLab_ |
+
 | **2020-09-18** | **`ffcdf76799b0`** | **Marek Olšák** (AMD) | **Added F16C inline asm (scalar)** | [**!6987**](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/6987) |
+
 | 2021-02-25 | `a9618e7c4214` | Rob Clark | `util_get_cpu_caps()` accessor | [!9266](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/9266) |
 | 2023-06-27 | `c9a5cac4ffa4` | Konstantin Seurer | `immintrin.h` → `xmmintrin.h` (compile time -22%) | [!23871](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/23871) |
 | 2024-10-03 | `3c0bf4238188` | David Heidelberg | aarch64 `fcvt` half→float (not float→half!) | [!31564](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31564) |
@@ -201,11 +224,17 @@ Pure software conversion via bit manipulation (mantissa/exponent extraction, den
 ### MR !6987 — The F16C Commit (Details)
 
 - **Title**: _"Implement F16C using inline assembly on x86_64"_
+
 - **Author**: Marek Olšák (`@mareko`, AMD)
+
 - **Branch**: `f16c-v2`
+
 - **Reviewer**: Matt Turner (Intel)
+
 - **Merged**: October 7, 2020
+
 - **Primary motivation**: Fix `bptc-float-modes` test on llvmpipe
+
 - **Approach**: Optimize the existing scalar `_mesa_float_to_half()` function, not create a batch variant
 
 ---
@@ -217,8 +246,11 @@ Pure software conversion via bit manipulation (mantissa/exponent extraction, den
 The `SWIZZLE_CONVERT_LOOP` framework (Jason Ekstrand, 2014) was designed as a **generic** format converter:
 
 - Iterates **pixel by pixel**, **channel by channel**
+
 - The conversion is passed as a macro parameter (`CONV = _mesa_float_to_half(src)`)
+
 - Swizzling (RGBA→BGRA reordering, etc.) is **interleaved** with conversion
+
 - The code relies on compiler loop unrolling (`nested switch` on `DST_CHANS` × `SRC_CHANS`) rather than explicit vectorization
 
 Vectorizing this code would require **significant refactoring**: separating conversion from swizzle, or creating a specialized `float[4] → half[4]` path with SIMD intrinsics.
@@ -230,6 +262,7 @@ When Marek Olšák added F16C support (MR !6987, 2020), he optimized the **exist
 ```c
 // Takes ONE float, returns ONE uint16_t
 static inline uint16_t _mesa_float_to_half(float val);
+
 ```
 
 His motivation was to **fix a bug** (`bptc-float-modes` on llvmpipe), not to optimize texture upload throughput. He never added a batch variant such as:
@@ -237,6 +270,7 @@ His motivation was to **fix a bug** (`bptc-float-modes` on llvmpipe), not to opt
 ```c
 // Hypothetical — does NOT exist in Mesa
 void _mesa_floats_to_halfs(uint16_t *dst, const float *src, size_t count);
+
 ```
 
 ### 3. llvmpipe Already Does Vectorized Conversion... via JIT
@@ -249,6 +283,7 @@ if (util_get_cpu_caps()->has_f16c &&
     intrinsic = "llvm.x86.vcvtps2ph.128";  // 4 floats at once
     // or "llvm.x86.vcvtps2ph.256"          // 8 floats at once (AVX)
 }
+
 ```
 
 This code is reserved for the **JIT rendering pipeline** (shaders compiled on-the-fly) and is **never used** for CPU-side texture uploads via `glTexSubImage2D`.
@@ -256,6 +291,7 @@ This code is reserved for the **JIT rendering pipeline** (shaders compiled on-th
 ### 4. Historical Issues with AVX Intrinsics
 
 Mesa release notes for **18.3.3**, **19.0.0**, and **19.3.0** document recurring build issues with `_mm256_cvtps_ph`:
+
 > _"format_types.h:1220: undefined reference to `_mm256_cvtps_ph`"_
 
 The SWR driver (Intel Software Rasterizer, now deprecated) emitted AVX/F16C intrinsics without verifying compiler and target support. These bugs made Mesa developers **cautious** about using SIMD intrinsics in C "hot path" code.
@@ -265,7 +301,9 @@ The SWR driver (Intel Software Rasterizer, now deprecated) emitted AVX/F16C intr
 For hardware drivers (radeonsi, iris, nouveau...):
 
 - `st_TexSubImage` first tries `texture_subdata` (direct memcpy if formats match)
+
 - Then GPU blit (conversion done by the GPU)
+
 - The CPU fallback is only reached when **source format ≠ destination format**
 
 Mesa developers assume that applications **should provide data in the texture's native format** (i.e., pass `GL_HALF_FLOAT` if the internal texture format is `GL_RGBA16F`).
@@ -274,23 +312,24 @@ Mesa developers assume that applications **should provide data in the texture's 
 
 ## Concrete Impact for a 4K RGBA HDR Texture
 
-| Parameter | Value |
-|---|---|
-| Resolution | 4096 × 2048 |
-| Channels | 4 (RGBA) |
-| Total pixels | 8,388,608 |
+| Parameter                        | Value          |
+| -------------------------------- | -------------- |
+| Resolution                       | 4096 × 2048    |
+| Channels                         | 4 (RGBA)       |
+| Total pixels                     | 8,388,608      |
 | Calls to `_mesa_float_to_half()` | **33,554,432** |
+
 | Instruction per call | `vcvtps2ph` (if F16C) or software fallback |
 | XMM register utilization | 1/4 (4 slots available, 1 used) |
 | YMM register utilization | 1/8 (8 slots available, not used) |
 
 ### Theoretical Gain from Vectorization
 
-| Method | Conversions/instruction | Theoretical speedup |
-|---|---|---|
-| Current scalar (XMM, 1 float) | 1 | 1× |
-| SSE/XMM vectorized (4 floats) | 4 | ~4× |
-| AVX/YMM vectorized (8 floats) | 8 | ~8× |
+| Method                        | Conversions/instruction | Theoretical speedup |
+| ----------------------------- | ----------------------- | ------------------- |
+| Current scalar (XMM, 1 float) | 1                       | 1×                  |
+| SSE/XMM vectorized (4 floats) | 4                       | ~4×                 |
+| AVX/YMM vectorized (8 floats) | 8                       | ~8×                 |
 
 ---
 
@@ -299,13 +338,17 @@ Mesa developers assume that applications **should provide data in the texture's 
 ### Application-side (recommended by Mesa)
 
 1. **Supply data as Float16** directly to `glTexSubImage2D` (`type = GL_HALF_FLOAT`), which activates the fast memcpy path
+
 2. **Perform the F32→F16 conversion application-side** using AVX2/F16C intrinsics before the upload, freeing the driver from an expensive conversion
+
 3. **Use PBOs (Pixel Buffer Objects)** to make the upload asynchronous
 
 ### Driver-side Mesa (potential improvements)
 
 1. Add a batch variant `_mesa_floats_to_halfs_avx2()` using `vcvtps2ph` on YMM registers
+
 2. Create a specialized path in `convert_half_float()` when the swizzle is identity (RGBA→RGBA)
+
 3. Integrate vectorized conversion directly into `_mesa_format_convert()` for the `FLOAT→HALF` case without swizzle
 
 ---
@@ -315,8 +358,11 @@ Mesa developers assume that applications **should provide data in the texture's 
 The observed bottleneck is **real and confirmed by the source code**: the Float32→Float16 conversion in Mesa is scalar even on CPUs with F16C support. This is the result of accumulated design decisions:
 
 1. A **generic** conversion framework designed in 2014 for flexibility, not performance
+
 2. A 2020 F16C optimization targeting **bug fixing**, not throughput
+
 3. An assumption that applications provide data in the **correct format**
+
 4. The fact that llvmpipe's JIT code **already vectorizes** this path, but only for shaders
 
 For the specific use case (asynchronous HDR resource loading on CPU threads while the GPU renders), the optimal solution is to perform the conversion **application-side** with SIMD instructions before calling `glTexSubImage2D`, allowing the driver to perform a simple `memcpy`.

--- a/docs/motion_blur_analysis.md
+++ b/docs/motion_blur_analysis.md
@@ -1,6 +1,6 @@
 # Analyse de l'implémentation du Motion Blur
 
-Cette documentation détaille l'état actuel de l'implémentation du Motion Blur dans **Suckless OGL**, ses performances, sa qualité, et les compare avec les approches des moteurs AAA, en s'appuyant particulièrement sur le cas du *RE Engine* (utilisé pour *Street Fighter 6*). Elle offre également des pistes d'amélioration concrètes.
+Cette documentation détaille l'état actuel de l'implémentation du Motion Blur dans **Suckless OGL**, ses performances, sa qualité, et les compare avec les approches des moteurs AAA, en s'appuyant particulièrement sur le cas du _RE Engine_ (utilisé pour _Street Fighter 6_). Elle offre également des pistes d'amélioration concrètes.
 
 ---
 
@@ -14,35 +14,44 @@ L'architecture actuelle repose sur des principes modernes de rendu basés sur l'
 graph TD
     V[Velocity Buffer] --> T[Tile Max Velocity Compute]
     T -->|Réduction à 16x16 via Shared Memory| TTex(Texture RG16F - Tile Max)
+
     TTex --> N[Neighbor Max Velocity Compute]
     N -->|textureGather sur un Voisinage 3x3| NTex(Texture RG16F - Neighbor Max)
+
     C[Color Buffer Raw] --> M(Passe Motion Blur Finale)
     D[Depth Buffer] --> M
     V --> M
     NTex --> M
     M -->|Échantillonnage de 8 frames \n+ Interleaved Gradient Noise \n+ Depth Weighting| O[Color Buffer Flouté]
+
 ```
 
 ### 💡 Points forts de la solution
 
 1. **Utilisation intensive des Compute Shaders :** L'approche en deux passes (`tile_max` et `neighbor_max`) est performante. La réduction dans la mémoire partagée (Shared Memory) pour l'étape Tile Max minimise considérablement la bande passante. L'utilisation intelligente du `textureGather` permet une lecture optimale en quads.
+
 2. **Neighbor Max Velocity :** Empêche efficacement le flou de se propager de manière incohérente sur les objets et supprime les halos disgracieux.
+
 3. **Pondération avec la Profondeur (Depth Weighting) :** Protège le premier plan en désactivant le mélange de couleurs lorsque l'échantillon prélevé est trop éloigné derrière le pixel central (`depthDiff > 1.0`).
-4. **Bruit de Gradient (Interleaved Gradient Noise) :** Empêche le phénomène de *banding* visuel en transformant les stries liées à un faible nombre d'échantillons en bruit esthétique de style pellicule.
+
+4. **Bruit de Gradient (Interleaved Gradient Noise) :** Empêche le phénomène de _banding_ visuel en transformant les stries liées à un faible nombre d'échantillons en bruit esthétique de style pellicule.
 
 ### 📉 Limite de l'implémentation actuelle : Camera-Only
 
-Dans le fichier `pbr_ibl_instanced.vert`, on observe que la configuration actuelle ne calcule le déplacement (Velocity) que par le biais de l'ancienne position de la caméra (`previousViewProj` * la position de la géométrie locale actuelle) :
+Dans le fichier `pbr_ibl_instanced.vert`, on observe que la configuration actuelle ne calcule le déplacement (Velocity) que par le biais de l'ancienne position de la caméra (`previousViewProj` \* la position de la géométrie locale actuelle) :
 
 ```glsl
+
 CurrentClipPos = projection * view * vec4(WorldPos, 1.0);
+
 PreviousClipPos = previousViewProj * vec4(WorldPos, 1.0);
+
 ```
 
 **Pourquoi c'est tout à fait justifié (pour le moment) :**
 Dans **Suckless OGL**, tous les objets 3D (comme la grille de sphères PBR) sont statiques dans l'espace "World". Seule la caméra se déplace ou effectue des rotations. Par conséquent, il n'y a pas (encore) de concept de vélocité "Objet" (Object Velocity). Le **Camera Motion Blur** est donc 100% suffisant à ce stade du développement.
 
-**Toutefois**, dès lors que le moteur implémentera des entités dynamiques (ex: des ennemis ou des objets physiques qui tombent), la vélocité propre de l'objet (sa *Previous World Position*) ainsi calculée sera `0` ou du moins faussée devant ne refléter que de la vélocité caméra. Un objet traversant rapidement l'écran devant une caméra fixe ne s'imprimera pas dans le *Velocity Buffer* en l'état actuel et ressortira hyper net par dessus le reste de l'image.
+**Toutefois**, dès lors que le moteur implémentera des entités dynamiques (ex: des ennemis ou des objets physiques qui tombent), la vélocité propre de l'objet (sa _Previous World Position_) ainsi calculée sera `0` ou du moins faussée devant ne refléter que de la vélocité caméra. Un objet traversant rapidement l'écran devant une caméra fixe ne s'imprimera pas dans le _Velocity Buffer_ en l'état actuel et ressortira hyper net par dessus le reste de l'image.
 
 ---
 
@@ -52,45 +61,62 @@ Afin d'atteindre l'état de l'art, voici les optimisations et changements possib
 
 ### A. Vitesse et Optimisation
 
-* **Échantillonnage Adaptatif (Dynamic Sample Count) :**
+- **Échantillonnage Adaptatif (Dynamic Sample Count) :**
+
   Actuellement, le shader effectue **toujours** `mb_samples` itérations (8 par défaut), même si la vitesse du pixel est proche de zéro (`speed < 0.0001` est ignoré, mais les faibles valeurs passent). Un nombre dynamique d'itérations basé sur la vitesse proportionnelle permettrait d'économiser un nombre monumental de cycles GPU.
-  ```glsl
-  int actual_samples = max(2, int(speed * TARGET_SAMPLES_PER_UNIT));
-  ```
-* **Half-Resolution Reconstruction (TODO) :**
-  Exécuter 8+ lectures aléatoires non-cohérentes avec le cache sur un buffer 4K ou 1440p est extrêmement gourmand. L'accumulation du Motion Blur dans une **toute petite texture** (à moitié de la résolution native) suivie d'un *upsample* bilatéral guidé par la profondeur est à implémenter pour les performances futures.
 
-    !!! warning "Plan d'implémentation (Refactoring de `postprocess.c`)"
-        L'implémentation du Motion Blur est actuellement incluse dans le composite unifié de la passe finale (`postprocess.frag`). Pour appliquer ce *Half-Res*, il faudra :
+```glsl
+int actual_samples = max(2, int(speed * TARGET_SAMPLES_PER_UNIT));
+```
 
-        1. Restructurer le rendu et casser le flux actuel en désolidarisant le Motion Blur de cette maxi-passe.
-        2. Créer un nouveau `Framebuffer` dédié au sous-échantillonnage de dimensions `width/2 x height/2`.
-        3. Créer une passe spécifique (via compute ou quad écran) ne calculant *uniquement* que l'effet de flou dans cette texture allégée en couleurs et vélocités.
-        4. Écrire et exécuter l'étape d'*upsample* bilatéral durant la passe `postprocess.frag` ou dans une passe dédiée, afin de recomposer judicieusement l'image finale sur les bords des objets définis par le `depth buffer`.
+- **Half-Resolution Reconstruction (TODO) :**
 
-* **Per-Object et Skinned Velocity (Critique) :**
-  Pour que le motion blur s'applique aux objets en mouvement ou aux personnages, il faut stocker et transmettre la matrice Modèle de la frame précédente pour *chaque* objet.
-  ```glsl
+  Exécuter 8+ lectures aléatoires non-cohérentes avec le cache sur un buffer 4K ou 1440p est extrêmement gourmand. L'accumulation du Motion Blur dans une **toute petite texture** (à moitié de la résolution native) suivie d'un _upsample_ bilatéral guidé par la profondeur est à implémenter pour les performances futures.
+
+  !!! warning "Plan d'implémentation (Refactoring de `postprocess.c`)"
+    L'implémentation du Motion Blur est actuellement incluse dans le composite unifié de la passe finale (`postprocess.frag`). Pour appliquer ce _Half-Res_, il faudra :
+
+    1. Restructurer le rendu et casser le flux actuel en désolidarisant le Motion Blur de cette maxi-passe.
+
+    2. Créer un nouveau `Framebuffer` dédié au sous-échantillonnage de dimensions `width/2 x height/2`.
+
+    3. Créer une passe spécifique (via compute ou quad écran) ne calculant _uniquement_ que l'effet de flou dans cette texture allégée en couleurs et vélocités.
+
+    4. Écrire et exécuter l'étape d'_upsample_ bilatéral durant la passe `postprocess.frag` ou dans une passe dédiée, afin de recomposer judicieusement l'image finale sur les bords des objets définis par le _depth buffer_.
+
+- **Per-Object et Skinned Velocity (Critique) :**
+
+  Pour que le motion blur s'applique aux objets en mouvement ou aux personnages, il faut stocker et transmettre la matrice Modèle de la frame précédente pour _chaque_ objet.
+
+```glsl
+
   vec4 PrevWorldPos = vec3(i_previous_model * vec4(in_position, 1.0));
+
   PreviousClipPos = previousViewProj * PrevWorldPos;
-  ```
-* **Soft Depth-Testing :**
+
+```
+
+- **Soft Depth-Testing :**
+
   Remplacer le test booléen et brutal de profondeur par une pondération lissée à l'aide d'un `smoothstep()`. Des limites dures créent un bruit granuleux ou des tremblements de pixels (flickering) sur les arêtes en mouvement.
 
 ### C. Le Cas Exceptionnel : Flou Analytique Procédural
 
-Puisque **Suckless OGL** rend nativement des objets purs via **Raytracing analytique** dans le Fragment Shader (par le biais des billboards et *impostors* de sphères dans `pbr_ibl_billboard.frag`), une solution mathématiquement parfaite et sans post-process (2D) est techniquement possible.
+Puisque **Suckless OGL** rend nativement des objets purs via **Raytracing analytique** dans le Fragment Shader (par le biais des billboards et _impostors_ de sphères dans `pbr_ibl_billboard.frag`), une solution mathématiquement parfaite et sans post-process (2D) est techniquement possible.
 
-Lorsqu'une sphère de centre $C$ se déplace d'une position $C_0$ vers $C_1$ (via un vecteur vitesse $\vec{V}$) au cours d'une frame, le volume balayé par cette sphère (*Swept Volume*) forme géométriquement une **Capsule** (un cylindre terminé par deux hémisphères).
+Lorsqu'une sphère de centre $C$ se déplace d'une position $C_0$ vers $C_1$ (via un vecteur vitesse $\vec{V}$) au cours d'une frame, le volume balayé par cette sphère (_Swept Volume_) forme géométriquement une **Capsule** (un cylindre terminé par deux hémisphères).
 
 **Comment l'implémenter mathématiquement au lieu du Post-Process ?**
 
-1. **Intersection Rayon-Capsule :** Au lieu de croiser un rayon avec une sphère, le shader des *impostors* calcule l'intersection analytique d'un rayon avec une capsule s'étendant du centre à $t=0$ au centre à $t=1$.
+1. **Intersection Rayon-Capsule :** Au lieu de croiser un rayon avec une sphère, le shader des _impostors_ calcule l'intersection analytique d'un rayon avec une capsule s'étendant du centre à $t=0$ au centre à $t=1$.
+
 2. **Intégration Temporelle :** Une fois l'intersection résolue sur la droite de mouvement de la capsule, l'opacité (Alpha) et la normale de surface en ce point peuvent être calculées en fonction du temps couvert par le croisement.
+
 3. **Mouvement de la Caméra + Mouvement de l'Objet :** La matrice de transformation de la vue au cours du temps peut simplement modifier l'origine du rayon $O(t) = O_0 + V_{cam} \cdot t$ pour simuler le flou de caméra.
+
 4. **Jittering Temporel / Stochasticité :** Au lieu d'accumuler dans un multi-buffer, le rayon généré depuis le point central de l'écran peut se voir attribuer une variable temps $t$ aléatoire par frame (via du Bruit Bleu par exemple). Couplé à un TAA (Temporal Anti-Aliasing), le flou de mouvement devient instantanément "gratuit" et mathématiquement parfait (vrai flou 3D) sans les erreurs d'occlusion du post-processing 2D.
 
-C'est une optimisation très avancée mais extrêmement élégante, souvent réservée aux moteurs de rendu hors-ligne (Pixar/RenderMan) ou aux *demoscenes* purement procédurales.
+C'est une optimisation très avancée mais extrêmement élégante, souvent réservée aux moteurs de rendu hors-ligne (Pixar/RenderMan) ou aux _demoscenes_ purement procédurales.
 
 ---
 
@@ -98,30 +124,37 @@ C'est une optimisation très avancée mais extrêmement élégante, souvent rés
 
 ### Unreal Engine 5 & Unity (HDRP)
 
-Ces moteurs utilisent une architecture extrêmement similaire au niveau du *Tile Max* / *Neighbor Max*. Cependant, ils intègrent l'effet au sein de leur écosystème global temporel :
-* **Découplage :** Ces moteurs comportent un contrôle séparant explicitement la force du flou de mouvement de la Caméra et celui des Objets, car le flou de mouvement de caméra est une cause très connue de *Motion Sickness* chez les joueurs.
-* **TSR / TAA :** Chez l'UE5, le flou de mouvement n'est pas uniquement un effet de post-process jetable, il aide visuellement la résolution temporelle (Temporal Super Resolution) en combinant les vecteurs de mouvement à l'Anti-Aliasing.
+Ces moteurs utilisent une architecture extrêmement similaire au niveau du _Tile Max_ / _Neighbor Max_. Cependant, ils intègrent l'effet au sein de leur écosystème global temporel :
+
+- **Découplage :** Ces moteurs comportent un contrôle séparant explicitement la force du flou de mouvement de la Caméra et celui des Objets, car le flou de mouvement de caméra est une cause très connue de _Motion Sickness_ chez les joueurs.
+
+- **TSR / TAA :** Chez l'UE5, le flou de mouvement n'est pas uniquement un effet de post-process jetable, il aide visuellement la résolution temporelle (Temporal Super Resolution) en combinant les vecteurs de mouvement à l'Anti-Aliasing.
 
 ---
 
 ## 4. L'Exemple de Street Fighter 6 (RE Engine)
 
-Le **RE Engine** (Capcom) livre un *Masterclass* sur l'utilisation poussée de l'effet dans le jeu de combat **Street Fighter 6** :
+Le **RE Engine** (Capcom) livre un _Masterclass_ sur l'utilisation poussée de l'effet dans le jeu de combat **Street Fighter 6** :
 
 1. **Per-Vertex Velocity Hyper-Précise :**
-   Dans SF6, la vélocité n'est pas seulement passée par *mesh*, mais elle est calculée os par os via le shader de *Skinning*. Lorsqu'un personnage donne un coup de pied, sa chaussure développe un vecteur de vélocité gigantesque comparé à sa cuisse.
+
+   Dans SF6, la vélocité n'est pas seulement passée par _mesh_, mais elle est calculée os par os via le shader de _Skinning_. Lorsqu'un personnage donne un coup de pied, sa chaussure développe un vecteur de vélocité gigantesque comparé à sa cuisse.
 
 2. **Sur-Échantillonnage Localisé (Targeted High-Samples) :**
+
    Pour économiser de la puissance sans sacrifier la qualité, le RE Engine se permet de lancer entre 16 et 32 échantillons (Samples) par pixel, **mais uniquement** sur les silhouettes enregistrant des vecteurs de haute amplitude. L'environnement statique derrière reste parfaitement net et très peu coûteux à évaluer.
 
 3. **Motion Blur Courbe (Curved Motion Blur) :**
+
    Contrairement à du flou Linéaire standard (« je prends un vecteur et je trace une ligne droite »), le moteur de Capcom stocke l'information de l'accélération en plus de la vitesse. L'échantillonnage de Flou est ainsi "courbé" dans l'espace afin de simuler la trajectoire radiale des membres et poings.
 
 ```mermaid
 graph LR
     A[Flou Linéaire \nStandard Suckless OGL] -->|Crée des lignes droites et des artefacts| B(Trajectoire d'un coup de poing)
     C[Flou Courbe \nRE Engine / SF6] -->|Échantillonnage le long d'un arc de cercle| D(Flou stylisé style Anime/Manga)
+
 ```
 
 ### Le Verdict
-Pour permettre à Suckless OGL de concurrencer commercialement ces rendus, l'ajout du *Camera-only* est insuffisant. **L'implémentation du stockage de l'ancienne matrice de modélisation (Previous Model Matrix)** par instance (dans `pbr_ibl_instanced.vert`) est l'étape la plus immédiate et gratifiante à entreprendre.
+
+Pour permettre à Suckless OGL de concurrencer commercialement ces rendus, l'ajout du _Camera-only_ est insuffisant. **L'implémentation du stockage de l'ancienne matrice de modélisation (Previous Model Matrix)** par instance (dans `pbr_ibl_instanced.vert`) est l'étape la plus immédiate et gratifiante à entreprendre.

--- a/docs/mouse_camera_control.md
+++ b/docs/mouse_camera_control.md
@@ -1,18 +1,23 @@
-
 # Mouse Camera Control
 
 ## Overview
+
 This document explains the implementation of the mouse-controlled camera system (First Person View) in the engine. The system allows orientation control (Pitch/Yaw) via the mouse and movement via the keyboard.
 
 ## Features
+
 - **Capture Mode**: The cursor is hidden and locked to the window center.
+
 - **Sensitivity**: Adjustable sensitivity factor.
+
 - **Clamping**: Pitch is limited to +/- 89 degrees to avoid Gimbal Lock.
+
 - **Smoothness**: Frame-rate independent movement using `deltaTime`.
 
 ## Architecture
 
 ### Data Flow
+
 The input event management is decoupled from the camera update logic.
 
 ```graphviz
@@ -53,36 +58,49 @@ digraph CameraInput {
   Global -> Update;
   Update -> Render [color="#bb9af7", penwidth=2];
 }
+
 ```
 
 ## Implementation Details
 
 ### Rotation Calculation (Euler Angles)
+
 The camera's direction vector is calculated from the Yaw and Pitch angles:
 
 ```c
 // Convert Spherical to Cartesian coordinates
 front.x = cos(glm_rad(yaw)) * cos(glm_rad(pitch));
+
 front.y = sin(glm_rad(pitch));
 front.z = sin(glm_rad(yaw)) * cos(glm_rad(pitch));
+
 glm_normalize(front);
+
 ```
 
 ### Input Handling
+
 The `mouse_callback` function handles the raw mouse input:
 
-1.  Calculate offset: `xoffset = xpos - lastX`
-2.  Apply sensitivity: `xoffset *= sensitivity`
-3.  Update angles: `yaw += xoffset`
-4.  Constrain Pitch: `pitch = clamp(pitch, -89.0f, 89.0f)`
+1. Calculate offset: `xoffset = xpos - lastX`
+
+2. Apply sensitivity: `xoffset *= sensitivity`
+
+3. Update angles: `yaw += xoffset`
+
+4. Constrain Pitch: `pitch = clamp(pitch, -89.0f, 89.0f)`
 
 > [!NOTE]
 > Ensure `firstMouse` check is implemented to prevent a sudden camera jump on the initial frame where the mouse enters the window.
 
 ## Usage
+
 To enable mouse capture:
+
 ```c
 // Enable mouse capture in GLFW
 glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+
 ```
+
 To release the mouse (e.g., for UI interaction), switch to `GLFW_CURSOR_NORMAL`.

--- a/docs/nvidia_optimizations.md
+++ b/docs/nvidia_optimizations.md
@@ -9,13 +9,19 @@ This document details the issues encountered when running the application on NVI
 These issues prevented the application from launching or caused immediate crashes/invalid states on NVIDIA drivers.
 
 ### 1. Robust Texture Mipmap Allocation (Error 0x501)
+
 - **Problem**: The application could fail or render incorrectly during IBL map generation. NVIDIA drivers are strict about `glTexStorage2D` parameters. An incorrect `levels` calculation for high-resolution 4K textures triggered `GL_INVALID_VALUE` (0x501).
+
 - **Fix**: Implemented a precise mip-level formula: `1 + (int)floor(log2(fmax(width, height)))` and added defensive range checks.
+
 - **Result**: Immediate resolution of 0x501 errors during the asynchronous loading phase.
 
 ### 2. Object Labeling & Initialization Sequence (Error 1282)
+
 - **Problem**: Calling `glObjectLabel` on objects immediately after `glGen*` caused "Unknown Object" errors. NVIDIA considers objects "uninitialized" until they are bound.
+
 - **Fix**: Reordered the sequence to ensure every object (VAO, VBO, Texture) is **bound at least once** before labeling.
+
 - **Result**: Clean debug logs and stable startup sequence.
 
 ---
@@ -25,21 +31,33 @@ These issues prevented the application from launching or caused immediate crashe
 These changes addressed recurring performance warnings and optimized the rendering pipeline for NVIDIA's driver heuristics.
 
 ### 1. Dummy Texture Strategy (Unit Binding Cleanup)
+
 - **Issue**: Binding `0` to an active texture unit triggered "undefined base level" warnings and potential driver-side shader recompilations.
+
 - **Fix**: Introduced `dummy_black_tex` and `dummy_white_tex` (1x1 pixels). These are bound whenever a real texture (like HDR environment or Bloom) is pending or disabled.
+
 - **Result**: Perfectly clean debug logs even during asynchronous asset loading; stable shader execution.
 
 ### 2. VAO State Reconciliation (Shader Recompilation)
+
 - **Issue**: Frequent "Vertex shader recompiled based on GL state" (0x20092) warnings caused by indeterminate attribute divisor states across different VAOs.
+
 - **Fix**:
-    - Explicitly called `glVertexAttribDivisor(index, 0)` for all non-instanced attributes in all VAOs.
-    - Systematically disabled unused attribute arrays (indices 1-7) in specialized VAOs (Skybox, Billboards).
+  - Explicitly called `glVertexAttribDivisor(index, 0)` for all non-instanced attributes in all VAOs.
+
+  - Systematically disabled unused attribute arrays (indices 1-7) in specialized VAOs (Skybox, Billboards).
+
 - **Result**: Recompilation is now limited to a one-time startup JIT event, eliminating runtime stuttering.
 
 ### 3. Efficient Memory Placement (Buffer Movement)
+
 - **Issue**: Performance warnings (0x20072) regarding buffer migration between VIDEO and HOST memory during luminance reduction transfers.
+
 - **Fix**:
-    - **Caching**: Luminance SSBOs are now persistent in the `App` struct to avoid per-frame allocation overhead.
-    - **Buffer Storage**: Used `glBufferStorage` with `GL_MAP_READ_BIT | GL_CLIENT_STORAGE_BIT` to hint to the driver that these small readback buffers should stay in host-visible memory.
-    - **Fast Readback**: Replaced mapping with `glGetBufferSubData` to minimize synchronization stalls for single-float transfers.
+  - **Caching**: Luminance SSBOs are now persistent in the `App` struct to avoid per-frame allocation overhead.
+
+  - **Buffer Storage**: Used `glBufferStorage` with `GL_MAP_READ_BIT | GL_CLIENT_STORAGE_BIT` to hint to the driver that these small readback buffers should stay in host-visible memory.
+
+  - **Fast Readback**: Replaced mapping with `glGetBufferSubData` to minimize synchronization stalls for single-float transfers.
+
 - **Result**: Smooth asynchronous exposure adaptation without driver-staged copies.

--- a/docs/opengl_cleanup.md
+++ b/docs/opengl_cleanup.md
@@ -5,13 +5,19 @@ This document summarizes the fixes and analyses performed to resolve OpenGL erro
 ## 1. Stability & Rendering Errors
 
 ### IBL: Mipmap Allocation (0x501)
+
 - **Problem**: `GL_INVALID_VALUE` during IBL texture creation.
+
 - **Cause**: `glTexStorage2D` did not reserve enough levels for a 4K texture (13 levels required).
+
 - **Fix**: Dynamic calculation of the required number of mips based on HDR file size at load time.
 
 ### Object Labeling (1282)
+
 - **Problem**: `GL_INVALID_OPERATION` when calling `glObjectLabel`.
+
 - **Cause**: Attempting to label an object (Buffer/Texture/VAO) before its first "bind". On some drivers, the ID is not "alive" until it has been bound at least once.
+
 - **Fix**: Moved all `glObjectLabel` calls after the first `glBind[Object]`.
 
 ```graphviz
@@ -50,36 +56,54 @@ digraph ObjectLifeycle {
   Bind -> Label [label="Correct", color="#9ece6a", penwidth=2];
   Gen -> Err [label="Too Early", style=dotted, color="#f7768e"];
 }
+
 ```
 
 ### Fallback Protection (0x502)
+
 - **Problem**: `GL_INVALID_OPERATION` during cleanup.
+
 - **Cause**: Accidental deletion of global fallback textures (`dummy_black_tex`) during post-process framebuffer destruction.
+
 - **Fix**: Pointer locking and strict lifecycle management of default textures.
 
 ## 2. Performance Optimizations (NVIDIA)
 
 ### Buffer Migration (0x20072)
+
 - **Problem**: "CPU mapping a GPU-busy buffer" during auto-exposure.
+
 - **Cause**: Synchronous reading of luminance via PBO causing massive stalls.
+
 - **Fix**: Migration to **Persistent SSBOs** with `GL_CLIENT_STORAGE_BIT`. Luminance reduction is now zero-stall.
 
 ### Resize Bridge (0x20084)
+
 - **Problem**: "Texture object (0) bound to unit X does not have a defined base level".
+
 - **Cause**: During a resize, textures are destroyed and recreated. The NVIDIA driver validates the texture units used by the last shader. If unit 0 (or others) points to 0 between two frames, a warning is raised.
+
 - **Fix**: Implemented a **Systematic Bridge** at the end of `postprocess_resize`. All units used (0-6) are bound to a valid dummy texture before returning control to the engine.
 
 ### Shader Recompilation (0x20092)
+
 - **Problem**: "Vertex shader in program 3 is being recompiled based on GL state".
+
 - **Cause**: Mismatch between the PBR Mesh layout and the PBR Billboard layout. The driver had to recompile the shader to adjust the "vertex fetch prologue".
+
 - **Fix**:
-    - **Uniform Signature Implementation**: Added `in_normal` attributes and `Current/PreviousClipPos` outputs to the Billboard shader to exactly match the Mesh Shader profile.
-    - **VAO Normalization**: Explicitly disabled and reset divisors for slots 8-15 in all VAOs to guarantee a stable state signature.
+  - **Uniform Signature Implementation**: Added `in_normal` attributes and `Current/PreviousClipPos` outputs to the Billboard shader to exactly match the Mesh Shader profile.
+
+  - **VAO Normalization**: Explicitly disabled and reset divisors for slots 8-15 in all VAOs to guarantee a stable state signature.
 
 ## 3. Residual Warning 0x20092 Analysis
+
 The warning occasionally persists at launch for the "PBR Billboard Shader".
+
 - **Analysis**: This shader uses `gl_FragDepth` to project a perfect sphere on a flat quad. Manually writing to depth forces the driver to recompile the shader to adjust optimization policies (Early-Z).
+
 - **Impact**: Negligible. Recompilation is performed only once at startup and cached.
 
 ---
+
 **Final Status**: 100% stable, clean log (excluding unavoidable JIT warning on billboards), optimal performance.

--- a/docs/perf_and_notifications.md
+++ b/docs/perf_and_notifications.md
@@ -10,8 +10,9 @@ The `PerfMode` module provides a unified interface for activating system-level p
 
 The refactored design uses a **context-based approach** (`PerfModeContext`), eliminating global variables to ensure thread safety and testability. It supports two backends:
 
-1.  **GameMode**: Leverages Feral Interactive's `libgamemode` daemon (preferred).
-2.  **Native**: Fallback using Linux scheduling syscalls (`sched_setscheduler`, `setpriority`).
+1. **GameMode**: Leverages Feral Interactive's `libgamemode` daemon (preferred).
+
+2. **Native**: Fallback using Linux scheduling syscalls (`sched_setscheduler`, `setpriority`).
 
 ```mermaid
 classDiagram
@@ -46,16 +47,21 @@ classDiagram
     }
 
     App *-- PerfModeContext
+
     PerfModeContext ..> GameModeBackend : Tries_First
     PerfModeContext ..> NativeBackend : Fallback
+
 ```
 
 ### Usage Flow
 
-1.  **Initialization**: `perf_mode_init` detects available backends and saves the current process scheduling state.
-2.  **Activation**: `perf_mode_request_start` attempts to enable optimizations via the best available backend.
-3.  **Deactivation**: `perf_mode_request_end` reverts changes (restoring original scheduler policy/nice values).
-4.  **Cleanup**: `perf_mode_cleanup` ensures any active mode is disabled before exit.
+1. **Initialization**: `perf_mode_init` detects available backends and saves the current process scheduling state.
+
+2. **Activation**: `perf_mode_request_start` attempts to enable optimizations via the best available backend.
+
+3. **Deactivation**: `perf_mode_request_end` reverts changes (restoring original scheduler policy/nice values).
+
+4. **Cleanup**: `perf_mode_cleanup` ensures any active mode is disabled before exit.
 
 ## Action Notifications
 
@@ -65,9 +71,11 @@ The `ActionNotifier` system provides immediate visual feedback for user actions 
 
 It uses a **circular buffer** of notification slots to manage message lifetimes without dynamic allocation during runtime.
 
--   **Zero Allocation**: Pre-allocated array of `ActionNotification` structs.
--   **Auto-expiration**: Each notification has a `lifetime` and `max_lifetime`.
--   **FIFO Replacement**: If the buffer is full, the oldest active notification is overwritten.
+- **Zero Allocation**: Pre-allocated array of `ActionNotification` structs.
+
+- **Auto-expiration**: Each notification has a `lifetime` and `max_lifetime`.
+
+- **FIFO Replacement**: If the buffer is full, the oldest active notification is overwritten.
 
 ```mermaid
 sequenceDiagram
@@ -92,9 +100,11 @@ sequenceDiagram
         AppInput->>ActionNotifier: action_notifier_draw(ui_ctx)
         ActionNotifier->>UI: ui_draw_text_ex(...)
     end
+
 ```
 
 ### Implementation Details
 
--   **Safe Strings**: Uses `safe_strncpy` to prevent buffer overflows.
--   **Alpha Blending**: Notifications fade out gracefully using the new `ui_draw_text_ex` API which supports alpha transparency.
+- **Safe Strings**: Uses `safe_strncpy` to prevent buffer overflows.
+
+- **Alpha Blending**: Notifications fade out gracefully using the new `ui_draw_text_ex` API which supports alpha transparency.

--- a/docs/perf_profiling.md
+++ b/docs/perf_profiling.md
@@ -11,42 +11,60 @@ The `make perf` target uses the Linux `perf` tool to record and report performan
 If you encounter an error like `Access to performance monitoring and observability operations is limited`, you need to adjust the `perf_event_paranoid` setting.
 
 #### 1. Temporary Fix (Immediate)
+
 Run this command on your **host machine**:
+
 ```bash
+
 sudo sysctl -w kernel.perf_event_paranoid=1
+
 ```
 
 #### 2. Permanent Fix (Survives Reboot)
+
 Add the setting to a sysctl configuration file:
+
 ```bash
+
 echo "kernel.perf_event_paranoid = 1" | sudo tee /etc/sysctl.d/99-perf.conf
 sudo sysctl --system
+
 ```
 
 ### Advanced Profiling Settings
 
 #### Kernel Pointer Access
+
 To see kernel symbols in your profiles (useful for identifying overhead in drivers or syscalls):
+
 ```bash
+
 sudo sysctl -w kernel.kptr_restrict=0
+
 ```
 
 ## Usage
 
-1.  **Build and Record:**
-    ```bash
-    make perf
-    ```
-    This will build the project with profiling symbols (`RelWithDebInfo`), run `perf record`, and then automatically open `perf report`.
+1. **Build and Record:**
 
-2.  **View Report Manually:**
-    If you want to view an existing `perf.data` file:
-    ```bash
-    distrobox enter <box-name> -- perf report
-    ```
+```bash
+make perf
+```
 
-## Other Tools
+This will build the project with profiling symbols (`RelWithDebInfo`), run `perf record`, and then automatically open `perf report`.
 
--   **Apitrace:** Use `make apitrace` to capture OpenGL calls and `make qapitrace` to inspect them.
--   **Valgrind (Primary):** Use `make memcheck` to run a deep analysis for leaks and uninitialized memory. Recommended for thorough verification.
--   **AddressSanitizer (ASan):** Use `make asan` to build with memory instrumentation and `make memcheck-asan` to run. Much faster, ideal for runtime error hunting.
+1. **View Report Manually:**
+
+   If you want to view an existing `perf.data` file:
+
+```bash
+distrobox enter <box-name> -- perf report
+```
+
+1. **Other Tools**
+
+- **Apitrace:** Use `make apitrace` to capture OpenGL calls and `make qapitrace` to inspect them.
+
+- **Valgrind (Primary):** Use `make memcheck` to run a deep analysis for leaks and uninitialized memory. Recommended for thorough verification.
+
+- **AddressSanitizer (ASan):** Use `make asan` to build with memory instrumentation and `make memcheck-asan` to run. Much faster, ideal for runtime error hunting.

--- a/docs/photographic_standards.md
+++ b/docs/photographic_standards.md
@@ -1,8 +1,6 @@
-
 # Photographic Standards for Real-Time Rendering
 
 Comprehensive guide to values and photographic concepts used in modern game engines and tone mapping.
-
 
 ## 📸 The 18% Middle Gray - The Cornerstone
 
@@ -10,25 +8,30 @@ Comprehensive guide to values and photographic concepts used in modern game engi
 
 **18% gray** (0.18 in linear space) has been the **universal standard of photometry** since the 1940s.
 
-```
+```text
 Value: 0.18 (linear) = 18% reflectance
 sRGB: ~119/255 = 0.466
 Hex: #777777
+
 ```
 
 ### Why 18%?
 
-1.  **Human Perception**: Our eye perceives 18% reflectance as a neutral "middle tone".
-2.  **Statistical Average**: The majority of real-world scenes have an average reflectance of ~12-20%.
-3.  **Ansel Adams' Zone System**: Zone V (middle of the 0-X scale) = 18%.
+1. **Human Perception**: Our eye perceives 18% reflectance as a neutral "middle tone".
+
+2. **Statistical Average**: The majority of real-world scenes have an average reflectance of ~12-20%.
+
+3. **Ansel Adams' Zone System**: Zone V (middle of the 0-X scale) = 18%.
 
 ### Applications
 
--   **Gray cards** for camera calibration.
--   **Light meters** calibrated to 18% to calculate correct exposure.
--   **Lightroom/Photoshop**: Target for auto-exposure.
--   **Unreal Engine, Unity**: Default Key value for eye adaptation.
+- **Gray cards** for camera calibration.
 
+- **Light meters** calibrated to 18% to calculate correct exposure.
+
+- **Lightroom/Photoshop**: Target for auto-exposure.
+
+- **Unreal Engine, Unity**: Default Key value for eye adaptation.
 
 ## 🎚️ Photographic Values Scale
 
@@ -36,14 +39,20 @@ Hex: #777777
 
 The EV scale measures the quantity of light:
 
-| EV | Condition | Luminance (cd/m²) | Rendering Usage |
-|----|-----------|-------------------|-----------------|
-| **-6** | Moonlight | 0.001 | Very dark scenes |
+| EV     | Condition | Luminance (cd/m²) | Rendering Usage  |
+| ------ | --------- | ----------------- | ---------------- |
+| **-6** | Moonlight | 0.001             | Very dark scenes |
+
 | **-4** | Dimly lit interior | 0.01 | Dungeons, caves |
+
 | **0** | Lit interior | 1.0 | Standard rooms |
+
 | **+4** | Outdoor shadow | 16 | Shaded outdoor scenes |
+
 | **+10** | Full sunlight | 1,000 | Sunny day |
+
 | **+15** | Snow in sunlight | 32,000 | Very bright environments |
+
 | **+20** | Direct Sun (surface) | 1,000,000 | Extreme HDR |
 
 ### Visual EV Scale
@@ -84,37 +93,45 @@ digraph EVScale {
 
   Moon -> Dark -> Room -> Shadow -> Sun -> Snow [arrowhead=none, color="#414868"];
 }
+
 ```
 
 ### Auto-Exposure Formula
 
 ```glsl
 targetExposure = keyValue / sceneLuminance
+
 ```
 
 **Examples** (with keyValue = 0.18):
 
--   Dark scene (0.01 cd/m²) → Exposure = 18.0 (boost ×18)
--   Middle gray (0.18 cd/m²) → Exposure = 1.0 (neutral)
--   Bright scene (10 cd/m²) → Exposure = 0.018 (attenuation)
+- Dark scene (0.01 cd/m²) → Exposure = 18.0 (boost ×18)
 
+- Middle gray (0.18 cd/m²) → Exposure = 1.0 (neutral)
+
+- Bright scene (10 cd/m²) → Exposure = 0.018 (attenuation)
 
 ## 🌈 Material Reflectance Values
 
 ### Standard Albedos (Physically Based)
 
-| Material | Reflectance | Linear | sRGB (8-bit) |
-|----------|-------------|--------|--------------|
-| **Charcoal** | 4% | 0.04 | 61 |
+| Material     | Reflectance | Linear | sRGB (8-bit) |
+| ------------ | ----------- | ------ | ------------ |
+| **Charcoal** | 4%          | 0.04   | 61           |
+
 | **Dark Skin** | 12% | 0.12 | 105 |
+
 | **18% Gray Card** | 18% | 0.18 | 119 |
+
 | **Light Skin** | 35% | 0.35 | 160 |
+
 | **Concrete** | 50% | 0.50 | 186 |
+
 | **Fresh Snow** | 90% | 0.90 | 241 |
+
 | **Maximum (Physical)** | 100% | 1.0 | 255 |
 
 > ⚠️ In PBR, albedos exceeding 0.90 are non-physical (except for special materials).
-
 
 ## 📊 Tone Mapping - Standard Curves
 
@@ -124,6 +141,7 @@ targetExposure = keyValue / sceneLuminance
 
 ```glsl
 output = input * exposure
+
 ```
 
 **Problem**: Brutal clipping at 1.0, loss of HDR details.
@@ -132,6 +150,7 @@ output = input * exposure
 
 ```glsl
 output = input / (input + 1.0)
+
 ```
 
 **Pros**: Soft compression, never clips.
@@ -150,14 +169,20 @@ vec3 FilmicToneMapping(vec3 x) {
     float F = 0.30; // Toe denominator
 
     return ((x * (A * x + C * B) + D * E) /
+
             (x * (A * x + B) + D * F)) - E / F;
+
 }
+
 ```
 
 **Features**:
--   **Toe**: Lifts shadows.
--   **Shoulder**: Compresses highlights.
--   **Linear section**: Preserves mid-tones.
+
+- **Toe**: Lifts shadows.
+
+- **Shoulder**: Compresses highlights.
+
+- **Linear section**: Preserves mid-tones.
 
 ### 4. ACES (Academy Color Encoding System)
 
@@ -171,14 +196,18 @@ vec3 ACESFilm(vec3 x) {
     float d = 0.59;
     float e = 0.14;
     return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
+
 }
+
 ```
 
 **Pros**:
--   Preserves saturated colors.
--   Smooth transition to white.
--   Industry standard (Movies, AAA Games).
 
+- **Preserves saturated colors.**
+
+- **Smooth transition to white.**
+
+- **Industry standard (Movies, AAA Games).**
 
 ## 🎮 Recommended Values for Games
 
@@ -186,12 +215,16 @@ vec3 ACESFilm(vec3 x) {
 
 ![Temporal Adaptation Curves](./images/exposure_adaptation.jpg)
 
-| Parameter | Conservative Value | Dynamic Value | Usage |
-|-----------|--------------------|---------------|-------|
-| **keyValue** | 0.18 | 0.14 - 0.20 | Standard / Fast FPS |
+| Parameter    | Conservative Value | Dynamic Value | Usage               |
+| ------------ | ------------------ | ------------- | ------------------- |
+| **keyValue** | 0.18               | 0.14 - 0.20   | Standard / Fast FPS |
+
 | **minLuminance** | 1.0 | 0.5 - 2.0 | No boost / Dungeons |
+
 | **maxLuminance** | 5000 | 1000 - 10000 | Daylight / Extreme HDR |
+
 | **speedUp** | 2.0 | 1.0 - 3.0 | Slow / Fast Adaptation |
+
 | **speedDown** | 1.0 | 0.5 - 2.0 | Pupil Adaptation |
 
 ### Examples by Genre
@@ -199,56 +232,65 @@ vec3 ACESFilm(vec3 x) {
 ![Auto-Exposure Comparison by Genre](./images/exposure_genres.jpg)
 
 **Realistic FPS** (like Call of Duty)
+
 ```c
 keyValue = 0.15        // Slightly darker (tactical)
 minLuminance = 0.8
 maxLuminance = 8000
 speedUp = 3.0          // Fast adaptation (gameplay)
 speedDown = 1.5
+
 ```
 
 **Fantasy RPG** (like Skyrim)
+
 ```c
 keyValue = 0.20        // Brighter (exploration)
 minLuminance = 0.5     // Boost for dungeons
 maxLuminance = 10000   // Magic HDR sky
 speedUp = 1.5          // Soft adaptation
 speedDown = 1.0
+
 ```
 
 **Horror** (like Resident Evil)
+
 ```c
 keyValue = 0.12        // Very dark (atmosphere)
 minLuminance = 2.0     // No boost (oppressive)
 maxLuminance = 1000
 speedUp = 0.5          // Very slow adaptation
 speedDown = 2.0        // Fast return to black
-```
 
+```
 
 ## 🔧 Interesting Alternative Values
 
 ### Key Value Alternatives
 
-| Value | Name | Effect | Usage |
-|-------|------|--------|-------|
+| Value    | Name                  | Effect            | Usage             |
+| -------- | --------------------- | ----------------- | ----------------- |
 | **0.18** | Photographic Standard | Neutral, balanced | Universal default |
+
 | **0.14** | Unreal Engine (UE4/5) | Slightly darker | AAA Games |
+
 | **0.12** | Low-Key | Dark, dramatic | Cinematic, Horror |
+
 | **0.25** | High-Key | Bright, airy | Cartoon, Light Fantasy |
+
 | **0.50** | Very High-Key | Very bright | Artistic overexposure |
 
 ### Middle Gray in sRGB
 
 Warning: 18% **linear** ≠ 18% **sRGB**!
 
-```
+```text
 Linear 0.18  → sRGB 0.466  (gamma 2.2)
 Linear 0.18  → 8-bit ~119
+
 ```
 
 **Common Trap**: Using 0.18 directly in sRGB results in a gray that is too dark!
-
 
 ## 📐 Useful Formulas
 
@@ -259,7 +301,9 @@ Linear 0.18  → 8-bit ~119
 float luminance_709 = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
 
 // Alternative (Rec. 601 - SD TV)
+
 float luminance_601 = dot(color.rgb, vec3(0.299, 0.587, 0.114));
+
 ```
 
 ### EV ↔ Luminance Conversion
@@ -267,6 +311,7 @@ float luminance_601 = dot(color.rgb, vec3(0.299, 0.587, 0.114));
 ```glsl
 float ev_val = log2(luminance_val);
 float luminance_res = exp2(ev_val);
+
 ```
 
 ### Temporal Adaptation
@@ -274,9 +319,10 @@ float luminance_res = exp2(ev_val);
 ```glsl
 float adaptationSpeed = (target > current) ? speedUp : speedDown;
 float factor = 1.0 - exp(-deltaTime * adaptationSpeed);
-float newExposure = mix(current, target, factor);
-```
 
+float newExposure = mix(current, target, factor);
+
+```
 
 ## 🎨 Practical Workflow
 
@@ -287,30 +333,38 @@ float newExposure = mix(current, target, factor);
 keyValue = 0.18
 minLuminance = 1.0
 maxLuminance = 5000.0
+
 ```
 
 ### 2. Test with Type Scenes
 
--   **Dark Interior**: Check boost isn't excessive.
--   **Outdoor Day**: Check for no over-exposure.
--   **Rapid Transition**: Adjust adaptation speeds.
+- **Dark Interior**: Check boost isn't excessive.
+
+- **Outdoor Day**: Check for no over-exposure.
+
+- **Rapid Transition**: Adjust adaptation speeds.
 
 ### 3. Artistic Tweaking
 
--   **Too bright** → Reduce keyValue (0.14 - 0.16)
--   **Too dark** → Increase keyValue (0.20 - 0.25)
--   **Flashy/Unstable** → Reduce speedUp/Down
--   **Too slow** → Increase speedUp
+- **Too bright** → Reduce keyValue (0.14 - 0.16)
 
+- **Too dark** → Increase keyValue (0.20 - 0.25)
+
+- **Flashy/Unstable** → Reduce speedUp/Down
+
+- **Too slow** → Increase speedUp
 
 ## 📚 Recommended Resources
 
-1.  **Film Lighting Simulator** (Unreal Engine docs)
-2.  **"Physically Based Rendering"** - Matt Pharr, Greg Humphreys
-3.  **Tone Mapping Comparison** - John Hable (Filmic Worlds blog)
-4.  **ACES Documentation** - Academy of Motion Picture Arts
-5.  **"Real Shading in Unreal Engine 4"** - Brian Karis (SIGGRAPH 2013)
+1. **Film Lighting Simulator** (Unreal Engine docs)
 
+2. **"Physically Based Rendering"** - Matt Pharr, Greg Humphreys
+
+3. **Tone Mapping Comparison** - John Hable (Filmic Worlds blog)
+
+4. **ACES Documentation** - Academy of Motion Picture Arts
+
+5. **"Real Shading in Unreal Engine 4"** - Brian Karis (SIGGRAPH 2013)
 
 ## ✨ Bonus: Exotic Values
 
@@ -319,6 +373,7 @@ maxLuminance = 5000.0
 ```c
 keyValue = 0.09       // Scotopic adaptation (rods)
 minLuminance = 5.0    // No boost, night vision
+
 ```
 
 ### Underwater
@@ -326,6 +381,7 @@ minLuminance = 5.0    // No boost, night vision
 ```c
 keyValue = 0.22       // Light diffusion compensation
 speedUp = 0.3         // Very slow adaptation (water)
+
 ```
 
 ### Space
@@ -333,4 +389,5 @@ speedUp = 0.3         // Very slow adaptation (water)
 ```c
 minLuminance = 10.0   // Extreme contrast
 maxLuminance = 100000 // Direct sunlight without atmosphere
+
 ```

--- a/docs/portability_pal.md
+++ b/docs/portability_pal.md
@@ -6,9 +6,11 @@ This document describes the design and implementation of the Platform Abstractio
 
 The PAL was introduced to:
 
-* **Enable Cross-Platform Support**: Prepare the codebase for Windows and macOS ports.
-* **Reduce Coupling**: Isolate OS-specific syscalls and headers from high-level engine logic.
-* **Improve Maintainability**: Centralize platform-specific code in a well-defined directory structure.
+- **Enable Cross-Platform Support**: Prepare the codebase for Windows and macOS ports.
+
+- **Reduce Coupling**: Isolate OS-specific syscalls and headers from high-level engine logic.
+
+- **Improve Maintainability**: Centralize platform-specific code in a well-defined directory structure.
 
 ## Architecture
 
@@ -46,6 +48,7 @@ graph TD
     E -.-> H
     F -.-> G
     F -.-> H
+
 ```
 
 ## PAL Components
@@ -54,23 +57,27 @@ graph TD
 
 Handles process/thread identification and memory management.
 
-* `platform_get_pid()`: Portable process ID retrieval.
-* `platform_get_tid()`: Portable thread ID retrieval (e.g., uses `syscall(SYS_gettid)` on Linux, `GetCurrentThreadId` on Windows).
-* `platform_aligned_alloc()` / `platform_aligned_free()`: Abstracts `posix_memalign` and `_aligned_malloc`.
+- `platform_get_pid()`: Portable process ID retrieval.
+
+- `platform_get_tid()`: Portable thread ID retrieval (e.g., uses `syscall(SYS_gettid)` on Linux, `GetCurrentThreadId` on Windows).
+
+- `platform_aligned_alloc()` / `platform_aligned_free()`: Abstracts `posix_memalign` and `_aligned_malloc`.
 
 ### 2. Platform Time (`platform_time.h`)
 
 Provides high-resolution timing and sleeping.
 
-* `platform_get_time_ns()`: Monotonic nanosecond timer.
-* `platform_get_time_precise()`: Real-time clock for timestamps (Unix epoch).
-* `platform_sleep_ms()`: Millisecond-precision sleep.
+- `platform_get_time_ns()`: Monotonic nanosecond timer.
+
+- `platform_get_time_precise()`: Real-time clock for timestamps (Unix epoch).
+
+- `platform_sleep_ms()`: Millisecond-precision sleep.
 
 ### 3. Platform Filesystem (`platform_fs.h`)
 
 Abstracts directory operations to avoid `dirent.h`.
 
-* `platform_dir_list()`: Recursively (or linearly) scans a directory using a callback-based interface.
+- `platform_dir_list()`: Recursively (or linearly) scans a directory using a callback-based interface.
 
 ## Implementation Details
 
@@ -82,6 +89,7 @@ To avoid OS-specific directory handles in high-level code, the PAL uses a callba
 typedef void (*PlatformDirCallback)(const char* name, bool is_dir, void* user_data);
 
 bool platform_dir_list(const char* path, PlatformDirCallback callback, void* user_data);
+
 ```
 
 This allows `scene.c` to scan for HDR files without knowing if the backend uses `opendir/readdir` or `FindFirstFile/FindNextFile`.
@@ -89,9 +97,9 @@ This allows `scene.c` to scan for HDR files without knowing if the backend uses 
 ## Adding a New Platform
 
 1. Open the relevant PAL implementation file in `src/platform/` (e.g., `platform_utils.c`).
-2. Add a new `#elif defined(__YOUR_OS__)` block.
-3. Implement the required functions using your platform's native API.
-4. Update `CMakeLists.txt` to handle any new platform-specific compile definitions or library links.
+1. Add a new `#elif defined(__YOUR_OS__)` block.
+1. Implement the required functions using your platform's native API.
+1. Update `CMakeLists.txt` to handle any new platform-specific compile definitions or library links.
 
 ## Build System Integration
 
@@ -101,9 +109,10 @@ The PAL is integrated into the build system via CMake. Linux-specific libraries 
 if(UNIX)
     target_link_libraries(app PRIVATE m dl)
 endif()
+
 ```
 
-* **Compiler Flags**: Hardcoded `-rdynamic` and OS-specific linker flags were abstracted or wrapped in `if(UNIX)` blocks in CMake.
+- **Compiler Flags**: Hardcoded `-rdynamic` and OS-specific linker flags were abstracted or wrapped in `if(UNIX)` blocks in CMake.
 
 ## CI/CD Integration
 
@@ -118,22 +127,30 @@ Every push to `master` and every Pull Request triggers a Windows cross-compilati
 If you develop on Linux and want to test the Windows build locally, you can use the provided `just` targets. These targets rely on your `clang-dev` distrobox environment having `mingw` and `wine` installed.
 
 1. **Install Dependencies:** Enter your distrobox and install MinGW-w64 and Wine (e.g., on Fedora/Bazzite):
-   ```bash
+
+```bash
    distrobox enter clang-dev
    sudo dnf install -y mingw64-gcc mingw64-gcc-c++ wine
-   ```
-2. **Run Windows Targets:** Use the `just` commands suffixed with `-win`. The Justfile automatically uses the distrobox container for these commands.
-   * `just configure-win`: Configure the CMake build using the `toolchain-mingw.cmake` file.
-   * `just build-win`: Build the Windows executables (`.exe`).
-   * `just run-win`: Run the compiled Windows application via Wine.
-   * `just test-win`: Run the integration tests via Wine.
-   * `just test-win-unit`: Run the CTest unit test suite via Wine.
+```
+
+1. **Run Windows Targets:** Use the `just` commands suffixed with `-win`. The Justfile automatically uses the distrobox container for these commands.
+   - `just configure-win`: Configure the CMake build using the `toolchain-mingw.cmake` file.
+
+   - `just build-win`: Build the Windows executables (`.exe`).
+
+   - `just run-win`: Run the compiled Windows application via Wine.
+
+   - `just test-win`: Run the integration tests via Wine.
+
+   - `just test-win-unit`: Run the CTest unit test suite via Wine.
 
 ### Nightly Releases
 
 The CI pipeline automatically generates a **Nightly Build** release.
-* **Assets**: Includes `app-Windows-Release.exe` alongside Linux binaries.
-* **Automation**: The release is recreated on every push to `master`, ensuring the latest binaries are always available with a fresh timestamp.
+
+- **Assets**: Includes `app-Windows-Release.exe` alongside Linux binaries.
+
+- **Automation**: The release is recreated on every push to `master`, ensuring the latest binaries are always available with a fresh timestamp.
 
 ### Pre-merge Validation
 
@@ -145,5 +162,6 @@ To ensure stability, the CI is configured to run the full unit test suite on bot
 
 When running the Windows build via Wine (`just build-win` and executing `app.exe`), transitioning to fullscreen via `glfwSetWindowMonitor` can cause the application to lose exclusive mouse focus.
 
-* **Workaround**: `glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);` is set during window creation to prevent the window from minimizing automatically.
-* **Cursor Re-capture**: A manual cursor reset (`glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL)` followed by `GLFW_CURSOR_DISABLED` and `glfwSetCursorPos()`) was added to `app_input.c` to help Wine re-capture the cursor, but perfect focus parity with native Linux is not always guaranteed due to Window Manager and Wine interactions.
+- **Workaround**: `glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);` is set during window creation to prevent the window from minimizing automatically.
+
+- **Cursor Re-capture**: A manual cursor reset (`glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL)` followed by `GLFW_CURSOR_DISABLED` and `glfwSetCursorPos()`) was added to `app_input.c` to help Wine re-capture the cursor, but perfect focus parity with native Linux is not always guaranteed due to Window Manager and Wine interactions.

--- a/docs/postprocess_optimizations_2026-02.md
+++ b/docs/postprocess_optimizations_2026-02.md
@@ -2,28 +2,42 @@
 
 > **Date** : 7 février 2026
 > **Cible** : OpenGL 4.6, Mesa / Intel Iris Xe (RPL-U), iGPU mémoire unifiée
+>
 > **Fichiers modifiés** : 12 fichiers (headers, sources C, shaders, tests)
 
 ---
 
 ## Table des matières
 
-1. [Résumé](#resume)
+1. [Résumé](#résumé)
+
 2. [Corrections de bugs](#1-corrections-de-bugs)
-   - [FXAA / Motion Blur — Ordre du pipeline fragment](#11-fxaa-motion-blur-ordre-du-pipeline-fragment)
-   - [Neighbor Max — Sur-dispatch du compute](#12-neighbor-max-sur-dispatch-du-compute)
-   - [Luminance Adaptation — Réduction parallèle](#13-luminance-adaptation-reduction-parallele)
-   - [Barrières mémoire manquantes](#14-barrieres-memoire-manquantes)
-   - [Auto-Exposure — FBO unbind avant compute](#15-auto-exposure-fbo-unbind-avant-compute)
+   - [FXAA / Motion Blur — Ordre du pipeline fragment](#11-fxaa--motion-blur--ordre-du-pipeline-fragment)
+
+   - [Neighbor Max — Sur-dispatch du compute](#12-neighbor-max--sur-dispatch-du-compute)
+
+   - [Luminance Adaptation — Réduction parallèle](#13-luminance-adaptation--réduction-parallèle)
+
+   - [Barrières mémoire manquantes](#14-barrières-mémoire-manquantes)
+
+   - [Auto-Exposure — FBO unbind avant compute](#15-auto-exposure--fbo-unbind-avant-compute)
+
 3. [Optimisations de performance](#2-optimisations-de-performance)
-   - [UBO dirty flag — Upload partiel](#21-ubo-dirty-flag-upload-partiel)
-   - [Sampler uniforms — Liaison unique](#22-sampler-uniforms-liaison-unique)
-   - [VAO bind/unbind — Factorisation](#23-vao-bindunbind-factorisation)
+   - [UBO dirty flag — Upload partiel](#21-ubo-dirty-flag--upload-partiel)
+
+   - [Sampler uniforms — Liaison unique](#22-sampler-uniforms--liaison-unique)
+
+   - [VAO bind/unbind — Factorisation](#23-vao-bindunbind--factorisation)
+
 4. [Refactoring du GPU Profiler](#3-refactoring-du-gpu-profiler)
-   - [Double-buffering des métadonnées](#31-double-buffering-des-metadonnees)
-   - [Séparation recording_count / stage_count](#32-separation-recording_count-stage_count)
-   - [Étapes de profiling restructurées](#33-etapes-de-profiling-restructurees)
-5. [Fichiers modifiés](#4-fichiers-modifies)
+   - [Double-buffering des métadonnées](#31-double-buffering-des-métadonnées)
+
+   - [Séparation recording_count / stage_count](#32-séparation-recording_count--stage_count)
+
+   - [Étapes de profiling restructurées](#33-étapes-de-profiling-restructurées)
+
+5. [Fichiers modifiés](#4-fichiers-modifiés)
+
 6. [Validation](#5-validation)
 
 ---
@@ -34,11 +48,17 @@ Série d'optimisations et corrections apportées au pipeline de post-processing
 et au GPU profiler. Les changements couvrent quatre axes :
 
 - **Corrections de bugs** dans l'ordre d'exécution des effets fragment, le
+
   dispatch des compute shaders, et les barrières de synchronisation.
+
 - **Optimisations CPU-side** réduisant les appels OpenGL redondants par frame.
+
 - **Refactoring du profiler GPU** pour corriger les conflits d'index entre
+
   frames dans le système double-buffered.
+
 - **Restructuration du profiling** pour séparer le coût compute du coût
+
   fragment dans le motion blur.
 
 ---
@@ -49,17 +69,20 @@ et au GPU profiler. Les changements couvrent quatre axes :
 
 **Fichier** : `shaders/postprocess.frag`
 
-**Problème** : Le FXAA était appliqué directement sur `screenTexture` *avant*
+**Problème** : Le FXAA était appliqué directement sur `screenTexture` _avant_
+
 le Motion Blur et le Chromatic Aberration. Le Motion Blur n'était donc jamais
 lissé par le FXAA, et le FXAA ne bénéficiait pas du contenu motion-blurred.
 
 **Avant** :
-```
+
+```text
 FXAA → (CA → MB) ou texture directe
 ```
 
 **Après** :
-```
+
+```text
 (MB → CA) → FXAA → DoF → Bloom → ...
 ```
 
@@ -71,23 +94,28 @@ Le FXAA reçoit maintenant la couleur déjà traitée par MB+CA via le paramètr
 **Fichier** : `src/effects/fx_motion_blur.c`
 
 **Problème** : Le pass Neighbor Max dispatching était identique au Tile Max
+
 (`groups = ceil(pixels / 16)`), alors que le Neighbor Max opère sur les
-*tiles*, pas sur les pixels. Cela provoquait un sur-dispatch de 16× en X et
+_tiles_, pas sur les pixels. Cela provoquait un sur-dispatch de 16× en X et
 16× en Y (256× au total).
 
 **Avant** :
+
 ```c
 glDispatchCompute(groups_x, groups_y, 1);  // groups = ceil(width/16)
 // Pour 1920×1080 : 120×68 = 8160 groupes (chacun 16×16 = 256 threads)
 // Total: ~2M threads pour traiter 8160 tiles
+
 ```
 
 **Après** :
+
 ```c
 int neighbor_groups_x = (tile_count_x + 15) / 16;
 int neighbor_groups_y = (tile_count_y + 15) / 16;
 glDispatchCompute(neighbor_groups_x, neighbor_groups_y, 1);
 // Pour 1920×1080 : 8×5 = 40 groupes → ~10K threads pour 8160 tiles
+
 ```
 
 ### 1.3 Luminance Adaptation — Réduction parallèle
@@ -95,10 +123,12 @@ glDispatchCompute(neighbor_groups_x, neighbor_groups_y, 1);
 **Fichier** : `shaders/lum_adapt.comp`
 
 **Problème** : Le compute shader d'adaptation de luminance utilisait un seul
+
 thread (`gl_GlobalInvocationID == (0,0)`) qui itérait séquentiellement sur les
 64×64 = 4096 texels de la carte de luminance.
 
 **Après** : Réduction parallèle en shared memory avec 256 threads (16×16),
+
 chaque thread traitant 16 texels (bloc 4×4), suivie d'une réduction
 logarithmique `256 → 128 → 64 → ... → 1`.
 
@@ -110,6 +140,7 @@ shared float sharedValidCount[256];
 // Chaque thread accumule 4×4 texels
 // Réduction parallèle avec barrier()
 for (uint s = 128u; s > 0u; s >>= 1u) { ... }
+
 ```
 
 ### 1.4 Barrières mémoire manquantes
@@ -117,6 +148,7 @@ for (uint s = 128u; s > 0u; s >>= 1u) { ... }
 **Fichier** : `src/postprocess.c`
 
 **Ajout** : `glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT)` en début de
+
 `postprocess_end()`, après le rendu de la scène MRT et avant les effets
 compute (Bloom, DoF, AE, MB). Garantit que les écritures dans les textures
 de couleur, vélocité et depth/stencil sont visibles aux compute shaders.
@@ -126,12 +158,14 @@ de couleur, vélocité et depth/stencil sont visibles aux compute shaders.
 **Fichier** : `src/effects/fx_auto_exposure.c`
 
 **Problème** : Le FBO de downsample restait bindé pendant le dispatch du
+
 compute shader d'adaptation. Le compute shader lisait `downsample_tex` qui
 était encore attachée au FBO actif, créant un conflit lecture/écriture
 potentiel.
 
 **Après** : Le FBO est unbindé (`glBindFramebuffer(GL_FRAMEBUFFER, 0)`)
-*avant* la barrière mémoire et le dispatch, garantissant que les données
+_avant_ la barrière mémoire et le dispatch, garantissant que les données
+
 rasterisées sont flushées.
 
 ---
@@ -143,78 +177,101 @@ rasterisées sont flushées.
 **Fichiers** : `include/postprocess.h`, `src/postprocess.c`
 
 **Problème** : Le `PostProcessUBO` (~300 octets, layout std140) était
+
 reconstruit et uploadé en totalité chaque frame via `glBufferSubData`, même
 si aucun paramètre n'avait changé (seul `time` change chaque frame).
 
 **Solution** : Ajout d'un flag `bool ubo_dirty` dans la struct `PostProcess`.
 
 - **Quand `ubo_dirty = true`** : Reconstruction complète du UBO et upload de
+
   `sizeof(PostProcessUBO)` octets.
+
 - **Quand `ubo_dirty = false`** : Upload partiel de 8 octets uniquement
+
   (`active_effects` + `time`), les deux premiers champs du UBO.
 
 Le flag est mis à `true` dans les 17 setters de paramètres (`postprocess_set_*`)
 et à l'initialisation. `postprocess_update_time()` ne met **pas** le flag à
+
 `true` car `time` est dans l'en-tête toujours mis à jour.
 
 ```c
 if (post_processing->ubo_dirty) {
     PostProcessUBO ubo = { /* ... full rebuild ... */ };
+
     glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(PostProcessUBO), &ubo);
     post_processing->ubo_dirty = false;
 } else {
     struct { uint32_t active_effects; float time; } header = { ... };
     glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(header), &header);
 }
+
 ```
 
 **Gain** : En régime stationnaire (pas d'interaction UI), l'upload passe de
+
 ~300 octets/frame à 8 octets/frame.
 
 ### 2.2 Sampler uniforms — Liaison unique
 
 **Fichiers** : `src/postprocess.c`, `src/effects/fx_bloom.c`,
+
 `src/effects/fx_dof.c`, `src/effects/fx_auto_exposure.c`,
 `src/effects/fx_motion_blur.c`
 
 **Problème** : Les `shader_set_int(shader, "samplerName", unit)` étaient
+
 appelés chaque frame dans les fonctions `*_render()`, alors que les sampler
 uniforms sont un **état par programme** (`glProgramUniform`) qui ne change
+
 jamais : chaque sampler est toujours associé à la même unité de texture.
 
 **Solution** :
 
 1. **Shader postprocess (uber-shader)** : Les 8 liaisons sampler→unité sont
+
    configurées dans `setup_sampler_uniforms()`, appelée une seule fois lors de
    `update_current_shader()` (changement ou recompilation du shader).
 
 2. **Shaders d'effets** : Les sampler uniforms sont configurés dans les
+
    fonctions `*_init()` :
    - Bloom : `srcTexture = 0` sur prefilter, downsample, upsample
+
    - Auto-Exposure : `sceneTexture = 0` sur downsample, `lumTexture = 0` sur adapt
+
    - Motion Blur : `velocityTexture = 0` sur tile_max, `tileMaxTexture = 0`
+
      sur neighbor_max
+
    - DoF : Réutilise les shaders Bloom (déjà configurés)
 
 **Gain** : Suppression de ~15 appels `glGetUniformLocation` + `glUniform1i`
+
 par frame.
 
-**Note** : `silent_warnings = true` est maintenant positionné *avant*
+**Note** : `silent_warnings = true` est maintenant positionné _avant_
+
 `update_current_shader()` dans `postprocess_compile_optimized()` pour éviter
 les warnings de uniforms manquants sur les samplers compilés out.
 
 ### 2.3 VAO bind/unbind — Factorisation
 
 **Fichiers** : `src/postprocess.c`, `src/effects/fx_bloom.c`,
+
 `src/effects/fx_dof.c`, `src/effects/fx_auto_exposure.c`
 
 **Problème** : Chaque effet (Bloom, DoF, AE downsample) bindait et unbindait
+
 le VAO du screen quad indépendamment (`glBindVertexArray(vao)` /
 `glBindVertexArray(0)`), générant des changements d'état inutiles vu que tous
 les fullscreen passes utilisent le même VAO.
 
 **Solution** : Le VAO est bindé **une seule fois** en début de
+
 `postprocess_end()` et unbindé **une seule fois** après le dernier
+
 `glDrawArrays` (Final Composite).
 
 ```c
@@ -225,9 +282,11 @@ glBindVertexArray(post_processing->screen_quad_vao);
 
 // Après le dernier draw
 glBindVertexArray(0);
+
 ```
 
 **Gain** : Suppression de ~6 appels `glBindVertexArray` par frame (3 bind +
+
 3 unbind dans Bloom, DoF, AE).
 
 ---
@@ -239,12 +298,14 @@ glBindVertexArray(0);
 **Fichiers** : `include/gpu_profiler.h`, `src/gpu_profiler.c`
 
 **Problème** : Les métadonnées des stages (nom, couleur, depth, parent_index)
+
 étaient écrites directement dans `profiler->stages[]` pendant l'enregistrement.
 Ce tableau est aussi lu par l'UI pour l'affichage. Avec le double-buffering
 des queries, les index de la frame N d'écriture pouvaient écraser les
 métadonnées de la frame N-1 encore en lecture.
 
 **Solution** : Ajout de `GPUStageInfo stage_info[MAX_GPU_STAGES]` dans chaque
+
 `GPUQueryBuffer`. Les métadonnées sont écrites dans le buffer d'écriture
 pendant `gpu_profiler_start_stage()`, puis restaurées dans `stages[]` lors du
 read-back dans `gpu_profiler_begin_frame()`.
@@ -256,21 +317,28 @@ typedef struct {
     int depth;
     int parent_index;
 } GPUStageInfo;
+
 ```
 
 ### 3.2 Séparation recording_count / stage_count
 
 **Fichiers** : `include/gpu_profiler.h`, `src/gpu_profiler.c`,
+
 `tests/test_gpu_profiler.c`
 
 **Problème** : `stage_count` servait à la fois de compteur d'enregistrement
+
 (write-path) et de compteur d'affichage (read-path). Après le swap de buffers,
 il était remis à 0, ce qui faisait clignoter l'UI pendant une frame.
 
 **Solution** : Deux compteurs distincts :
+
 - `recording_count` : compteur d'écriture, remis à 0 à chaque
+
   `begin_frame()`.
+
 - `stage_count` : compteur d'affichage, mis à jour depuis le read buffer
+
   complété, **jamais** remis à 0.
 
 ### 3.3 Étapes de profiling restructurées
@@ -279,14 +347,15 @@ il était remis à 0, ce qui faisait clignoter l'UI pendant une frame.
 
 Le profiling du post-process est restructuré pour distinguer :
 
-| Stage              | Contenu                                        |
-|--------------------|------------------------------------------------|
-| **Post-Process**   | Englobant (parent de tous les sous-stages)      |
-| Bloom              | Prefilter + Downsample + Upsample              |
-| DoF                | Downsample + Tent blur                          |
-| Auto-Exposure      | Lum downsample + Compute adaptation             |
-| MB Compute         | Tile Max + Neighbor Max (compute dispatches)    |
-| **Final Composite**| Fullscreen quad : MB sampling, CA, FXAA, etc.   |
+| Stage            | Contenu                                    |
+| ---------------- | ------------------------------------------ |
+| **Post-Process** | Englobant (parent de tous les sous-stages) |
+
+| Bloom | Prefilter + Downsample + Upsample |
+| DoF | Downsample + Tent blur |
+| Auto-Exposure | Lum downsample + Compute adaptation |
+| MB Compute | Tile Max + Neighbor Max (compute dispatches) |
+| **Final Composite**| Fullscreen quad : MB sampling, CA, FXAA, etc. |
 
 Ajout de la couleur `GPU_PROFILER_COMPOSITE_COLOR` (Nord Frost Medium Blue,
 `0x81A1C1`) dans `app_settings.h`.
@@ -295,27 +364,30 @@ Ajout de la couleur `GPU_PROFILER_COMPOSITE_COLOR` (Nord Frost Medium Blue,
 
 ## 4. Fichiers modifiés
 
-| Fichier | Changements |
-|---------|-------------|
-| `include/postprocess.h` | Ajout `bool ubo_dirty` |
-| `include/gpu_profiler.h` | `GPUStageInfo`, `recording_count`, docs |
-| `include/perf_timer.h` | Clarification docs `GPUTimer` |
-| `include/app_settings.h` | `GPU_PROFILER_COMPOSITE_COLOR` |
-| `src/postprocess.c` | UBO dirty flag, `setup_sampler_uniforms()`, VAO factorisation, barrière mémoire, profiling restructuré |
-| `src/gpu_profiler.c` | Double-buffering métadonnées, recording_count, docs |
-| `src/effects/fx_bloom.c` | Sampler init, suppression VAO/sampler per-frame |
-| `src/effects/fx_dof.c` | Suppression VAO/sampler per-frame |
-| `src/effects/fx_auto_exposure.c` | Sampler init, FBO unbind, suppression VAO/sampler per-frame |
-| `src/effects/fx_motion_blur.c` | Sampler init, dispatch corrigé, docs |
-| `shaders/postprocess.frag` | Réordonnancement FXAA/MB/CA |
-| `shaders/lum_adapt.comp` | Réduction parallèle 256 threads |
-| `tests/test_gpu_profiler.c` | Adaptation aux nouveaux champs |
+| Fichier                          | Changements                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `include/postprocess.h`          | Ajout `bool ubo_dirty`                                                                                 |
+| `include/gpu_profiler.h`         | `GPUStageInfo`, `recording_count`, docs                                                                |
+| `include/perf_timer.h`           | Clarification docs `GPUTimer`                                                                          |
+| `include/app_settings.h`         | `GPU_PROFILER_COMPOSITE_COLOR`                                                                         |
+| `src/postprocess.c`              | UBO dirty flag, `setup_sampler_uniforms()`, VAO factorisation, barrière mémoire, profiling restructuré |
+| `src/gpu_profiler.c`             | Double-buffering métadonnées, recording_count, docs                                                    |
+| `src/effects/fx_bloom.c`         | Sampler init, suppression VAO/sampler per-frame                                                        |
+| `src/effects/fx_dof.c`           | Suppression VAO/sampler per-frame                                                                      |
+| `src/effects/fx_auto_exposure.c` | Sampler init, FBO unbind, suppression VAO/sampler per-frame                                            |
+| `src/effects/fx_motion_blur.c`   | Sampler init, dispatch corrigé, docs                                                                   |
+| `shaders/postprocess.frag`       | Réordonnancement FXAA/MB/CA                                                                            |
+| `shaders/lum_adapt.comp`         | Réduction parallèle 256 threads                                                                        |
+| `tests/test_gpu_profiler.c`      | Adaptation aux nouveaux champs                                                                         |
 
 ---
 
 ## 5. Validation
 
 - **Build** : `make all` — 0 erreurs, 0 warnings
+
 - **Tests** : `make test` — 32/32 tests passés (100%)
+
 - **Lint** : `make lint` — Tous les checks passés (clang-tidy)
+
 - **Exécution** : `make run-release` — Vérification visuelle OK

--- a/docs/postprocess_optimizations_2026-03.md
+++ b/docs/postprocess_optimizations_2026-03.md
@@ -1,0 +1,93 @@
+# Analyse Technique : Optimisations Post-Process (Mars 2026)
+
+Cette documentation détaille les pistes d'optimisation GPU pour le pipeline de post-processing de `suckless-ogl`, basées sur le passage des calculs vers les **Compute Shaders**.
+
+## Objectifs Généraux
+
+1. **Réduction de l'overhead CPU** : Supprimer les changements de Framebuffer (FBO) et les draw calls multiples.
+
+2. **Maximisation de l'occupation GPU** : Utiliser le parallélisme massif des unités de calcul (EUs/CUs) via les Compute Shaders.
+
+3. **Réduction des barrières de synchronisation** : Minimiser les attentes entre les passes.
+
+---
+
+## Partie 1 : Auto-Exposure (Calcul de Luminance)
+
+### Concept
+
+Remplacer la passe de rasterisation (Fragment Shader sur un quad 64x64) par un Compute Shader traitant la texture de scène.
+
+### Points Critiques (Leçons Apprises)
+
+Pour conserver un rendu **ISO avec master**, le Compute Shader doit impérativement répliquer la logique physique :
+
+- **Échantillonnage 4x4** : Ne pas se contenter d'un `texture()` au centre. Il faut moyenner un bloc de pixels (box filter) pour capturer les pics de lumière.
+
+- **Seuil d'exclusion (0.05)** : Ignorer les pixels dont la luminance est inférieure à 0.05. Sans cela, le ciel noir ou les ombres profondes tirent la moyenne vers le bas, provoquant une surexposition massive.
+
+- **Valeur Sentinelle (-100.0)** : Si un bloc est entièrement noir, il doit être marqué pour être ignoré par l'étape d'adaptation.
+
+### Étapes d'implémentation
+
+1. **Shader** : Créer `shaders/lum_downsample.comp` avec une boucle de sampling 4x4.
+
+2. **Texture** : Passer `downsample_tex` en format `R32F` pour le stockage d'images (image2D).
+
+3. **C Code** : Supprimer `downsample_fbo`. Remplacer `glDrawArrays` par `glDispatchCompute(8, 8, 1)`.
+
+4. **Barrière** : Ajouter `glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT)` avant l'étape d'adaptation.
+
+---
+
+## Partie 2 : Bloom (Downsampling Single-Pass)
+
+### Concept
+
+Remplacer les 5 à 6 passes de Downsampling successives par un seul dispatch Compute Shader (similaire au _Single Pass Downsampler_ d'AMD).
+
+### Détails Techniques
+
+- **Hiérarchie de Mips** : Utiliser `glBindImageTexture` pour lier plusieurs niveaux de mipmaps (1 à 4) simultanément.
+
+- **Parallélisme** : Chaque groupe de travail (8x8) traite une zone et écrit dans les mips correspondantes.
+
+- **Format** : Utiliser `R11F_G11F_B10F` pour un stockage HDR compact et performant.
+
+### Étapes d'implémentation
+
+1. **Shader** : Créer `shaders/bloom_downsample.comp`.
+
+2. **C Code** : Modifier `fx_bloom_init` pour configurer les textures de mips avec l'accès image.
+
+3. **Render** : Remplacer la boucle de rendu fragment par un dispatch unique. Conserver le mode Raster pour l'Upsampling (qui bénéficie du blending hardware `GL_ONE, GL_ONE`).
+
+---
+
+## Partie 3 : Gestion des Ressources & RAII
+
+### Concept
+
+Fiabiliser la suppression des ressources lors du redémarrage du moteur ou du changement de résolution.
+
+### Recommandations
+
+- **Macro `SHADER_SAFE_DESTROY`** : Utiliser systématiquement une macro vérifiant la nullité avant `shader_destroy`.
+
+- **Nettoyage FBO** : S'assurer que les textures attachées aux FBO sont bien libérées _après_ les FBO pour éviter les dangling pointers dans le driver.
+
+---
+
+## Partie 4 : Validation et Métriques
+
+### Méthodologie de test
+
+1. **Parité Visuelle** : Utiliser `tests/test_visual_fx.c` pour comparer, pixel à pixel, le rendu Raster et le rendu Compute. Toute différence de luminance moyenne > 1% doit être traitée comme un bug.
+
+2. **Benchmarking** : Utiliser `apitrace` pour vérifier la disparition des "bubbles" dans le pipeline (zones où le GPU attend le CPU).
+
+3. **Watchdog** : Pour les tests sous Wine, implémenter un timeout de sortie si l'application ignore le signal `Escape` suite à une désynchronisation X11.
+
+---
+
+_Analyse réalisée le 13 Mars 2026._

--- a/docs/postprocess_ubo_architecture.md
+++ b/docs/postprocess_ubo_architecture.md
@@ -1,4 +1,3 @@
-
 # Post-Processing UBO Architecture
 
 This document details the implementation of the **Uniform Buffer Object (UBO)** used to manage post-processing parameters in the engine. This transition from individual uniforms (`glUniform*`) was made to improve CPU performance and code clarity.
@@ -7,25 +6,35 @@ This document details the implementation of the **Uniform Buffer Object (UBO)** 
 
 Instead of sending dozens of uniforms (floats, integers) one by one every frame, we bundle all configuration data (Vignette, Bloom, Exposure, FXAA, etc.) into a single contiguous memory structure.
 
--   **C Side**: `struct PostProcessUBO` (file `include/postprocess.h`)
--   **GPU Side**: `program Block` with `std140` layout (file `shaders/postprocess/ubo.glsl`)
--   **Transfer**: A single `glBufferSubData` call per frame.
+- **C Side**: `struct PostProcessUBO` (file `include/postprocess.h`)
+
+- **GPU Side**: `program Block` with `std140` layout (file `shaders/postprocess/ubo.glsl`)
+
+- **Transfer**: A single `glBufferSubData` call per frame.
 
 ## 2. Critical Constraints: std140 Layout
 
 The `std140` layout imposes strict alignment rules in GPU memory. To ensure the driver reads data correctly, the C structure must mimic this alignment **byte-for-byte**.
 
 ### std140 Alignment Rules (Simplified)
-1.  **Scalars (float, int, bool)**: Base alignment N (4 bytes).
-2.  **Vectors (vec2)**: Alignment 2N (8 bytes).
-3.  **Vectors (vec3, vec4)**: Alignment 4N (16 bytes).
-4.  **Arrays / Structures**: Alignment rounded up to 16 bytes (size of a vec4).
-5.  **Padding**: There is **no** implicit padding between scalars, unless necessary to respect the alignment of the next member.
+
+1. **Scalars (float, int, bool)**: Base alignment N (4 bytes).
+
+2. **Vectors (vec2)**: Alignment 2N (8 bytes).
+
+3. **Vectors (vec3, vec4)**: Alignment 4N (16 bytes).
+
+4. **Arrays / Structures**: Alignment rounded up to 16 bytes (size of a vec4).
+
+5. **Padding**: There is **no** implicit padding between scalars, unless necessary to respect the alignment of the next member.
 
 ### The "Array vs Scalar" Padding Trap
+
 This is where a subtle error can occur:
--   If you declare `float padding[3]` in GLSL, `std140` treats this as an array. **Every array element must be aligned to 16 bytes**. So `padding[0]` takes 16 bytes (4 useful + 12 empty), `padding[1]` takes 16 bytes, etc.
--   **Solution**: Use individual scalar fields for GLSL padding (`float _pad1; float _pad2; ...`) so they are packed compactly (4 bytes each), matching exactly the packed `float padding[3]` in C.
+
+- **Problem**: If you declare `float padding[3]` in GLSL, `std140` treats this as an array. **Every array element must be aligned to 16 bytes**. So `padding[0]` takes 16 bytes (4 useful + 12 empty), `padding[1]` takes 16 bytes, etc.
+
+- **Solution**: Use individual scalar fields for GLSL padding (`float _pad1; float _pad2; ...`) so they are packed compactly (4 bytes each), matching exactly the packed `float padding[3]` in C.
 
 ### Memory Visualization (std140)
 
@@ -57,11 +66,13 @@ digraph UBOLayout {
 
   struct -> gpu [label="Binary Match", fontname="Helvetica", fontsize=12, fontcolor="#9aa5ce"];
 }
+
 ```
 
 ## 3. Data Structure
 
 ### C Structure (postprocess.h)
+
 We use explicit padding to align logical blocks to 16 bytes, facilitating memory reading and debugging.
 
 ```c
@@ -71,6 +82,7 @@ typedef struct {
     float _pad0[2];          // 8 bytes (Padding to reach 16 bytes)
 
     /* Vignette (16 bytes) */
+
     float vignette_intensity;
     float vignette_smoothness;
     float vignette_roundness;
@@ -79,14 +91,17 @@ typedef struct {
     // ... (Grain, Exposure, etc.)
 
     /* FXAA (16 bytes) */
+
     float fxaa_quality_subpix;
     float fxaa_quality_edge_threshold;
     float fxaa_quality_edge_threshold_min;
     float _pad10;
 } PostProcessUBO_Layout;
+
 ```
 
 ### GLSL Block (ubo.glsl)
+
 The block defines `std140` layout and binding 0.
 
 > **IMPORTANT**: Padding fields must be declared individually!
@@ -99,6 +114,7 @@ LAYOUT_CONFIG(std140, binding = 0) uniform PostProcessBlock_Layout {
     float _pad0_1; // Matches _pad0[1] in C
 
     /* Vignette */
+
     float v_intensity;
     float v_smoothness;
     float v_roundness;
@@ -107,40 +123,52 @@ LAYOUT_CONFIG(std140, binding = 0) uniform PostProcessBlock_Layout {
     // ... (Grain, Exposure, etc.)
 
     /* FXAA */
+
     float fxaaQualitySubpix;
     float fxaaQualityEdgeThreshold;
     float fxaaQualityEdgeThresholdMin;
     float _pad10;
 };
+
 ```
 
 ## 4. Adding a New Parameter
 
 To add an effect or parameter, meticulously follow these steps:
 
-1.  **Add to C struct (`postprocess.h`)**:
-    -   Add the field `float my_param`.
-    -   Adjust the padding array `_padX` so the total block size remains a multiple of 16 bytes (optional but recommended for organization).
+1. **Add to C struct (`postprocess.h`)**:
+   - Add the field `float my_param`.
 
-2.  **Add to GLSL block (`ubo.glsl`)**:
-    -   Add the field `float my_param`.
-    -   **Crucial:** Update the scalar padding fields (`_padX_0`, etc.) to match the C offsets *exactly*.
+   - Adjust the padding array `_padX` so the total block size remains a multiple of 16 bytes (optional but recommended for organization).
 
-3.  **Usage in shaders**:
-    -   The file `ubo.glsl` is included via `@header "postprocess/ubo.glsl"`.
-    -   Access `my_param` directly (the block makes members global).
-    -   For boolean flags, add a macro in `ubo.glsl`:
-    ```glsl
+2. **Add to GLSL block (`ubo.glsl`)**:
+   - Add the field `float my_param`.
+
+   - **Crucial:** Update the scalar padding fields (`_padX_0`, etc.) to match the C offsets _exactly_.
+
+3. **Usage in shaders**:
+   - The file `ubo.glsl` is included via `@header "postprocess/ubo.glsl"`.
+
+   - Access `my_param` directly (the block makes members global).
+
+   - For boolean flags, add a macro in `ubo.glsl`:
+
+```glsl
     #define enableMyEffect ((activeEffects & (1u << N)) != 0u)
-    ```
+```
 
 ## 5. Performance
 
 Using the UBO allowed removing the following per-frame calls:
--   `glUseProgram` (for uploads)
--   ~30-50 calls to `glUniform1f` / `glUniform1i`
--   The driver validation associated with each call.
+
+- `glUseProgram` (for uploads)
+
+- ~30-50 calls to `glUniform1f` / `glUniform1i`
+
+- The driver validation associated with each call.
 
 Now, `postprocess_end()` performs:
-1.  Copy data to local struct (on stack).
-2.  **A single call** to `glBufferSubData`.
+
+1. Copy data to local struct (on stack).
+
+2. **A single call** to `glBufferSubData`.

--- a/docs/pr_evaluation_report.md
+++ b/docs/pr_evaluation_report.md
@@ -5,13 +5,17 @@ Cette PR apporte une amélioration critique à la sécurité et à la robustesse
 ## 1. Apport de la PR
 
 - **Sécurité (Voisinage Zero-Trust)** : L'ajout de `is_safe_path` empêche l'utilisation de `..`, des chemins absolus `/`, et des caractères suspects (`:`, `\`). C'est essentiel pour éviter qu'un shader malveillant ne puisse lire des fichiers sensibles (ex: `/etc/passwd` ou des clés SSH) via des inclusions relatives.
+
 - **Robustesse des Buffers** : Remplacement des opérations de chaînes potentiellement risquées par des vérifications explicites de taille (`safe_snprintf`, `safe_memcpy`) et détection de la troncation des chemins.
+
 - **Testabilité** : Introduction des tests "Standalone", permettant de tester la logique métier sans dépendances lourdes (GPU, Drivers).
 
 ## 2. Qualité du Code
 
 - **Programmation Défensive** : Utilisation de `MAX_INCLUDE_DEPTH` pour limiter la récursivité et `MAX_SHADER_SOURCE_SIZE` (16MB) pour prévenir les attaques par déni de service (DoS).
+
 - **Gestion RAII** : Usage intelligent de `__attribute__((cleanup(ctx_free)))` pour garantir la libération de la mémoire complexe du système d'inclusions, même en cas d'erreur précoce.
+
 - **Précision du Parsing** : Le parser de `@header` gère correctement les chemins avec ou sans guillemets, et nettoie les espaces/retours chariot résiduels.
 
 ## 3. Analyse de `tests/test_shader_path_security_standalone.c`
@@ -21,7 +25,9 @@ Cette PR apporte une amélioration critique à la sécurité et à la robustesse
 Le fichier utilise une stratégie astucieuse pour isoler la logique de `src/shader.c` :
 
 1. **Mocks Légers** : Au lieu de lier `glad` ou le système de log complexe, le test redéfinit des fonctions "vides" (lignes 11-173). Cela permet au compilateur de satisfaire les symboles sans infrastructure OpenGL.
+
 2. **Inclusion Directe du C** : `#include "shader.c"` (ligne 175). C'est la clé pour tester des fonctions `static` (ex: `get_dir_from_path`, `parse_include_path`) sans les exposer dans le header public.
+
 3. **Isolation Totale** : Le test se compile en un exécutable minimal, ultra-rapide et déterministe, idéal pour une CI qui doit tourner sans GPU (ex: GitHub Actions standard).
 
 ### Focus sur la Sécurité via Mock
@@ -32,9 +38,10 @@ Le test valide spécifiquement les **cas aux limites de troncation**. Par exempl
 
 ## Conclusion & Recommandations
 
-**Score : 9/10**
+### Score : 9/10
 
 - **Points forts** : Sécurité granulaire, tests rapides, code propre.
+
 - **Amélioration possible** : Ajouter un test dans le standalone pour `is_safe_path` lui-même avec une liste de "payloads" classiques (`../../`, `/etc/`, `C:\`, etc.) pour centraliser la validation de la blacklist.
 
 > [!TIP]

--- a/docs/profiling_guide.md
+++ b/docs/profiling_guide.md
@@ -13,11 +13,15 @@ Our engine injects manual `GL_TIMESTAMP` queries and `glPushDebugGroup` markers 
 ## 1. Prerequisites
 
 Ensure you have **ApiTrace** installed on your system.
+
 The `Makefile` expects `apitrace` to be in your PATH, or you can point to a specific binary using `APITRACE_BIN`.
 
 ```console
+
 # Example for a specific location
+
 $ export APITRACE_BIN="/path/to/apitrace"
+
 ```
 
 ---
@@ -28,12 +32,13 @@ To record the execution of the application:
 
 ```sh
 make apitrace
+
 ```
 
 This will:
 
 1. Build the application in "Profile" mode (without high-level debug overhead).
-2. Use `apitrace trace` to record all OpenGL calls into `build-profile/app.trace`.
+1. Use `apitrace trace` to record all OpenGL calls into `build-profile/app.trace`.
 
 ---
 
@@ -43,19 +48,23 @@ The easiest way to see the results is to use the integrated target:
 
 ```sh
 make trace-perf
+
 ```
 
 This command runs `scripts/trace_analyze.py` which produces two tables:
 
 1. **Performance by Shader (Cumulative)**: Groups all calls by shader name/label.
-2. **Debug Groups (Per Instance)**: Shows the chronological execution of marked blocks (e.g., IBL generation steps).
+1. **Debug Groups (Per Instance)**: Shows the chronological execution of marked blocks (e.g., IBL generation steps).
 
 ### Understanding the Metrics
 
 | Column | Description |
-| :--- | :--- |
+| :----- | :---------- |
+
 | **GPU [ms]** | Driver-reported duration (Standard `glDraw*` calls). Use this for Vertex/Fragment shaders. |
+
 | **Timer [ms]** | **Manual GL_TIMESTAMP markers**. Use this for **Compute Shaders** and IBL generation blocks. |
+
 | **Avg/Fr[ms]** | Cumulative GPU time divided by the total number of frames in the trace. |
 
 ---
@@ -65,14 +74,19 @@ This command runs `scripts/trace_analyze.py` which produces two tables:
 You can run the script manually for more control:
 
 ```sh
+
 # Usage: python3 scripts/trace_analyze.py <trace_file> [apitrace_bin]
+
 python3 scripts/trace_analyze.py build-profile/app.trace
+
 ```
 
 ### Script Logic
 
 - **Regex Parsing**: The script parses `apitrace dump` to extract `glObjectLabel` (to name shaders) and `glGetQueryObjectui64v` (to get manual timestamps).
+
 - **Matching**: It looks for query result fetches that happen immediately after a debug group ends to measure that group's duration.
+
 - **Nested Sums**: If a parent debug group doesn't have its own timer, the script sums up the durations of its direct children (marked with `*` in the table).
 
 ---
@@ -82,15 +96,16 @@ python3 scripts/trace_analyze.py build-profile/app.trace
 To make a new feature measurable:
 
 1. **Label your shaders**: Use `shader_set_label(shader, "Description")` in C.
-2. **Add debug groups**:
+1. **Add debug groups**:
 
-   ```c
+```c
    GL_PUSH_GROUP("My Complex Task", 0);
    // ... GPU calls ...
    GL_POP_GROUP();
-   ```
+```
 
-3. **Add fine-grained timers (Optional)**:
+1. **Add fine-grained timers (Optional)**:
+
    The engine automatically attempts to capture timestamps around critical IBL sections. See `src/pbr.c` for examples.
 
 ---
@@ -100,6 +115,7 @@ To make a new feature measurable:
 To prevent performance regressions from entering the codebase, we use automated ApiTrace analysis:
 
 - **Unit-Level (`just test-apitrace`)**: Records a trace of the integration suite (`test_app`) and greps for "performance issue" or "stall" messages.
+
 - **Full-Integration (`just test-integration-apitrace`)**: Records a trace of the **main application** while simulating user input via `xdotool`. This is the most comprehensive check, covering environment swaps, post-processing toggles, and UI interactions.
 
 If these tests fail with `❌ Validation failed: Performance issues found in trace`, it usually indicates a new GPU stall has been introduced.
@@ -111,6 +127,9 @@ If these tests fail with `❌ Validation failed: Performance issues found in tra
 The analysis script is fully tested:
 
 - **Linting**: `make lint` (uses Ruff).
+
 - **Formatting**: `make format` (uses Ruff).
+
 - **Tests**: `make test-python` (uses Pytest).
+
 - **Coverage**: `make coverage` (generates HTML report for Python logic).

--- a/docs/profiling_tracy.md
+++ b/docs/profiling_tracy.md
@@ -9,16 +9,22 @@ This guide explains how to read and analyze the profiling data captured with Tra
 ### The Timeline (Top)
 
 - **Frame Marks:** Each vertical bar is a frame. Green is good, red indicates a "slow" frame.
+
 - **Navigation:** Use the mouse wheel to zoom (centered on the cursor) and click-drag to move.
 
 ### The Lanes (Main View)
 
 - **Main Thread:** Shows CPU zones. Look for wide blocks (expensive functions).
+
 - **OpenGL Main Context:** This is the most important for GPU work. It shows the actual GPU execution time.
+
 - **Async Status (Fibers):** A custom lane showing the loader's state machine.
   - `IDLE`: No current task.
+
   - `LOADING`: Worker thread is decoding an image/mesh.
+
 - **Async Loader:** The dedicated thread for disk I/O and CPU decoding.
+
 - **CPU/Memory/Power Usage:** Charts showing system resource consumption.
 
 ## 2. What to look for?
@@ -26,22 +32,30 @@ This guide explains how to read and analyze the profiling data captured with Tra
 ### CPU/GPU Sync Issues
 
 - Compare the gaps in the **Main Thread** with the **OpenGL Context**.
+
 - If the CPU is waiting (empty space) while the GPU is busy, you are **GPU Bound**.
+
 - If the GPU is idle while the CPU is working hard, you are **CPU Bound**.
 
 ### Asset Loading Analysis
 
 1. Find a jump in the **Memory Usage** graph.
+
 2. Look at the **Async Status** lane just before the jump.
+
 3. Check the **Async Loader** thread to see which function was active (e.g., `stbi_load`).
+
 4. Look at the **CPU Usage**; spikes during loading confirmed heavy decoding work.
 
 ### Finding "Stutter" (Glitches)
 
 - Locate a frame in the **Frames** row that is significantly wider than others.
+
 - Zoom in to see what caused the delay.
   - Is it a driver stall (Wait for GPU)?
+
   - Is it a long disk read?
+
   - Is it a heavy CPU calculation?
 
 ### Analyzing "Screenshot Skip (GPU Stall)" Messages
@@ -49,7 +63,9 @@ This guide explains how to read and analyze the profiling data captured with Tra
 If you see an orange message saying `Screenshot skip (GPU stall)`:
 
 - **What it means**: The GPU is currently overwhelmed (e.g., executing heavy Compute Shaders like IBL generation). The CPU tried to capture a frame using `glReadPixels` into a PBO, but the GPU hasn't even finished drawing the previous frame yet.
+
 - **Why we skip**: Instead of blocking the CPU for 40ms with `glMapBuffer` to wait for the GPU, the application uses an asynchronous check (`glFenceSync` + `glClientWaitSync` with a 0 timeout). If the GPU isn't ready, the screenshot is dropped to maintain a fluid CPU profiling timeline.
+
 - **When it happens**: Typically during the first seconds of loading a new environment (`Async Status` = `IDLE` after a `LOADING` phase), as the `IBLCoordinator` slices heavy PBR compute workloads across multiple frames.
 
 ## 3. Hybrid Profiling Identifiers
@@ -59,26 +75,36 @@ When using the `HYBRID_MEASURE_LOG` macro, you will see specific zones in the ti
 ### Host (CPU)
 
 - **Color:** Reddish
+
 - **Meaning:** This measures the time the CPU spent **recording commands** (e.g., `glDraw*`, `glUniform*`) and submitting them to the driver.
+
 - **Analysis:**
   - **Short duration (< 0.1ms):** Excellent. The command buffer was built quickly and sent to the GPU without blocking.
+
   - **Long duration:** The CPU is struggling to generate commands, or the driver is stalling (e.g., implicit sync, resource creation).
 
 ### Sync (GPU Wait)
 
 - **Color:** Greenish
+
 - **Meaning:** This measures the time the CPU spent **waiting** for the GPU to finish execution of the previous commands.
+
 - **Analysis:**
   - **Presence:** Usually undesirable in a real-time loop, as it means the CPU is blocked.
-  - **Context:** In `HYBRID_MEASURE_LOG`, we *intentionally* wait to measure the true GPU cost.
+
+  - **Context:** In `HYBRID_MEASURE_LOG`, we _intentionally_ wait to measure the true GPU cost.
 
 ## 4. Advanced Tools
 
 - **Statistics Button:** View which functions take the most cumulative time.
+
   > [!NOTE]
   > Since the application is multi-threaded (Main Thread + Async Loader), the sum of percentages may exceed 100%. This is normal: it represents total CPU time across all threads relative to wall-clock time.
+
 - **Find Button:** Search for specific zones or log messages.
+
 - **Memory Button:** Audit every allocation and find exactly who leaked memory.
+
 - **Messages:** View your application logs (`LOG_INFO`, etc.) perfectly synced with the timeline.
 
 ## 5. Enabling Sampling (Linux)
@@ -89,6 +115,7 @@ To enable it, run this command on your host machine (or inside the container if 
 
 ```bash
 sudo sysctl -w kernel.perf_event_paranoid=-1
+
 ```
 
 > [!WARNING]
@@ -103,7 +130,9 @@ The **Sampling** tab shows where the CPU spends its time based on periodic stack
 By default, you will see a lot of noise (kernel functions, libc, drivers).
 
 - **Name:** The function name.
+
 - **Time:** The percentage of total CPU time spent in this function (Self time).
+
 - **Location:** Source file and line number (if debug symbols are available).
 
 ### Filtering the Noise
@@ -111,7 +140,9 @@ By default, you will see a lot of noise (kernel functions, libc, drivers).
 To make sense of the data, use the buttons at the top of the Sampling view:
 
 1. **Uncheck `Kernel`**: Hides OS functions (like `__memmove_avx`, `sys_call`, etc.).
+
 2. **Uncheck `External`**: Hides functions from external libraries (like `libc`, `libGL`).
+
 3. **Check `Inlines`**: Shows functions that were inlined by the compiler (requires debug info).
 
 ### Finding Hotspots
@@ -119,5 +150,7 @@ To make sense of the data, use the buttons at the top of the Sampling view:
 Once filtered, look for functions from your `suckless-ogl` codebase with high **Time** percentages.
 
 - **Self Time:** Time spent strictly inside the function logic (excluding children).
+
 - **Call Stacks:** Select a function row to see who called it (Call Stack) and whom it called (Callees) in the bottom pane.
+
 - **Code View:** Double-click a row to see the assembly and source code, annotated with the cost of each instruction!

--- a/docs/progressive_ibl.md
+++ b/docs/progressive_ibl.md
@@ -1,4 +1,3 @@
-
 # Progressive & Asynchronous IBL Architecture
 
 This document details the implementation of asynchronous loading and progressive generation of IBL (Image Based Lighting) maps to eliminate freezes when changing environments.
@@ -10,11 +9,16 @@ The goal was to move from a blocking synchronous load (100ms - 800ms freeze) to 
 ### The Pipeline
 
 1. **Disk Load (Separate Thread)**: The `.hdr` file is loaded and decoded (stb_image) in a dedicated thread (`async_loader.c`).
+
 2. **GPU Upload (Main Thread)**: Once ready, raw data is uploaded to VRAM (HDR texture).
+
 3. **IBL Generation (Progressive)**: A state machine (`ibl_coordinator_update`) drives the compute shaders step-by-step to generate:
-    * Mean Luminance (Async GPU readback via `glFenceSync`).
-    * Irradiance Map (Diffuse).
-    * Specular Prefiltered Map (Reflection).
+   - Mean Luminance (Async GPU readback via `glFenceSync`).
+
+   - Irradiance Map (Diffuse).
+
+   - Specular Prefiltered Map (Reflection).
+
 4. **Swap (Double Buffering)**: We use "Pending" textures. The old environment remains displayed until the new one is 100% ready.
 
 ---
@@ -28,6 +32,7 @@ PBR Compute Shaders (especially for high-resolution Specular maps) are very expe
 ### 2.1 Overlap Protection (Crucial)
 
 Compute Shader Workgroups have a fixed size (32x32). If we ask to compute a slice **1 pixel** high, the GPU still launches a block 32 pixels high.
+
 Without protection, the 31 excess rows overwrite/recalculate neighboring pixels, massively wasting resources.
 
 **The Fix (`u_max_y_slice`)**:
@@ -43,6 +48,7 @@ void main_task() {
     if (pixel_pos.y >= u_max_y_slice) return; // Immediate stop for phantom threads
     // ...
 }
+
 ```
 
 ---
@@ -55,34 +61,43 @@ To reconcile **fluidity** (no freeze) and **overall speed** (fast loading), we u
 
 Computing the mean luminance is necessary to adjust brightness automatically, but reading the result back to the CPU can cause a significant pipeline stall (`glGetBufferSubData`).
 
-* **Strategy**: Asynchronous readback.
-* **Implementation**: We dispatch the compute shader and insert a `glFenceSync`. The state machine enters `IBL_STATE_LUMINANCE_WAIT`. In subsequent frames, `glClientWaitSync(..., 0)` is used to poll the GPU non-blockingly. Once the data is ready, we read it instantly without stalling.
+- **Strategy**: Asynchronous readback.
+
+- **Implementation**: We dispatch the compute shader and insert a `glFenceSync`. The state machine enters `IBL_STATE_LUMINANCE_WAIT`. In subsequent frames, `glClientWaitSync(..., 0)` is used to poll the GPU non-blockingly. Once the data is ready, we read it instantly without stalling.
 
 ### B. Mipmap Generation (`glGenerateMipmap`)
 
 Before IBL computation begins, the uploaded HDR texture must have its mipmap chain generated.
 
-* **Strategy**: Isolated Frame.
-* **Cost**: ~40ms (on a 4K HDR image).
-* **Limitation**: `glGenerateMipmap` is a monolithic OpenGL function. It cannot be sliced or interrupted. It forces the GPU to read, downscale, and write 13 levels of high-precision floating-point data in a single massive operation.
-* **Result**: This creates a single irreducible frame "spike" (~24 FPS for one frame). It is voluntarily isolated on its own dedicated frame to prevent compounding with upload (`glTexSubImage2D`) or IBL Compute Shaders.
+- **Strategy**: Isolated Frame.
+
+- **Cost**: ~40ms (on a 4K HDR image).
+
+- **Limitation**: `glGenerateMipmap` is a monolithic OpenGL function. It cannot be sliced or interrupted. It forces the GPU to read, downscale, and write 13 levels of high-precision floating-point data in a single massive operation.
+
+- **Result**: This creates a single irreducible frame "spike" (~24 FPS for one frame). It is voluntarily isolated on its own dedicated frame to prevent compounding with upload (`glTexSubImage2D`) or IBL Compute Shaders.
 
 ### C. Irradiance Map (64x64)
 
-* **Strategy**: Constant slicing.
+- **Strategy**: Constant slicing.
 
-* **Slicing**: 12 Slices.
-* **Cost**: ~5ms / slice.
+- **Slicing**: 12 Slices.
+
+- **Cost**: ~5ms / slice.
 
 ### D. Specular Map (1024x1024)
 
 This is the heaviest part. The cost per mipmap decreases exponentially.
 
 | Mip Level | Size | Strategy | Est. Cost / Frame | Description |
-| :--- | :--- | :--- | :--- | :--- |
+| :-------- | :--- | :------- | :---------------- | :---------- |
+
 | **Mip 0** | 1024x1024 | **24 Slices** | ~25-35ms | Heaviest (High Frequency details). |
+
 | **Mip 1** | 512x512 | **8 Slices** | ~15-25ms | Medium. |
+
 | **Mip 2** | 256x256 | **1 Slice** | ~15ms | Light, computed in one go. |
+
 | **Mip 3-10** | 128..1 | **Tail Grouping** | ~20ms (Total) | All computed in **a single frame**. |
 
 **Total "Tail Grouping"**: Grouping small mips (3 to 10) avoids wasting 7 frames of latency for tiny jobs (<1ms each).
@@ -126,6 +141,7 @@ flowchart LR
   style Mip1 fill:#414868,stroke:#f7768e
   style Mip2 fill:#414868,stroke:#9ece6a
   style Tail fill:#414868,stroke:#9ece6a
+
 ```
 
 ---
@@ -138,10 +154,14 @@ Initially, each slice dispatch called `glMemoryBarrier(GL_ALL_BARRIER_BITS)` at
 the end. This forced the GPU to:
 
 1. **Drain the entire pipeline** — all in-flight commands complete before the
-    next dispatch starts.
+
+   next dispatch starts.
+
 2. **Invalidate all GPU caches** — texture cache, L2, framebuffer, etc.
+
 3. **Cold-restart** — the next dispatch re-fetches `env_hdr_tex` from VRAM
-    instead of hitting cache.
+
+   instead of hitting cache.
 
 The overhead was **super-linear**: doubling the slice count more than doubled
 the total processing time. This made fine-grained slicing (many small slices
@@ -151,15 +171,18 @@ for ~33ms/frame budget) impractical.
 
 Analyzing the data flow reveals that slices are **independent**:
 
-```
+```text
 Slice 0: READ env_hdr_tex → WRITE dest_tex[mip][y: 0..N]
 Slice 1: READ env_hdr_tex → WRITE dest_tex[mip][y: N..2N]
 ...etc
+
 ```
 
-* All slices **read** from the same source HDR texture (never modified).
-* Each slice **writes** to a disjoint Y-range of the destination texture.
-* There is no read-after-write or write-after-write hazard between slices.
+- All slices **read** from the same source HDR texture (never modified).
+
+- Each slice **writes** to a disjoint Y-range of the destination texture.
+
+- There is no read-after-write or write-after-write hazard between slices.
 
 The same holds across mip levels: each mip writes to a different mip level of
 the destination, and reads from the same source HDR.
@@ -168,13 +191,18 @@ the destination, and reads from the same source HDR.
 
 Remove all per-slice barriers and issue **one** barrier at the end:
 
-* `pbr_prefilter_mip()` and `pbr_irradiance_slice_compute()` no longer call
-    `glMemoryBarrier()`. The caller is responsible.
-* A single `glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT)` is placed in
-    `IBL_STATE_DONE`, just before the textures are sampled for rendering.
-* The barrier type is narrowed from `GL_ALL_BARRIER_BITS` to
-    `GL_SHADER_IMAGE_ACCESS_BARRIER_BIT` — only the image-store-to-texture-fetch
-    coherency path is flushed.
+- `pbr_prefilter_mip()` and `pbr_irradiance_slice_compute()` no longer call
+
+  `glMemoryBarrier()`. The caller is responsible.
+
+- A single `glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT)` is placed in
+
+  `IBL_STATE_DONE`, just before the textures are sampled for rendering.
+
+- The barrier type is narrowed from `GL_ALL_BARRIER_BITS` to
+
+  `GL_SHADER_IMAGE_ACCESS_BARRIER_BIT` — only the image-store-to-texture-fetch
+  coherency path is flushed.
 
 ```mermaid
 %%{init: {
@@ -207,15 +235,20 @@ sequenceDiagram
     end
     CPU->>GPU: glMemoryBarrier(IMAGE_ACCESS_BIT)
     Note right of GPU: Single flush before sampling
+
 ```
 
 ### 4.4 Benchmark Results (16 slices on Mip 0)
 
 | Metric | Before (per-slice barrier) | After (deferred) | Improvement |
-| :--- | :--- | :--- | :--- |
+| :----- | :------------------------- | :--------------- | :---------- |
+
 | **Average** | ~1004 ms | ~875 ms | **~13%** |
+
 | **Min** | 792 ms | 668 ms | **~16%** |
+
 | **Max** | 1189 ms | 904 ms | **~24%** |
+
 | **Variance** | ±200 ms | ±80 ms | **Much more stable** |
 
 The variance reduction is significant: per-slice pipeline drains introduced
@@ -233,13 +266,18 @@ continuously without stalls.
 
 With this architecture on a discrete GPU:
 
-* **FPS**: Remains fluid (~30+ FPS during IBL generation).
-* **Total Time**: A complete environment transition takes about **850ms to 950ms** (with 24+8+12 slices).
-* **Perceived Latency**: Near-zero thanks to continuous display of the old environment during computation.
+- **FPS**: Remains fluid (~30+ FPS during IBL generation).
+
+- **Total Time**: A complete environment transition takes about **850ms to 950ms** (with 24+8+12 slices).
+
+- **Perceived Latency**: Near-zero thanks to continuous display of the old environment during computation.
 
 ## 6. Key Files
 
-* `src/ibl_coordinator.c`: Contains the State Machine (`ibl_coordinator_update`) and the deferred barrier in `IBL_STATE_DONE`.
-* `src/pbr.c`: Implements sliced compute dispatches (`pbr_prefilter_mip`, `pbr_irradiance_slice_compute`) — no internal barriers.
-* `include/pbr.h`: API documentation with `@note` about caller barrier responsibility.
-* `shaders/IBL/*.glsl`: Shaders modified to support `u_offset_y` and `u_max_y`.
+- `src/ibl_coordinator.c`: Contains the State Machine (`ibl_coordinator_update`) and the deferred barrier in `IBL_STATE_DONE`.
+
+- `src/pbr.c`: Implements sliced compute dispatches (`pbr_prefilter_mip`, `pbr_irradiance_slice_compute`) — no internal barriers.
+
+- `include/pbr.h`: API documentation with `@note` about caller barrier responsibility.
+
+- `shaders/IBL/*.glsl`: Shaders modified to support `u_offset_y` and `u_max_y`.

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -1,4 +1,3 @@
-
 # Project Structure: Refactored Icosphere
 
 ## Modular Architecture
@@ -6,8 +5,11 @@
 The code has been refactored according to the following principles:
 
 - **Separation of Concerns**: Each module has a clear function.
+
 - **Encapsulation**: Data structures are managed by their own modules.
+
 - **Reusability**: Components can be used independently.
+
 - **Maintainability**: Code that is easier to read, test, and modify.
 
 ## Folder Structure
@@ -15,23 +17,37 @@ The code has been refactored according to the following principles:
 ```text
 icosphere/
 ├── .github/workflows/  # CI/CD Workflows
+
 │   └── scripts/        # CI-specific scripts (Xvfb wrapper, reporting, ...)
+
 ├── src/
 │   ├── main.c              # Entry Point
+
 │   ├── app.c               # Orchestration & Loop
+
 │   ├── app_env.c           # IBL Management (Async/Progressive)
+
 │   ├── app_input.c         # Callbacks & Input State
+
 │   ├── app_scene.c         # Scene Rendering (Instanced/Billboards)
+
 │   ├── app_ui.c            # Overlay UI & Debug
+
 │   ├── effects/            # Post-Process Effects (Bloom, DoF, Manual, ...)
+
 │   ├── camera.c            # Camera Physics
+
 │   ├── async_loader.c      # Thread Loading
+
 │   ├── postprocess.c       # FXAA/ToneMapping Pipeline
+
 │   ├── pbr.c               # PBR Functions
+
 │   └── ... (utils, log, shader, texture)
 │
 ├── include/
 │   ├── app.h               # Main App Structure
+
 │   ├── app_env.h
 │   ├── app_input.h
 │   ├── app_scene.h
@@ -40,9 +56,13 @@ icosphere/
 │
 ├── shaders/
 │   ├── IBL/                # IBL Compute Shaders
+
 │   ├── postprocess/        # FX Shaders (Bloom, DoF, FXAA)
+
 │   ├── pbr_ibl_*.vert/frag # Physically Based Rendering Shaders
+
 │   └── ...
+
 ```
 
 ## Architecture Diagram
@@ -75,9 +95,11 @@ digraph ProjectStructure {
   ];
 
   /* Core */
+
   App [label="App\n(app.c)", color="#e0af68", fontcolor="#e0af68", penwidth=3];
 
   /* Sub-Modules */
+
   subgraph cluster_modules {
     label="Functional Modules";
     fontname="Helvetica Bold,Arial,sans-serif";
@@ -93,6 +115,7 @@ digraph ProjectStructure {
   }
 
   /* Utils/Engines */
+
   subgraph cluster_engine {
     label="Graphics Engine";
     fontname="Helvetica Bold,Arial,sans-serif";
@@ -108,6 +131,7 @@ digraph ProjectStructure {
   }
 
   /* Relations */
+
   App -> AppUI;
   App -> AppInput;
   App -> AppEnv;
@@ -120,6 +144,7 @@ digraph ProjectStructure {
   AppEnv -> PBR [label="Gen Maps"];
   AppScene -> PBR [label="Render"];
 }
+
 ```
 
 ## Modules and Responsibilities
@@ -127,21 +152,29 @@ digraph ProjectStructure {
 ### 1. Core (App)
 
 - `app.c`: Conductor. Initializes, updates, renders.
+
 - `app_input.c`: Handles keyboard/mouse and fills `App` state.
+
 - `app_ui.c`: Draws overlays (text, loading spinners, graphs).
+
 - `app_env.c`: Handles asynchronous loading and IBL generation.
+
 - `app_scene.c`: Handles instance buffers and sphere draw calls.
 
 ### 2. Post-Processing
 
 - Complex pipeline managed by `postprocess.c`.
+
 - Supports: Auto-Exposure, Bloom, DoF, Motion Blur, FXAA, Vignette...
+
 - Uses a standardized UBO (`PostProcessUBODef`) for shaders.
 
 ### 3. Physical Rendering (PBR)
 
 - `pbr.c`: Configures PBR shaders.
+
 - `material.c`: Manages the material library.
+
 - `sphere_sorting.c`: Sorts transparent instances (Back-to-Front).
 
 ## Improvements over Original Code
@@ -149,56 +182,75 @@ digraph ProjectStructure {
 ### ✅ Organization
 
 - Code divided into logical modules.
+
 - Headers separating interface and implementation.
+
 - Easy to find and modify specific features.
 
 ### ✅ Reusability
 
 - Modules can be reused in other projects.
+
 - Clear and documented APIs.
+
 - Encapsulated data structures.
 
 ### ✅ Maintainability
 
 - Clearly defined responsibilities.
+
 - Less coupling between components.
+
 - Easier to debug and test.
 
 ### ✅ Extensibility
 
 - Easy to add new features.
+
 - Example: adding a new geometry type following the icosphere model.
+
 - Modular shader system.
 
 ### ✅ Memory Management
 
 - Clear init/cleanup functions for each module.
+
 - Reduced risk of memory leaks.
+
 - Well-defined resource lifecycle.
 
 ### ✅ Readability
 
 - Descriptive function names with module prefixes.
+
 - Consistent code structure.
+
 - Comments at key locations.
 
 ## Compilation and Execution
 
 ```sh
+
 # Compile the project
+
 make
 
 # Run the application
+
 make run
 
 # Clean generated files
+
 make clean
 
 # Format the code
+
 make format
 
 # Lint the code (static analysis - Zero Warning Project)
+
 make lint
+
 ```
 
 ## Controls
@@ -208,20 +260,27 @@ make lint
 **Camera Mode Enabled (Default)**:
 
 - **Move Mouse**: Orient camera (yaw/pitch).
+
 - **Mouse Wheel**: Zoom in/out.
+
 - **C**: Toggle camera control activation/deactivation.
+
 - **SPACE**: Reset camera position.
 
 When camera mode is **enabled**:
 
 - The cursor is hidden and captured.
+
 - Mouse movements control orientation.
+
 - Pitch is limited to avoid gimbal lock.
 
 When camera mode is **disabled** (press **C**):
 
 - The cursor becomes visible.
+
 - Mouse movements do not affect the camera.
+
 - Useful for interacting with the interface.
 
 ### ⌨️ Keyboard Control
@@ -229,27 +288,43 @@ When camera mode is **disabled** (press **C**):
 **Display**:
 
 - **W**: Toggle wireframe/solid.
+
 - **↑**: Increase subdivisions (max 6).
+
 - **↓**: Decrease subdivisions (min 0).
+
 - **PAGE_UP / PAGE_DOWN**: Increase/Decrease environment blur (LOD).
+
 - **F**: Toggle between Windowed and Fullscreen mode.
+
 - **ESC**: Quit the application.
 
 ## Dependencies
 
 - **GLFW**: Window management and inputs.
+
 - **GLAD**: OpenGL 4.4+ loader.
+
 - **cglm**: Vector/Matrix mathematics.
+
 - **stb_image**: HDR image loading.
 
 ## Technical Notes
 
 - Uses OpenGL 4.4 Core Profile.
+
 - macOS support with `GLFW_OPENGL_FORWARD_COMPAT`.
+
 - Real-time procedural geometry generation.
+
 - Environment mapping with HDR and direct equirectangular mapping.
+
 - Dynamic window resizing management.
+
 - Automated build system with FetchContent (cglm, glad, stb).
+
 - Zero clang-tidy warnings on the entire project source code.
+
 - Structured logging for easier debugging.
+
 - Full interactive Fullscreen support.

--- a/docs/raii_cleanup_guide.md
+++ b/docs/raii_cleanup_guide.md
@@ -7,13 +7,15 @@ This document explains the **RAII-style** (Resource Acquisition Is Initializatio
 ## 1. The Concept: RAII in C
 
 In standard C, resources (memory, file handles, timers) must be managed manually. This often leads to:
-1.  **Deep indentation** when using scope-based macros (like `for` loops).
-2.  **Resource leaks** when a function returns early due to an error.
-3.  **Repetitive code** (multiple `stop_timer()` or `free()` calls before every `return`).
+
+1. **Deep indentation** when using scope-based macros (like `for` loops).
+1. **Resource leaks** when a function returns early due to an error.
+1. **Repetitive code** (multiple `stop_timer()` or `free()` calls before every `return`).
 
 To solve this, we use a technique borrowed from C++ called RAII, made possible in C by a GCC/Clang extension.
 
 ### The attribute cleanup Extension
+
 This attribute tells the compiler to automatically call a specific "cleanup function" when a local variable goes out of scope.
 
 ```graphviz
@@ -53,9 +55,13 @@ digraph RAIIScope {
     margin=25;
 
     Init [label="1. Init Variable\n(Constructor)", color="#9ece6a", fontcolor="#9ece6a", penwidth=3];
+
     Work [label="2. Do Work\n(Logic)", color="#7dcfff", fontcolor="#7dcfff"];
+
     Exit [label="3. Scope Exit\n(Return/Break/End)", shape=diamond, color="#e0af68", fontcolor="#e0af68"];
+
     Cleanup [label="4. Auto-Cleanup\n(Destructor)", color="#f7768e", fontcolor="#f7768e", penwidth=3];
+
   }
 
   Init -> Work [label=" Normal Flow"];
@@ -64,6 +70,7 @@ digraph RAIIScope {
 
   Init -> Exit [label=" Error/Early Return", style=dotted, color="#f7768e"];
 }
+
 ```
 
 ---
@@ -76,48 +83,52 @@ We use this primarily for performance monitoring via the `HYBRID_FUNC_TIMER` mac
 
 ### The Core Components
 
-1.  **The RAII Container**: A structure that holds the resource and its metadata.
+1. **The RAII Container**: A structure that holds the resource and its metadata.
 
-    ```c
+```c
     typedef struct {
         HybridTimer timer;
         const char* label;
+
     } HybridTimerRAII;
-    ```
+```
 
-2.  **The Cleanup Function**: A static function that the compiler will trigger.
+1. **The Cleanup Function**: A static function that the compiler will trigger.
 
-    ```c
+```c
     static inline void hybrid_timer_cleanup_raii(HybridTimerRAII* timer_raii) {
+
         perf_hybrid_stop(&timer_raii->timer, timer_raii->label);
     }
-    ```
+```
 
-3.  **The Macro**: A convenient way to declare the guarded variable.
+1. **The Macro**: A convenient way to declare the guarded variable.
 
-    ```c
+```c
     #define HYBRID_FUNC_TIMER(label) \
         HybridTimerRAII _h_raii __attribute__((cleanup(hybrid_timer_cleanup_raii))) = { \
             perf_hybrid_start(), label }
-    ```
+```
 
-4.  **The GPU Profiler RAII**: Used for automatic management of GPU profiling stages.
+1. **The GPU Profiler RAII**: Used for automatic management of GPU profiling stages.
 
-    ```c
+```c
     #define GPU_STAGE_PROFILER(profiler_ptr, name, color) \
         GPUStageRAII _stage_raii##__LINE__ \
             __attribute__((cleanup(gpu_stage_cleanup_raii))) = {profiler_ptr}; \
         gpu_profiler_start_stage(profiler_ptr, name, color)
-    ```
+```
 
 ---
 
 ## 3. Benefits & Usage
 
 ### Less Indentation
+
 Unlike the older `HYBRID_MEASURE_LOG` which required a code block `{ ... }`, the new RAII macro allows for "flat" code.
 
 **Old Way (Indented):**
+
 ```c
 void process() {
     HYBRID_MEASURE_LOG("Task") {
@@ -125,9 +136,11 @@ void process() {
         do_more_work();
     }
 }
+
 ```
 
 **New Way (Flat):**
+
 ```c
 void process() {
     HYBRID_FUNC_TIMER("Task");
@@ -135,20 +148,25 @@ void process() {
     do_work();
     do_more_work();
 } // Timer stops here automatically
+
 ```
 
 ### Safety with Early Returns
+
 The cleanup is guaranteed to run even if the function exits early.
 
 ```c
 void demo_load_data(const char* file_path) {
+
     HYBRID_FUNC_TIMER("File Load");
 
     FILE* file_ptr = fopen(file_path, "r");
+
     if (!file_ptr) return; // Timer STOPS and LOGS here automatically!
 
     // ... processing ...
 } // Timer STOPS and LOGS here automatically!
+
 ```
 
 ---
@@ -157,35 +175,37 @@ void demo_load_data(const char* file_path) {
 
 In the IBL (Image Based Lighting) generation pipeline, we use `HYBRID_FUNC_TIMER` at the start of expensive compute shader dispatches.
 
-    ```c
-    // signature renamed to prevent Doxygen auto-linking info
-    GLuint
-    demo_build_irradiance_map(GLuint shader_id, GLuint env_hdr_ptr, int map_size, float threshold_value)
-    {
-        if (shader_id == 0) return 0;
+```c
+// signature renamed to prevent Doxygen auto-linking info
+GLuint
+demo_build_irradiance_map(GLuint shader_id, GLuint env_hdr_ptr, int map_size, float threshold_value)
+{
+    if (shader_id == 0) return 0;
 
-        GLuint irr_tex = 0;
-        HYBRID_FUNC_TIMER("IBL: Irradiance Map"); // Automatic measurement starts
+    GLuint irr_tex = 0;
+    HYBRID_FUNC_TIMER("IBL: Irradiance Map"); // Automatic measurement starts
 
-        glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "IBL: Irradiance Map");
+    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "IBL: Irradiance Map");
 
-        // ... OpenGL Setup ...
-        glDispatchCompute(groups, groups, 1);
-        // ...
+    // ... OpenGL Setup ...
+    glDispatchCompute(groups, groups, 1);
+    // ...
 
-        glPopDebugGroup();
+    glPopDebugGroup();
 
-        return irr_tex;
-    } // Measurement stops and result is printed to log
+    return irr_tex;
+} // Measurement stops and result is printed to log
 ```
 
 ---
 
 ## 5. Compatibility & Requirements
 
-*   **Compilers**: This feature requires **GCC** or **Clang**. It is not part of the standard ISO C (C99/C11), but it is a de-facto standard in professional Linux C programming (used extensively in the Linux Kernel and `systemd`).
-*   **Order of Execution**: If multiple variables in the same scope have cleanup attributes, they are executed in **reverse order** of declaration (LIFO).
-*   **Caveats**: The cleanup function is NOT called if the program terminates via `exit()` or `abort()`. It only triggers when leaving a scope normally or via `goto`, `break`, `continue`, or `return`.
+- **Compilers**: This feature requires **GCC** or **Clang**. It is not part of the standard ISO C (C99/C11), but it is a de-facto standard in professional Linux C programming (used extensively in the Linux Kernel and `systemd`).
+
+- **Order of Execution**: If multiple variables in the same scope have cleanup attributes, they are executed in **reverse order** of declaration (LIFO).
+
+- **Caveats**: The cleanup function is NOT called if the program terminates via `exit()` or `abort()`. It only triggers when leaving a scope normally or via `goto`, `break`, `continue`, or `return`.
 
 ---
 
@@ -197,39 +217,46 @@ Clang's static analyzer does not yet fully model the control flow of `__attribut
 
 To maintain clean linting logs without sacrificing RAII's runtime safety, we use **Analyzer Hints**.
 
-### The RAII_SATISFY_* Patterns
+### The RAII*SATISFY*\* Patterns
 
 Defined in `include/utils.h`, these macros satisfy the analyzer by simulating a cleanup call only during static analysis. They have **zero runtime cost**.
 
 - `RAII_SATISFY_FILE(f)`: Simulates `fclose(f)`.
+
 - `RAII_SATISFY_FREE(p)`: Simulates `free(p)`.
 
 **Usage Example:**
 
-    ```c
-    // Example of multiple resource management using RAII
-    static char*
-    demo_raii_loader(const char* file_path)
-    {
-        CLEANUP_FILE FILE* file_ptr = fopen(file_path, "rb");
-        if (!file_ptr) return NULL;
+```c
+// Example of multiple resource management using RAII
+static char*
+demo_raii_loader(const char* file_path)
 
-        CLEANUP_FREE char* data_buffer = malloc(1024);
-        if (error_flag) {
-            // Surgical hints to satisfy the analyzer on this path
-            RAII_SATISFY_FILE(file_ptr);
-            RAII_SATISFY_FREE(data_buffer);
-            return NULL;
-        }
+{
+    CLEANUP_FILE FILE* file_ptr = fopen(file_path, "rb");
 
+    if (!file_ptr) return NULL;
+
+    CLEANUP_FREE char* data_buffer = malloc(1024);
+
+    if (error_flag) {
+        // Surgical hints to satisfy the analyzer on this path
         RAII_SATISFY_FILE(file_ptr);
-        return TRANSFER_OWNERSHIP(data_buffer);
-    } // Actual cleaning happens here at runtime via RAII
-    ```
+        RAII_SATISFY_FREE(data_buffer);
+        return NULL;
+    }
+
+    RAII_SATISFY_FILE(file_ptr);
+    return TRANSFER_OWNERSHIP(data_buffer);
+} // Actual cleaning happens here at runtime via RAII
+```
 
 ### Why use this instead of // NOLINT?
+
 - **Granularity**: `NOLINT` blocks can hide real bugs. Hints are surgical and only "complete the puzzle" for the analyzer.
+
 - **Documentation**: It explicitly states that we are aware of the analyzer's limitation and are providing the missing link.
+
 - **Safety**: If you forget a hint, the code is still safe at runtime. If you forget a `fclose` in legacy code, the code leaks.
 
 ---
@@ -245,16 +272,18 @@ For a deep dive into why RAII is "semantically impossible" to do perfectly in st
 
 **Key Takeaways for this Project:**
 
-1.  **The Copy Problem**: C blindly `memcpy` structs. If you copy a struct containing an RAII-managed resource, you will get a **double-free**.
-    > [!IMPORTANT]
-    > **Rule**: Never copy structures that own resources. Pass them by pointer, or use `TRANSFER_OWNERSHIP` to move them.
+1. **The Copy Problem**: C blindly `memcpy` structs. If you copy a struct containing an RAII-managed resource, you will get a **double-free**.
 
-2.  **The Tooling Gap**: Static analyzers (like Clang-Tidy) are designed for standard C models. Our "Analyzer Hints" (`RAII_SATISFY_*`) are the bridge needed to reconcile modern safety hacks with rigid analysis tools.
+   > [!IMPORTANT]
+   > **Rule**: Never copy structures that own resources. Pass them by pointer, or use `TRANSFER_OWNERSHIP` to move them.
 
-3.  **Safety vs. Purism**: This project chooses **Safety**. While "pure" C relies on manual cleanup and discipline, our RAII approach ensures that a forgotten path doesn't lead to a production leak, at the cost of being slightly "non-standard".
+1. **The Tooling Gap**: Static analyzers (like Clang-Tidy) are designed for standard C models. Our "Analyzer Hints" (`RAII_SATISFY_*`) are the bridge needed to reconcile modern safety hacks with rigid analysis tools.
+1. **Safety vs. Purism**: This project chooses **Safety**. While "pure" C relies on manual cleanup and discipline, our RAII approach ensures that a forgotten path doesn't lead to a production leak, at the cost of being slightly "non-standard".
 
 ---
 
 ## Further Reading
+
 - [GCC Variable Attributes: cleanup](https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html)
+
 - [Resource Acquisition Is Initialization (RAII) in C](https://echorand.me/posts/clean_up_variable_attribute/)

--- a/docs/refactoring_analysis_2026_02.md
+++ b/docs/refactoring_analysis_2026_02.md
@@ -9,8 +9,11 @@ This report evaluates the massive refactoring of the IBL (Image-Based Lighting) 
 The refactoring transforms a blocking IBL generation into a **progressive, state-driven workflow**.
 
 - **Internal States**: `LUMINANCE` → `LUMINANCE_WAIT` → `SPEC_INIT` → `SPEC_MIPS` → `IRRADIANCE` → `DONE`.
+
 - **Slicing Mechanism**: Work is divided into "slices" (e.g., 24 for Mip 0, 8 for Mip 1).
+
 - **Fallback Logic**: Detection of software renderers (llvmpipe) automatically disables slicing to avoid state transition overhead, ensuring consistent behavior across hardware.
+
 - **Resource Ownership**: Strict "Transfer of Ownership" via `ibl_coordinator_get_results`. Once retrieved, the handles are nulled in the coordinator, preventing double-free or stale usage.
 
 ### Application Integration
@@ -18,24 +21,32 @@ The refactoring transforms a blocking IBL generation into a **progressive, state
 The application manages a secondary state machine (`App->transition_state`) that wraps the IBL generation.
 
 - **Dual Coupling**: The app enters `TRANSITION_LOADING` and waits for IBL.
+
 - **Async Safety**: IBL results are generated in the background (across frames). The app only "consumes" them in specific states (`WAIT_IBL` or `LOADING`).
 
 ## 2. Risk Assessment
 
 | Risk Area | Score (1-10) | Mitigation |
-| :--- | :---: | :--- |
+| :-------- | :----------: | :--------- |
+
 | **State Regression** | 4/10 | The recent fix ensures IBL results are buffered until the transition mode (especially Black Screen) is ready to swap. |
+
 | **Memory/GL Leaks** | 2/10 | Use of `ibl_coordinator_reset` and ownership transfer handles resource lifecycles reliably. |
+
 | **Concurrency/Race** | 3/10 | Single-threaded state machine with explicit `glMemoryBarrier` at the end of generation ensures data visibility. |
+
 | **Build/Link Errors** | 1/10 | Moving utils to `.c` caused initial churn but is now fully integrated into `CMakeLists.txt` and all 50+ tests. |
 
-**Overall Risk Score: 2.5 / 10 (Low)**
+### Overall Risk Score: 2.5 / 10 (Low)
 
 ## 3. Why we can be confident
 
 1. **Unit Test Coverage**: `test_ibl_coordinator.c` performs full cycle tests, verifying state transitions and resource cleanup in isolation with mocked OpenGL.
-2. **Integration Coverage**: `test_env_transition.c` simulates the **exact temporal flow** of transitions, including the tricky "Black Screen" mode where IBL finishes *before* the fade-out ends.
+
+2. **Integration Coverage**: `test_env_transition.c` simulates the **exact temporal flow** of transitions, including the tricky "Black Screen" mode where IBL finishes _before_ the fade-out ends.
+
 3. **Static Analysis**: The code now passes `lint-full` (clang-tidy) without any `NOLINT` suppressions, meaning the logic is clear enough for formal verification tools to understand.
+
 4. **Platform Parity**: The logic explicitly handles software rendering fallbacks, making it robust for CI/CD environments.
 
 ## 4. Conclusion

--- a/docs/renderdoc_guide.md
+++ b/docs/renderdoc_guide.md
@@ -1,4 +1,3 @@
-
 # User Guide: RenderDoc on Debian 13 (Intel Iris Xe)
 
 This guide explains how to install and use RenderDoc to profile and verify the GPU performance of `suckless-ogl`.
@@ -7,52 +6,61 @@ This guide explains how to install and use RenderDoc to profile and verify the G
 
 The `renderdoc` package has been removed from Debian Testing (Trixie) repositories. The most reliable (and up-to-date) method is to use the official binary:
 
-1.  **Download**: Go to [renderdoc.org](https://renderdoc.org/builds) and download the latest stable version for **Linux 64-bit**.
-1.  **Extract**:
-    ```sh
-    tar -xvf renderdoc_*.tar.gz
-    cd renderdoc_*
-    ```
-2.  **Launch**:
-    ```sh
-    ./bin/qrenderdoc
-    ```
-    *(Optional) You can add the `bin` folder to your PATH or create a symbolic link to `/usr/local/bin/qrenderdoc`.*
+1. **Download**: Go to [renderdoc.org](https://renderdoc.org/builds) and download the latest stable version for **Linux 64-bit**.
+1. **Extract**:
+
+```sh
+tar -xvf renderdoc_*.tar.gz
+cd renderdoc_*
+```
+
+1. **Launch**:
+
+```sh
+./bin/qrenderdoc
+```
+
+_(Optional) You can add the `bin` folder to your PATH or create a symbolic link to `/usr/local/bin/qrenderdoc`._
 
 ## 2. Profiling Configuration
 
-1.  Launch the GUI: `qrenderdoc`.
-2.  Go to the **"Launch Application"** tab.
-3.  Configure the paths:
-    *   **Executable Path**: `./build-small/app`
-    *   **Working Directory**: `.`
-4.  Check the following options (recommended for profiling):
-    *   `Capture Child Processes`
-    *   `Ref All Resources` (useful to see all HDR textures even if not bound at that moment)
+1. Launch the GUI: `qrenderdoc`.
+1. Go to the **"Launch Application"** tab.
+1. Configure the paths:
+   - **Executable Path**: `./build-small/app`
+   - **Working Directory**: `.`
+
+1. Check the following options (recommended for profiling):
+   - `Capture Child Processes`
+   - `Ref All Resources` (useful to see all HDR textures even if not bound at that moment)
 
 ## 3. Capturing a Loading Event
 
 Environment loading is asynchronous and is triggered via the `Page Up` / `Page Down` keys.
 
-1.  Click **"Launch"** in RenderDoc.
-2.  In your application, get ready to switch environments.
-3.  Press **F12** (or `Print Screen`) in the application to capture a frame.
-    *   *Note: Since IBL loading takes several frames (~500ms), you may need to take several successive captures to hit the exact frame where the Compute Shaders are running.*
-4.  A thumbnail appears in RenderDoc. Double-click it to open.
+1. Click **"Launch"** in RenderDoc.
+1. In your application, get ready to switch environments.
+1. Press **F12** (or `Print Screen`) in the application to capture a frame.
+   - _Note: Since IBL loading takes several frames (~500ms), you may need to take several successive captures to hit the exact frame where the Compute Shaders are running._
+
+1. A thumbnail appears in RenderDoc. Double-click it to open.
 
 ## 4. Performance Analysis (Ground Truth)
 
 Once the capture is open:
 
-1.  Open the **"Event Browser"** window (`Window` -> `Event Browser`).
-2.  Look for `glDispatchCompute` calls. These correspond to your IBL (Luminance, Specular, Irradiance).
-3.  Click the **Clock** icon (Time durations) at the top of the Event Browser.
-    *   RenderDoc will replay the frame multiple times to get a precise GPU measurement.
-4.  **Verification**: Compare the value in the `Duration` column with your `perf.hybrid` logs.
-    *   If RenderDoc indicates `325,450 us` (microseconds), this corresponds to `325.45 ms`.
+1. Open the **"Event Browser"** window (`Window` -> `Event Browser`).
+1. Look for `glDispatchCompute` calls. These correspond to your IBL (Luminance, Specular, Irradiance).
+1. Click the **Clock** icon (Time durations) at the top of the Event Browser.
+   - RenderDoc will replay the frame multiple times to get a precise GPU measurement.
+
+1. **Verification**: Compare the value in the `Duration` column with your `perf.hybrid` logs.
+   - If RenderDoc indicates `325,450 us` (microseconds), this corresponds to `325.45 ms`.
 
 ## 5. Specific Intel / Mesa Tips
 
-*   **Pipeline Details**: In the **"Pipeline State"** tab, you can see exactly which shader is used, the "Dispatch Thread Groups", and bound textures.
-*   **HDR Visualization**: In the **"Texture Viewer"**, you can inspect your `RGBA16F` textures. Use the exposure slider at the top of the window to "see" details in very bright areas.
-*   **Debug Shaders**: You can click "Edit" on a shader in RenderDoc, modify a formula, and "Refresh" to see the visual and performance impact instantly without recompiling your C project.
+- **Pipeline Details**: In the **"Pipeline State"** tab, you can see exactly which shader is used, the "Dispatch Thread Groups", and bound textures.
+
+- **HDR Visualization**: In the **"Texture Viewer"**, you can inspect your `RGBA16F` textures. Use the exposure slider at the top of the window to "see" details in very bright areas.
+
+- **Debug Shaders**: You can click "Edit" on a shader in RenderDoc, modify a formula, and "Refresh" to see the visual and performance impact instantly without recompiling your C project.

--- a/docs/shader-cross-gpu-compatibility.md
+++ b/docs/shader-cross-gpu-compatibility.md
@@ -31,6 +31,7 @@ FragColor_out = vec4(color_val, luma_val);  // Store in alpha
 
 // Post-processing (reuse)
 float stored_luma = texture(tex_sampler, uv_coords).a;  // Consistent across vendors
+
 ```
 
 ### 3. Use Explicit Precision Qualifiers (Mobile/WebGL)
@@ -40,6 +41,7 @@ float stored_luma = texture(tex_sampler, uv_coords).a;  // Consistent across ven
 precision highp float;
 precision highp int;
 #endif
+
 ```
 
 **Note**: Desktop OpenGL ignores these, but they're critical for mobile/WebGL.
@@ -54,6 +56,7 @@ float val_bad = pow(someInput, 0.1);
 
 // Good
 float val_good = pow(clamp(someInput, 0.0, 10.0), 0.1);
+
 ```
 
 ### 5. Avoid Fast Math Assumptions
@@ -63,6 +66,7 @@ Use explicit parentheses to control floating-point operation order:
 ```glsl
 // Order-dependent
 float result_val = ((a * b) + (c * d)) + (e * f);
+
 ```
 
 ## Common Pitfalls
@@ -75,6 +79,7 @@ vec3 color_res = texture(envMap_tex, direction).rgb;
 
 // Explicit LOD is consistent
 vec3 color_res_fixed = textureLod(envMap_tex, direction, roughness * 4.0).rgb;
+
 ```
 
 ### Pitfall 2: Small Exponents in pow()
@@ -85,6 +90,7 @@ float bad_pow = pow(variation, 0.1);   // 10th root
 
 // More stable
 float better_sqrt = sqrt(variation);     // Square root
+
 ```
 
 ### Pitfall 3: Derivatives in Divergent Branches
@@ -95,6 +101,7 @@ float dx_precomputed = dFdx(value_val);
 if (someCondition) {
     // Use dx_precomputed
 }
+
 ```
 
 ### Pitfall 4: Mixed Bitwise Operator Types
@@ -113,24 +120,32 @@ uint result = some_uint & 0x1;
 uint result = some_uint & 0x1u;
 // OR
 uint result = some_uint & uint(some_int);
+
 ```
 
 ## Testing Workflow
 
 1. **Visual Comparison**: Test on 2+ GPU vendors
+
 2. **Pixel Diff**: Use image comparison tools (see [Visual Testing Artifacts](./visual_testing_artifacts.md))
+
 3. **Frame Capture**: Compare with RenderDoc/ApiTrace
+
 4. **Driver Versions**: Test with different driver releases
 
 ### Tools
 
 ```sh
+
 # Visual diff
+
 compare intel.png nvidia.png diff.png
 
 # ApiTrace
+
 apitrace trace ./app
 apitrace replay app.trace
+
 ```
 
 ## When to Use Derivatives
@@ -138,13 +153,17 @@ apitrace replay app.trace
 ✅ **Safe uses**:
 
 - Debug visualization (where exact parity is not required)
+
 - Non-critical effects (optional grain, etc.)
+
 - Explicitly documented vendor-specific behavior
 
 ❌ **Avoid for**:
 
 - Core rendering logic where cross-GPU "Difference Maps" must be clean
+
 - Anti-aliasing (prefer FXAA or Analytic smoothing)
+
 - Material property adjustments (use `MIN_ROUGHNESS` constants)
 
 ## Implementation Example: Analytic Edge Smoothing
@@ -155,6 +174,7 @@ Instead of `fwidth(h)`:
 // h = discriminant (0 at edge)
 // analyticFwidth = footprint of pixel in h-space
 float edgeFactor_val = clamp(h / analyticFwidth, 0.0, 1.0);
+
 ```
 
 See [pbr_ibl_billboard.frag](https://github.com/yoyonel/suckless-ogl/blob/main/shaders/pbr_ibl_billboard.frag) for a production example.
@@ -164,5 +184,7 @@ More details on why testing artifacts appear in CI can be found in [Visual Testi
 ## References
 
 - [OpenGL Derivative Functions](https://www.khronos.org/opengl/wiki/Derivative)
-- [GLSL Precision Qualifiers](https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Precision_qualifiers)
+
+- [GLSL Precision Qualifiers](<https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Precision_qualifiers>)
+
 - [Floating Point Determinism](https://randomascii.wordpress.com/2013/07/16/floating-point-determinism/)

--- a/docs/shader_optimization.md
+++ b/docs/shader_optimization.md
@@ -4,24 +4,34 @@
 
 The post-processing pipeline now supports two compilation modes to balance development flexibility with release performance:
 
-1.  **Debug Mode (Dynamic)**: Features are toggled at runtime using standard uniforms (`if (enableBloom_val) ...`). This allows instant feedback when modifying settings but incurs a GPU cost for branching.
-2.  **Release Mode (Static)**: Features are baked into the shader using preprocessor directives (`#define OPT_ENABLE_BLOOM 1`). The driver's GLSL compiler eliminates all unused code (Dead Code Elimination), resulting in a specialized, high-performance shader.
+1. **Debug Mode (Dynamic)**: Features are toggled at runtime using standard uniforms (`if (enableBloom_val) ...`). This allows instant feedback when modifying settings but incurs a GPU cost for branching.
+1. **Release Mode (Static)**: Features are baked into the shader using preprocessor directives (`#define OPT_ENABLE_BLOOM 1`). The driver's GLSL compiler eliminates all unused code (Dead Code Elimination), resulting in a specialized, high-performance shader.
 
 ## Build Modes
 
 ### Debug Build (make debug / make run)
+
 - **Flags**: `ENABLE_SHADER_OPTIMIZATION=OFF`
+
 - **Behavior**: Shaders use dynamic uniforms. All effects are compiled, but only active ones are executed (via runtime branching, e.g. `if (enableBloom_val) ...`).
+
 - **Use Case**: Development, tweaking parameters, debugging effect interactions.
 
 ### Release Build (make release / make run-release)
+
 - **Flags**: `ENABLE_SHADER_OPTIMIZATION=ON`
+
 - **Behavior**:
-    - The application detects active effects at startup.
-    - It generates a custom shader variant (e.g., `OPT_ENABLE_BLOOM 1`, `OPT_ENABLE_VIGNETTE 0`).
-    - The GLSL compiler strips all disabled effects.
-    - **Uniforms**: Textures and parameters for disabled effects are *not* set, avoiding driver validation overhead.
+  - The application detects active effects at startup.
+
+  - It generates a custom shader variant (e.g., `OPT_ENABLE_BLOOM 1`, `OPT_ENABLE_VIGNETTE 0`).
+
+  - The GLSL compiler strips all disabled effects.
+
+  - **Uniforms**: Textures and parameters for disabled effects are _not_ set, avoiding driver validation overhead.
+
 - **Runtime Toggling**: If you toggle an effect at runtime (e.g., press 'B'), the application **recompiles** the shader on the fly to generate a new optimized variant.
+
 - **Use Case**: Performance profiling, production deployment.
 
 ## Technical Implementation
@@ -38,6 +48,7 @@ We use a hybrid approach where uniforms are converted to `const bool` if the opt
     // Debug Mode: Runtime uniform -> Branching
     uniform bool enableBloom_val;
 #endif
+
 ```
 
 ### 2. Startup Logic (src/app.c)
@@ -50,6 +61,7 @@ When built with `-DENABLE_SHADER_OPTIMIZATION`, the application triggers an imme
     // Specialized wrapper for optimized compilation
     postprocess_compile_optimized(&app->postprocess, initial_flags);
 #endif
+
 ```
 
 ### 3. Conditional Uniforms (src/postprocess.c)
@@ -61,17 +73,22 @@ To avoid OpenGL warnings (e.g., "Uniform 'bloomTexture' not found"), we guard un
 if (!is_optimized || (static_flags & POSTFX_BLOOM)) {
     shader_set_int(shader, "bloomTexture", UNIT_BLOOM);
 }
+
 ```
 
 ## Verification
 
 To verify the optimization works:
-1.  Run `make release`.
-2.  Check the logs:
-    ```
-    [INFO] Compiled OPTIMIZED shader with effects:
-      ✓ Manual Exposure
-      ✓ Color Grading
-    [INFO] Shader optimization complete (Flags: 0x...)
-    ```
-3.  Observe that no "Uniform not found" warnings appear.
+
+1. Run `make release`.
+1. Check the logs:
+
+```text
+[INFO] Compiled OPTIMIZED shader with effects:
+  ✓ Manual Exposure
+  ✓ Color Grading
+[INFO] Shader optimization complete (Flags: 0x...)
+
+```
+
+1. Observe that no "Uniform not found" warnings appear.

--- a/docs/simd_optimization.md
+++ b/docs/simd_optimization.md
@@ -9,6 +9,7 @@ This guide details the implementation of SIMD (Single Instruction, Multiple Data
 Profiling via [Tracy](profiling_tracy.md) revealed that `glTexSubImage2D` was a significant bottleneck during the loading phase, particularly for large HDR environment maps (4K resolution).
 
 - **Problem**: The OpenGL driver was performing the `Float32 -> Float16` conversion on the CPU using a scalar (single-value) path, leading to high CPU usage and stalling the main thread. See the detailed [Mesa F32-to-F16 Analysis](mesa_f32_to_f16_analysis.md) for a technical breakdown of this bottleneck.
+
 - **Goal**: Offload this conversion to optimized hardware vector instructions (AVX2/F16C) before handing the data to the driver, allowing `glTexSubImage2D` to perform a fast `memcpy`.
 
 ## Implementation
@@ -16,12 +17,15 @@ Profiling via [Tracy](profiling_tracy.md) revealed that `glTexSubImage2D` was a 
 The optimization is implemented in `src/simd_utils.c` and relies on x86-64 extensions:
 
 - **AVX2**: For processing 8 floats (256 bits) in parallel.
+
 - **F16C**: For the `_mm256_cvtps_ph` intrinsic, which converts a vector of 8 floats to 8 half-floats.
 
 ### Code Path
 
 1. **Check**: The build system determines if `__AVX2__` and `__F16C__` are available.
+
 2. **SIMD Path**: If available, the code processes pixels in batches of 8 using intrinsics.
+
 3. **Scalar Fallback**: For the remaining pixels ("tail") or on unsupported hardware, a scalar implementation `float_to_half_intrinsic` is used.
 
 ### Build System Configuration
@@ -33,6 +37,7 @@ option(ENABLE_NATIVE_ARCH "Enable native architecture optimizations" ON)
 if(ENABLE_NATIVE_ARCH)
     add_compile_options(-march=native -mavx2 -mf16c)
 endif()
+
 ```
 
 > [!IMPORTANT]
@@ -43,7 +48,9 @@ endif()
 ### Impact
 
 - **Before**: 4K HDR upload took **~112ms** (driver conversion).
+
 - **After**: 4K HDR upload takes **~35ms** (SIMD conversion + upload).
+
 - **Speedup**: **~3.2x** faster texture uploads.
 
 ### Memory Trade-off
@@ -51,7 +58,9 @@ endif()
 This optimization requires a temporary buffer to store the converted 16-bit data before upload.
 
 - **Ram Usage**: `Width * Height * 4 (RGBA) * 2 (Bytes)`
+
 - **Example**: A 4K texture (4096x2048) requires a **~64MB** temporary allocation.
+
 - **Rationale**: We trade transient RAM usage for significantly reduced CPU time to avoid frame stutters during loading.
 
 ## Verification
@@ -60,6 +69,7 @@ To verify the optimization is active at runtime, check the log output:
 
 ```text
 [INFO] simd_utils: SIMD Optimization: AVX2/F16C Enabled
+
 ```
 
 If you see `Software Fallback (No F16C/AVX)`, check your build flags and CPU capabilities (`lscpu | grep f16c`).

--- a/docs/skybox_rendering.md
+++ b/docs/skybox_rendering.md
@@ -1,16 +1,18 @@
-
 # Skybox Rendering Technique (Equirectangular)
 
 The engine uses direct **Equirectangular** mapping for the environment background. This is more memory-efficient as it avoids converting to and storing a generated cubemap.
 
-### Early-Z Optimization
+## Early-Z Optimization
+
 To maximize performance on integrated GPUs, the skybox is rendered **after** the scene objects.
 
-1.  **Vertex Shader**: Positions the skybox triangles exactly on the far plane (`z = 1.0`).
-2.  **Depth Test**: By using `glDepthFunc(GL_LEQUAL)`, the GPU automatically rejects skybox fragments that are occluded by 3D objects (like the icosphere) before launching the fragment shader.
-3.  **Fragment Shader**: Performs an inverse spherical projection to sample the 2D HDR texture.
+1. **Vertex Shader**: Positions the skybox triangles exactly on the far plane (`z = 1.0`).
 
-### Optimization Diagram
+2. **Depth Test**: By using `glDepthFunc(GL_LEQUAL)`, the GPU automatically rejects skybox fragments that are occluded by 3D objects (like the icosphere) before launching the fragment shader.
+
+3. **Fragment Shader**: Performs an inverse spherical projection to sample the 2D HDR texture.
+
+## Optimization Diagram
 
 ```graphviz
 digraph SkyboxZ {
@@ -69,6 +71,7 @@ digraph SkyboxZ {
   Test -> FS [label="Visible (Sky)"];
   Test -> Discard [label="Hidden (Object)"];
 }
+
 ```
 
 ```glsl
@@ -79,6 +82,7 @@ vec2 SampleEquirectangular(vec3 v) {
     uv *= invAtan;
     uv.x += 0.5;
     uv.y = 0.5 - uv.y;
+
     return uv;
 }
 
@@ -87,14 +91,16 @@ void skybox_main() {
     vec2 uv = SampleEquirectangular(dir);
     out_color_val = textureLod(environmentMap, uv, blur_lod);
 }
+
 ```
 
-### C Implementation (View Matrix)
+## C Implementation (View Matrix)
 
 We remove the **translation** component from the view matrix so the skybox appears infinitely far away (centered on the camera):
 
 ```c
 /* Copy view and strip translation to keep skybox at infinity */
+
 mat4 view_sky;
 glm_mat4_copy(view, view_sky);
 view_sky[3][0] = 0.0f;
@@ -102,9 +108,11 @@ view_sky[3][1] = 0.0f;
 view_sky[3][2] = 0.0f;
 
 /* Compute inverse view-projection for equirect sampling */
+
 mat4 inv_vp_sky;
 glm_mat4_mul(proj, view_sky, inv_vp_sky);
 glm_mat4_inv(inv_vp_sky, inv_vp_sky);
+
 ```
 
 ## 🔍 Technical Details
@@ -112,8 +120,10 @@ glm_mat4_inv(inv_vp_sky, inv_vp_sky);
 ### Mipmap Sampling
 
 Using `textureLod` with an equirectangular texture allows precise control over bluriness:
--   **LOD 0**: Sharp environment.
--   **LOD > 0**: Blurred environment (useful for PBR background or debugging).
+
+- **LOD 0**: Sharp environment.
+
+- **LOD > 0**: Blurred environment (useful for PBR background or debugging).
 
 ### Orientation Correction
 
@@ -124,7 +134,9 @@ The inversion `uv.y = 0.5 - uv.y` is crucial to map the "top" of the HDR image t
 ```c
 // Main render loop integration
 void render_scene_example(App* app) {
+
     // 1. View Matrix without translation
+
     mat4 view_sky;
     glm_mat4_copy(app->view, view_sky);
     view_sky[3][0] = 0.0f;
@@ -136,36 +148,46 @@ void render_scene_example(App* app) {
     glm_mat4_inv(inv_vp_sky, inv_vp_sky);
 
     // 2. Render via skybox module
+
     skybox_render(&app->skybox, app->skybox_shader,
                   app->hdr_texture, inv_vp_sky, app->env_lod);
 }
+
 ```
 
 ## 🌟 Advantages
 
-1.  **Performance**: No complex matrix math, just zeroing 3 floats.
-2.  **Simplicity**: Easy to understand and maintain.
-3.  **Robustness**: Standard industry technique.
-4.  **Quality**: Seamless infinite background.
+1. **Performance**: No complex matrix math, just zeroing 3 floats.
+
+2. **Simplicity**: Easy to understand and maintain.
+
+3. **Robustness**: Standard industry technique.
+
+4. **Quality**: Seamless infinite background.
 
 ## 📝 Important Notes
 
--   Use `glDepthFunc(GL_LEQUAL)` so the skybox is drawn at the back processing.
--   The skybox does not write significant depth.
--   The LOD (blur_lod) allows controlling the environment blur.
+- Use `glDepthFunc(GL_LEQUAL)` so the skybox is drawn at the back processing.
+
+- The skybox does not write significant depth.
+
+- The LOD (blur_lod) allows controlling the environment blur.
 
 ## 🔗 Python → C Equivalence
 
 ### Python (moderngl)
+
 ```python
 view_m = camera.matrix
 view_m[3][0] = 0
 view_m[3][1] = 0
 view_m[3][2] = 0
 inv_view_proj_sky = glm.inverse(projection_matrix * view_m)
+
 ```
 
 ### C (cglm)
+
 ```c
 mat4 view_m;
 glm_lookat(camera_pos, target, up, view_m);
@@ -176,6 +198,7 @@ view_m[3][2] = 0.0f;
 mat4 inv_view_proj_sky;
 glm_mat4_mul(proj_matrix, view_m, inv_view_proj_sky);
 glm_mat4_inv(inv_view_proj_sky, inv_view_proj_sky);
+
 ```
 
 **Perfectly equivalent!** ✅

--- a/docs/specular_aa.md
+++ b/docs/specular_aa.md
@@ -21,11 +21,11 @@ In the GGX/PBR model, the "roughness" parameter (\(r\)) is related to the varian
 To account for sub-pixel geometry variation (\(\sigma_g^2\)), we simply add the variances:
 
 \[
-\alpha_{total} = \alpha_{micro} + \sigma_g^2
+\alpha*{total} = \alpha*{micro} + \sigma_g^2
 \]
 
 \[
-\text{roughness}_{clamped} = \sqrt{\text{roughness}^2 + \sigma_g^2}
+\text{roughness}\_{clamped} = \sqrt{\text{roughness}^2 + \sigma_g^2}
 \]
 
 ## 3. Implementation Modes
@@ -42,8 +42,9 @@ Used for general meshes (`u_aaMode == 0`). It uses GPU derivatives (`dFdx`/`dFdy
 \sigma_g^2 = \text{SCALE} \cdot \max\left( \| \frac{\partial \mathbf{N}}{\partial x} \|^2, \| \frac{\partial \mathbf{N}}{\partial y} \|^2 \right)
 \]
 
-* **Pros**: Automatic, works on any mesh.
-* **Cons**: Hardware-dependent (derivatives vary between vendors), prone to spikes at silhouettes.
+- **Pros**: Automatic, works on any mesh.
+
+- **Cons**: Hardware-dependent (derivatives vary between vendors), prone to spikes at silhouettes.
 
 ### B. Curvature-Based Mode (Analytic)
 
@@ -55,15 +56,17 @@ Used for primitives with known analytic curvature, like the raytraced spheres (`
 \sigma_g^2 = \text{SCALE} \cdot \left( \frac{\text{pixelSizeWorld}}{\text{Radius}} \right)^2
 \]
 
-* **Pros**: Hardware-independent, perfectly stable at any distance, no silhouette spikes.
-* **Cons**: Requires explicit knowledge of the primitive's geometry.
+- **Pros**: Hardware-independent, perfectly stable at any distance, no silhouette spikes.
+
+- **Cons**: Requires explicit knowledge of the primitive's geometry.
 
 ## 4. Tuning Constants and Factors
 
 Found in `shaders/pbr_functions.glsl`:
 
 | Constant | Value | Description |
-| :--- | :--- | :--- |
+| :------- | :---- | :---------- |
+
 | `SCALE` | `50.0` | Global multiplier for variance. High value for extreme stability. |
 | `MAX_VARIANCE` | `0.1` | Caps the variance to prevent "exploding" roughness at silhouettes. |
 | `MIN_ROUGHNESS` | `0.04` | Hard floor for roughness to avoid numerical singularities and fireflies. |
@@ -75,5 +78,6 @@ When Specular AA increases the roughness, the **Multiple Scattering Compensation
 
 ## 6. Integration
 
-* **Billboards**: Use **Curvature-mode** by default for reference-level stability.
-* **Instanced**: Can use **Screen-Space mode** for general geometry, but currently defaults to a safe minimum roughness (\(0.04\)).
+- **Billboards**: Use **Curvature-mode** by default for reference-level stability.
+
+- **Instanced**: Can use **Screen-Space mode** for general geometry, but currently defaults to a safe minimum roughness (\(0.04\)).

--- a/docs/sphere_rendering.md
+++ b/docs/sphere_rendering.md
@@ -1,4 +1,3 @@
-
 # Sphere Rendering: Transparency and Analytic Anti-Aliasing
 
 This document details the "High Quality" rendering implementation for sphere instances (impostor billboards), including CPU sorting for correct transparency and an analytic anti-aliasing technique for perfect edges.
@@ -8,24 +7,35 @@ This document details the "High Quality" rendering implementation for sphere ins
 To correctly handle Transparency Alpha Blending (`GL_SRC_ALPHA`, `GL_ONE_MINUS_SRC_ALPHA`), objects must be drawn from furthest to closest (Back-to-Front) relative to the camera.
 
 ### SphereSorter Architecture
+
 The sorting system is encapsulated in the `sphere_sorting` module (`src/sphere_sorting.c`).
 
-1.  **Data**:
-    -   Instances (`SphereInstance`) are stored contiguously.
-    -   An intermediate structure `SphereSortEntry` contains `{ index, depth }` for each sphere.
-2.  **Algorithm**:
-    -   Each frame, the squared distance (`glm_vec3_distance2`) between the camera and each sphere is calculated.
-    -   Standard `qsort` is used to sort `SphereSortEntry` keys by descending depth (Back-to-Front).
-    -   A temporary sorted instance buffer is reconstructed.
-3.  **SIMD Optimization**:
-    -   Instance buffers are allocated via `aligned_alloc` with 64-byte alignment (`SIMD_ALIGNMENT`) to optimize memory access and enable potential AVX vectorization.
+1. **Data**:
+
+- Instances (`SphereInstance`) are stored contiguously.
+
+- An intermediate structure `SphereSortEntry` contains `{ index, depth }` for each sphere.
+
+1. **Algorithm**:
+
+- Each frame, the squared distance (`glm_vec3_distance2`) between the camera and each sphere is calculated.
+
+- Standard `qsort` is used to sort `SphereSortEntry` keys by descending depth (Back-to-Front).
+
+- A temporary sorted instance buffer is reconstructed.
+
+1. **SIMD Optimization**:
+
+- Instance buffers are allocated via `aligned_alloc` with 64-byte alignment (`SIMD_ALIGNMENT`) to optimize memory access and enable potential AVX vectorization.
 
 ### Rendering Pipeline
+
 If the `USE_TRANSPARENT_BILLBOARDS` macro is enabled and "Transparent" mode is active (Key `T`):
-1.  **Skybox Render** (First, depth write).
-2.  **CPU Sort** of spheres via `sphere_sorter_sort`.
-3.  **Upload** sorted data via `glBufferSubData`.
-4.  **Draw** spheres with Blending enabled and Depth Write **disabled** (Read-Only).
+
+1. **Skybox Render** (First, depth write).
+1. **CPU Sort** of spheres via `sphere_sorter_sort`.
+1. **Upload** sorted data via `glBufferSubData`.
+1. **Draw** spheres with Blending enabled and Depth Write **disabled** (Read-Only).
 
 ### Ray-Tracing Diagram
 
@@ -81,6 +91,7 @@ digraph SphereLogic {
   Hit -> Normal [label="Hit Found"];
   Normal -> Depth;
 }
+
 ```
 
 ---
@@ -90,6 +101,7 @@ digraph SphereLogic {
 The spheres are not real 3D geometry but **Impostors** (2D Billboards on a Quad). The exact sphere rendering is calculated mathematically for each pixel in the Fragment Shader (`pbr_ibl_billboard.frag`).
 
 ### The Aliasing Problem
+
 If we brutally "cut" the pixel when the ray misses the sphere (`discard` if `discriminant < 0`), we get very visible jagged edges (aliasing). MSAA does not work well here because to the GPU, it's a flat Quad.
 
 ### Solution: Discriminant Smoothing
@@ -99,11 +111,15 @@ If we brutally "cut" the pixel when the ray misses the sphere (`discard` if `dis
 ![Perfect AA: Pixel-Level Coverage Analysis](./images/sphere_perfect_aa_detail.jpg)
 
 The Ray-Sphere intersection equation gives a **discriminant** (Delta or h).
--   h > 0: Intersection (inside sphere).
--   h < 0: No intersection (outside sphere).
--   h approx 0: Exact sphere edge.
+
+- h > 0: Intersection (inside sphere).
+
+- h < 0: No intersection (outside sphere).
+
+- h approx 0: Exact sphere edge.
 
 To smooth the edge, we use the derivative of the distance function to estimate pixel coverage:
+
 ```glsl
 // Analytic intersection calculation
 float discriminant_val = b*b - c; // Discriminant
@@ -117,20 +133,29 @@ float edge_factor_val = smoothstep(0.0, fwidth(discriminant_val), discriminant_v
 
 // Apply this factor to alpha or final color
 out_color.a *= edge_factor_val;
+
 ```
+
 This `edge_factor_val` darkens (or makes transparent) pixels that straddle the mathematical edge of the sphere, producing **analytically perfect** anti-aliasing, independent of resolution.
 
 ---
 
 ## 3. Configuration & Macros
+
 The behavior is controlled by the `USE_TRANSPARENT_BILLBOARDS` macro defined in `include/app_settings.h` (automatically injected into shaders).
 
--   **"Legacy-Calculation" Mode (Macro undefined)**:
-    -   Opaque Rendering (Depth Test/Write ON).
-    -   No sorting.
-    -   Alpha used to store Luma (FXAA optimization).
--   **"Transparent-Rendering" Mode (Macro defined + Key T)**:
-    -   Transparent Rendering (Blend ON, Depth Write OFF).
-    -   Back-to-Front sort every frame.
-    -   Alpha used for opacity (True Transparency).
-    -   FXAA recalculates Luma from RGB.
+- **"Legacy-Calculation" Mode (Macro undefined)**:
+  - Opaque Rendering (Depth Test/Write ON).
+
+  - No sorting.
+
+  - Alpha used to store Luma (FXAA optimization).
+
+- **"Transparent-Rendering" Mode (Macro defined + Key T)**:
+  - Transparent Rendering (Blend ON, Depth Write OFF).
+
+  - Back-to-Front sort every frame.
+
+  - Alpha used for opacity (True Transparency).
+
+  - FXAA recalculates Luma from RGB.

--- a/docs/standalone_testing_mocking.md
+++ b/docs/standalone_testing_mocking.md
@@ -7,7 +7,9 @@ Cette documentation décrit la technique de tests "standalone" et de mocking uti
 L'objectif est de pouvoir tester une unité de code (un fichier `.c`) en isolation totale. Cela permet :
 
 - Une exécution instantanée (< 10ms).
+
 - Aucun besoin d'un contexte OpenGL valide ou de drivers GPU.
+
 - Une compatibilité parfaite avec les environnements CI restreints.
 
 ## 2. Technique de Mocking par "Shadowing"
@@ -20,10 +22,12 @@ Dans le fichier de test (ex: `tests/test_shader_path_security_standalone.c`), no
 
 ```c
 /* Mock OpenGL Definition */
+
 GLuint glCreateShader(GLenum type) {
     (void)type;
     return 1; // Retourne un faux ID
 }
+
 ```
 
 ### B. Inclusion Directe de l'Implémentation
@@ -32,29 +36,38 @@ Pour tester les fonctions privées (`static`) sans les exposer dans le header pu
 
 ```c
 /* 1. Mocks */
+
 void log_message(...) { /* no-op */ }
 
 /* 2. Target Implementation */
+
 #include "shader.c"
 
 /* 3. Tests */
+
 void test_logic() {
     // Appel d'une fonction static définie dans shader.c
     ASSERT_TRUE(get_dir_from_path(...));
 }
+
 ```
 
 ## 3. Avantages et Limites
 
 | Avantage | Description |
-| :--- | :--- |
+| :------- | :---------- |
+
 | **Accès Static** | Permet de tester 100% de la logique interne sans pollution d'API. |
+
 | **Vitesse** | Pas de lien dynamique lourd ou d'initialisation matérielle. |
+
 | **Zéro Dépendance** | Le binaire de test est "pure C". |
 
 | Limite | Précaution |
-| :--- | :--- |
+| :----- | :--------- |
+
 | **Collision de Symboles** | Ne peut pas être lié avec la vraie bibliothèque en même temps. |
+
 | **Maintenance** | Si l'API réelle change, le mock doit être synchronisé manuellement. |
 
 ## 4. Exemple Concret : Security Standalone
@@ -62,7 +75,9 @@ void test_logic() {
 Le test `tests/test_shader_path_security_standalone.c` démontre parfaitement cette approche :
 
 1. Il définit des stubs pour ~20 fonctions OpenGL.
+
 2. Il inclut `src/shader.c`.
+
 3. Il valide les algorithmes de `is_safe_path` et de gestion des buffers de chemins.
 
 > [!TIP]

--- a/docs/stencil_masking.md
+++ b/docs/stencil_masking.md
@@ -11,8 +11,10 @@ Separating background pixels from geometry is a common optimization in post-proc
 The buffer is cleared to `0` at the start of each frame.
 
 | Value | Meaning | Description |
-| :--- | :--- | :--- |
+| :---- | :------ | :---------- |
+
 | `0` | **Skybox / Background** | Background pixels (infinite distance). |
+
 | `1` | **Object / Geometry** | Main scene objects (Spheres, Billboards). |
 
 ## Technical Implementation
@@ -23,6 +25,7 @@ During the main rendering pass (`app_render`), the stencil test is enabled befor
 
 ```c
 /* Mark pixels where geometry is rendered with 1 */
+
 glEnable(GL_STENCIL_TEST);
 glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 glStencilFunc(GL_ALWAYS, 1, 0xFF);
@@ -31,6 +34,7 @@ glStencilMask(0xFF);
 /* Render Spheres/Billboards... */
 
 glDisable(GL_STENCIL_TEST);
+
 ```
 
 The skybox is rendered with the stencil test disabled (or after clearing), ensuring it remains at `0`.
@@ -50,12 +54,15 @@ if (enableChromAbbr && !isSkybox) {
 } else {
     color = getSceneSource(TexCoords);
 }
+
 ```
 
 ## Benefits
 
 1. **Optimization**: Expensive sampling (like Chromatic Aberration) is skipped for background pixels that often lack detail or are far away.
+
 2. **Visual Quality**: Prevents bleeding of background colors into foreground effects or vice-versa.
+
 3. **Flexibility**: Provides a cheap 1-bit mask that can be reused by multiple effects without extra textures.
 
 ## Debugging
@@ -63,4 +70,5 @@ if (enableChromAbbr && !isSkybox) {
 You can visualize the stencil mask by enabling the `POSTFX_STENCIL_DEBUG` flag (Toggle with **F6**). This will color the screen based on the stencil value:
 
 - **Black**: Skybox (0)
+
 - **White**: Objects (1)

--- a/docs/synchronization_overview.md
+++ b/docs/synchronization_overview.md
@@ -7,7 +7,9 @@ This document provides a high-level summary of how `suckless-ogl` handles asynch
 Modern high-performance rendering requires that the **Main Thread (Render Thread) never blocks**. Any operation that takes more than 1-2ms should be either:
 
 1. **Offloaded** to a background worker thread (for CPU/IO tasks).
+
 2. **Sliced** over multiple frames (for heavy GPU tasks).
+
 3. **Fenced** for non-blocking status checks (for CPU/GPU data transfers).
 
 ## Frame Scheduling & Task Interleaving
@@ -41,17 +43,23 @@ sequenceDiagram
 
     Note over M: Frame N starts
     M->>M: 1. Poll Async Loader (5ms)
+
     M->>M: 2. Update IBL Slice (10ms)
+
     par Parallel Execution
         W->>W: Background I/O & SH Projection
         M->>G: 3. Upload GI Probes (5ms)
+
     end
     M->>G: 4. Render Scene (15ms)
+
     M->>G: 5. Swap Buffers (5ms)
+
     Note over M: Frame N ends (~40ms)
 
     Note over M: Frame N+1 starts
     M->>M: Poll & Process...
+
 ```
 
 ### 1. Asynchronous CPU Workers
@@ -59,8 +67,10 @@ sequenceDiagram
 We use dedicated worker threads for tasks that don't require an OpenGL context.
 
 | Worker | Task | Sync Mechanism |
-| :--- | :--- | :--- |
+| :----- | :--- | :------------- |
+
 | **Async Loader** | I/O, Decoding, SIMD Conversion | Mutex + CondVar + PBO Handshake |
+
 | **GI Probe Worker** | SH Projection for Indirect Light | Mutex + TryLock (Main thread never waits) |
 
 ## 2. PBO-based GPU Transfers
@@ -70,12 +80,15 @@ All pixel data movement between CPU and GPU uses **Pixel Buffer Objects (PBOs)**
 ### Uploads (Textures)
 
 - **Double-Buffering**: Prevents the CPU from overwriting a buffer that the GPU is currently reading.
+
 - **Unsynchronized Mapping**: `GL_MAP_UNSYNCHRONIZED_BIT` is used to bypass internal driver checks, ensuring `glMapBufferRange` returns instantly.
 
 ### Readbacks (Measurements)
 
 - Used for: Auto-exposure (luminance), Histogram extraction, and Tracy screenshots.
+
 - **Fence Sync**: We insert a `glFenceSync` after the GPU command.
+
 - **Non-blocking poll**: We check the fence state using `glClientWaitSync` with a **0 timeout**. If the GPU isn't ready, we skip the update for that frame instead of blocking.
 
 ## 3. Progressive GPU Tasks (Slicing)
@@ -83,6 +96,7 @@ All pixel data movement between CPU and GPU uses **Pixel Buffer Objects (PBOs)**
 Some tasks cannot be offloaded to another thread because they require the primary OpenGL context. To avoid stalls, we split these tasks over multiple frames.
 
 - **IBL Generation**: Specular and Irradiance maps are generated slice-by-slice.
+
 - **Resource Initialization**: Texture allocation (`glTexImage2D`) and Mipmap generation are deferred into 3 steps to spread the cost.
 
 ## 4. Handling Driver Deadlocks
@@ -90,6 +104,7 @@ Some tasks cannot be offloaded to another thread because they require the primar
 Special care is taken for operations that trigger synchronous driver/OS handshakes.
 
 - **Fullscreen Toggle**: We call `glFinish()` to drain the GPU pipeline before switching modes, preventing a known deadlock on NVIDIA hardware where the mode-switch handshake stalls if the command queue is busy.
+
 - **Deferred Resize**: Instead of recreating FBOs inside the GLFW resize callback (which can be synchronous), we set a flag and perform the resize at the start of the next frame.
 
 ## 5. Performance Monitoring
@@ -101,6 +116,9 @@ The whole system is instrumented with **Tracy fibers**. This allows you to see e
 ### Related Documentation
 
 - [Async Loader Details](async_loader.md)
+
 - [PBO Strategy Deep-dive](async_pbo.md)
+
 - [Progressive IBL](progressive_ibl.md)
+
 - [Fullscreen Deadlock Analysis](fullscreen_deadlock.md)

--- a/docs/texture_optimization.md
+++ b/docs/texture_optimization.md
@@ -1,19 +1,28 @@
-
 # Texture Pipeline Optimization (Immutable Storage)
 
 ## 1. Problem: Mutable Storage
+
 The historical function `glTexImage2D`:
-1.  Allows resizing the texture at any time.
-2.  Allows changing the format (RGB -> RGBA) at any time.
-3.  **Consequence**: The driver must check the "completeness" of the texture *at every Draw Call*.
-4.  **Overhead**: Validation CPU cost.
+
+1. Allows resizing the texture at any time.
+
+2. Allows changing the format (RGB -> RGBA) at any time.
+
+3. **Consequence**: The driver must check the "completeness" of the texture _at every Draw Call_.
+
+4. **Overhead**: Validation CPU cost.
 
 ## 2. Solution: Immutable Storage
+
 Since OpenGL 4.2, `glTexStorage2D`:
-1.  Allocates all mipmap levels in one go.
-2.  Sizes and formats are frozen (Immutable).
-3.  Data is uploaded via `glTexSubImage2D`.
-4.  **Benefit**: The driver knows the texture is valid. No validation at Draw time.
+
+1. Allocates all mipmap levels in one go.
+
+2. Sizes and formats are frozen (Immutable).
+
+3. Data is uploaded via `glTexSubImage2D`.
+
+4. **Benefit**: The driver knows the texture is valid. No validation at Draw time.
 
 ## 3. Implementation in Engine
 
@@ -25,26 +34,35 @@ Since OpenGL 4.2, `glTexStorage2D`:
 
 // New Method (GOOD)
 // 1. Determine number of levels
+
 int levels = 1 + floor(log2(max(width, height)));
 
 // 2. Allocate storage (VRAM)
+
 glTexStorage2D(GL_TEXTURE_2D, levels, GL_RGBA8, width, height);
 
 // 3. Upload data
+
 glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
 
 // 4. Generate Mipmaps (Hardware)
+
 glGenerateMipmap(GL_TEXTURE_2D);
+
 ```
 
 ## 4. Alignment Constraint (Unpack Alignment)
+
 When `stb_image` loads an image with 3 channels (RGB), the rows may not be aligned to 4 bytes (standard OpenGL default).
-*   **Symptom**: Skewed or slanted image.
-*   **Fix**:
-    ```c
+
+- **Symptom**: Skewed or slanted image.
+
+- **Fix**:
+
+```c
     if (channels == 3) glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     else               glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-    ```
+```
 
 ## 5. Memory Layout Comparison
 
@@ -112,9 +130,13 @@ digraph TextureStorage {
     Sub1 -> Draw;
   }
 }
+
 ```
 
 ## 6. Performance Gains
--   Significantly reduced driver overhead.
--   Better memory locality (Mipmaps are often packed together).
--   Eliminates "Incomplete Texture" errors.
+
+- Significantly reduced driver overhead.
+
+- Better memory locality (Mipmaps are often packed together).
+
+- Eliminates "Incomplete Texture" errors.

--- a/docs/ui_batching_optimization.md
+++ b/docs/ui_batching_optimization.md
@@ -5,8 +5,11 @@ This document details the GPU-side optimizations implemented to reduce the rende
 ## The Problem: Draw Call Explosion
 
 Previously, every UI primitive (rect, text glyph, textured quad) was drawn using a dedicated OpenGL draw call. For the keyboard overlay, which consists of ~100 keys, each requiring:
+
 1. A base keycap (Textured)
+
 2. A focus glow (Procedural SDF)
+
 3. A label (Text)
 
 This resulted in **over 300 draw calls per frame**, causing the "UI" metric to spike above **2.0ms** on mid-range GPUs. Frequent state changes and `glBufferSubData` calls further exacerbated the issue.
@@ -18,17 +21,25 @@ The UI system was refactored to use a centralized batching mechanism in `src/ui.
 ### 1. Unified Vertex Layout
 
 All UI primitives now share a single `UIVertex` structure (12 floats), allowing different types of shapes to be packed into the same VBO:
+
 - `mode 0`: Solid Quads
+
 - `mode 1`: Text Glyphs (Grayscale sampling)
+
 - `mode 2`: Rounded Rects (SDF-based)
+
 - `mode 3`: Textured Quads (RGBA tinting)
+
 - `mode 5`: Procedural Neon Bloom/Glow
 
 ### 2. Intelligent Texture Tracking
 
 The `UIContext` now tracks the currently bound texture. When a drawing function is called:
+
 1. `prepare_batch` checks if the requested texture matches the current one.
+
 2. If not, the current batch is **flushed** (sent to GPU), and the new texture is bound.
+
 3. Primitives using the same texture (e.g., all characters in a long text string or all keycaps) are merged into a single `glDrawArrays` call.
 
 ### 3. Application-Side Pass Refactoring
@@ -36,15 +47,20 @@ The `UIContext` now tracks the currently bound texture. When a drawing function 
 In `app_ui.c`, the `draw_help_overlay_keys` function was re-organized into **three distinct passes** to maximize batching:
 
 - **Pass 1: Keycaps**: All keys draw their base texture. Since they all use `kbd_tex_key_base`, this results in **exactly 1 draw call**.
+
 - **Pass 2: Effects**: Active/Hovered keys draw their neon glow. These use procedural SDFs (mode 5) and no textures, resulting in **exactly 1 draw call**.
+
 - **Pass 3: Labels**: All key labels are drawn. Since they all use the common Font Atlas texture, this results in **exactly 1 draw call**.
 
 ## Bilan Final
 
 | Metric | Before Optimization | After Optimization | Improvement |
-| :--- | :--- | :--- | :--- |
+| :----- | :------------------ | :----------------- | :---------- |
+
 | **Draw Calls (Overlay)** | ~135 | **~4** | **33x Reduction** |
+
 | **GPU Time (Overlay)** | ~2.2ms | **~0.15ms** | **14x Faster** |
+
 | **CPU Overhead** | High (State thrashing) | Negligible | - |
 
 The UI is now extremely lean and no longer impacts the main rendering loop's performance, even on high-latency mobile or integrated GPUs.

--- a/docs/ui_visual_parameters.md
+++ b/docs/ui_visual_parameters.md
@@ -7,7 +7,8 @@ This document provides a technical and visual reference for the styling constant
 These constants define the behavior and core aesthetics of the Cyberpunk help overlay.
 
 | Constant | Value | Description |
-| :--- | :--- | :--- |
+| :------- | :---- | :---------- |
+
 | `HELP_BG_COLOR` | `{0.05, 0.05, 0.07}` | Deep midnight-blue color for the fullscreen overlay backdrop. |
 | `HELP_BG_ALPHA` | `0.88F` | Opacity of the backdrop. High enough to focus on UI, low enough to see scene motion. |
 | `PANEL_FRAME_ALPHA` | `0.72F` | Opacity of the `kbd_panel_frame.png` texture (scanlines and neon borders). |
@@ -18,7 +19,8 @@ These constants define the behavior and core aesthetics of the Cyberpunk help ov
 These values control how individual keys react to interaction and their binding state.
 
 | Constant | Value | Description |
-| :--- | :--- | :--- |
+| :------- | :---- | :---------- |
+
 | `KEY_COLOR_DEFAULT` | `{0.15, 0.15, 0.20}` | Base color for keys without any functional binding. |
 | `KEY_COLOR_TOGGLE` | `[Cyan]` | Binding color for On/Off features. |
 | `KEY_COLOR_CYCLE` | `[Green]` | Binding color for features that cycle through multiple states. |
@@ -37,34 +39,43 @@ graph LR
     A[Mouse over Key] --> B[Target Dim: 0.3]
     B --> C{Mouse leaves?}
     C -- Yes --> D[Wait 150ms]
+
     D -- Still Empty --> E[Target Dim: 1.0]
+
     D -- Enters New Key --> B
+
 ```
 
 | Constant | Value | Description |
-| :--- | :--- | :--- |
+| :------- | :---- | :---------- |
+
 | `GLOBAL_DIM_MAX_FALLOFF` | `0.70F` | How much current keyboard dims when a key is focused (1.0 - 0.7 = 0.3 alpha). |
+
 | `GLOBAL_DIM_SMOOTH_FACTOR` | `15.0F` | Speed of the exponential interpolation (dimming speed). |
 | `HOVER_DECAY_DURATION` | `0.15s` | **Crucial:** Grace period to prevent flickering when the mouse passes over gaps. |
+
 | `BLOOM_MAX_INTENSITY` | `0.50F` | Caps the additive glow intensity to prevent visual "burn-in" or oversaturation. |
 
 ## 4. Environment & Debug Overlays
 
 | Constant | Value | Description |
-| :--- | :--- | :--- |
+| :------- | :---- | :---------- |
+
 | `HISTO_BAR_COLOR_BLUE` | `[Blue]` | Color for the Primary/Averaged histogram data. |
 | `HISTO_BAR_COLOR_GREEN` | `[Green]` | Color for the normalized/target histogram data. |
 | `DEBUG_TEXT_Y_OFFSET` | `Font * 4` | Relative spacing for debug text lines to avoid overlap with window borders. |
+
 | `GRAPH_TEXT_PADDING` | `20.0F` | Interior padding for the exposure and histogram boxes. |
 
 ## 5. Loading & Animations
 
 | Constant | Value | Description |
-| :--- | :--- | :--- |
+| :------- | :---- | :---------- |
+
 | `UI_SPINNER_SPEED` | `10.0` | Rotation speed for the blue loading spinner (radians/sec). |
 | `UI_SPINNER_COLOR` | `[Cobalt Blue]` | Color of the spinning segments. |
 | `UI_CENTER_FACTOR` | `0.5F` | Generic coordinate multiplier to achieve center-alignment. |
 
 ---
 
-*Note: Most of these constants are `static const` in `src/app_ui.c` to maintain encapsulation, while base layout sizes (Padding, Key Size) are in `include/app_settings.h` for external accessibility.*
+_Note: Most of these constants are `static const` in `src/app_ui.c` to maintain encapsulation, while base layout sizes (Padding, Key Size) are in `include/app_settings.h` for external accessibility._

--- a/docs/visual_testing_artifacts.md
+++ b/docs/visual_testing_artifacts.md
@@ -8,16 +8,19 @@ The project CI (GitHub Actions) uses **Mesa llvmpipe**, a software-based OpenGL 
 
 ### 1. Floating Point Precision
 
-* **Bit-Level Parity**: Even with standard-compliant drivers, transcendental functions like `pow()`, `exp()`, `sin()`, and `cos()` vary slightly in their low-level implementation.
-* **Accumulated Errors**: In complex PBR shaders, these micro-discrepancies accumulate, leading to "salt and pepper" noise in difference maps.
+- **Bit-Level Parity**: Even with standard-compliant drivers, transcendental functions like `pow()`, `exp()`, `sin()`, and `cos()` vary slightly in their low-level implementation.
+
+- **Accumulated Errors**: In complex PBR shaders, these micro-discrepancies accumulate, leading to "salt and pepper" noise in difference maps.
 
 ### 2. The "Sphere Center" Artifact
 
 A common finding in our PBR tests is a concentric ring pattern at the center of spheres.
 
-* **Cause**: At the center of a sphere, the dot product **N · V** is exactly `1.0`.
-* **Sensitivity**: The BRDF LUT (Look-Up Table) is sampled using (**N · V**, **roughness**). Any tiny floating-point variation in the calculation of **N · V** or the texture sampling coordinates causes the hardware to pick a different pixel in the LUT than the software renderer.
-* **Result**: High-contrast deltas in the difference map, even if the visual change is imperceptible to the human eye.
+- **Cause**: At the center of a sphere, the dot product **N · V** is exactly `1.0`.
+
+- **Sensitivity**: The BRDF LUT (Look-Up Table) is sampled using (**N · V**, **roughness**). Any tiny floating-point variation in the calculation of **N · V** or the texture sampling coordinates causes the hardware to pick a different pixel in the LUT than the software renderer.
+
+- **Result**: High-contrast deltas in the difference map, even if the visual change is imperceptible to the human eye.
 
 ## PBR Engine Evolution
 
@@ -31,26 +34,33 @@ We implemented a compensation term for energy loss on rough surfaces. This incre
 
 To ensure portability across vendors, we replaced derivative-based smoothing (`fwidth`) with **Analytic Roughness Clamping** (`MIN_ROUGHNESS = 0.03`).
 
-* **Benefit**: Identical results on Intel, NVIDIA, and Mesa.
-* **Delta**: Reference images captured with older versions using `fwidth` will show significant edges deltas.
+- **Benefit**: Identical results on Intel, NVIDIA, and Mesa.
+
+- **Delta**: Reference images captured with older versions using `fwidth` will show significant edges deltas.
 
 ## Guidelines for Reference Updates
 
 When a Visual Regression Report shows failures:
 
 1. **Check the Difference Map**: If the deltas are concentrated at geometric edges or in smooth gradients (PBR centers), it is likely a precision delta.
+
 2. **Verify PR Intent**: If the PR modified PBR math or synchronization, a delta is expected.
+
 3. **Update Reference**: If the PR is visually correct but fails the automated threshold due to the reasons above, update the references in `tests/ref_*.png`.
-    * Run `GEN_REFS=1 .github/workflows/scripts/run_test_with_xvfb.sh build/tests/test_app` to regenerate all 6 faces locally.
-    * Commit the updated PNG files.
+   - Run `GEN_REFS=1 .github/workflows/scripts/run_test_with_xvfb.sh build/tests/test_app` to regenerate all 6 faces locally.
+
+   - Commit the updated PNG files.
 
 ## Multi-View (Cube) Regression
 
 To ensure full scene consistency, the engine captures 6 viewpoints around the origin `(0,0,0)`:
 
-* **Faces**: `front`, `back`, `left`, `right`, `top`, `bottom`.
-* **Camera Distance**: Fixed at `25.0` to cover the entire setup.
-* **Bootstrapping**: The system uses a specialized loop in `test_app.c` that can either compare frames (test mode) or write them (generation mode).
+- **Faces**: `front`, `back`, `left`, `right`, `top`, `bottom`.
+
+- **Camera Distance**: Fixed at `25.0` to cover the entire setup.
+
+- **Bootstrapping**: The system uses a specialized loop in `test_app.c` that can either compare frames (test mode) or write them (generation mode).
 
 ---
-*See also: [Shader Cross-GPU Compatibility](./shader-cross-gpu-compatibility.md)*
+
+_See also: [Shader Cross-GPU Compatibility](./shader-cross-gpu-compatibility.md)_

--- a/doxygen_resources/api_index.md
+++ b/doxygen_resources/api_index.md
@@ -5,19 +5,27 @@ Welcome to the technical API reference for **Suckless OGL**.
 This section is auto-generated from the C source code and provides:
 
 - **Files**: List of all source and header files.
+
 - **Globals**: Functions, variables, enumerations, and macros.
+
 - **Data Structures**: Structs and Unions.
+
 - **Dependency Graphs**: Visual representation of include graphs and call graphs.
 
 ## Navigation
 
 Use the **sidebar** (or the menu icon on mobile) to navigate through:
+
 - [Files](files.html)
+
 - [Data Structures](annotated.html)
+
 - [Globals](globals.html)
 
 ## Key Modules
 
 - **App**: The core application structure and main loop.
+
 - **Renderer**: PBR rendering pipeline and shader management.
+
 - **Scene**: Scene graph and object management.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
     - Photographic Standards: photographic_standards.md
     - Environment Transitions: env_transitions.md
     - Post-Process Optimizations (Feb 2026): postprocess_optimizations_2026-02.md
+    - Post-Process Optimizations (March 2026): postprocess_optimizations_2026-03.md
     - Motion Blur Analysis: motion_blur_analysis.md
     - Bloom Debugging: bloom_debug.md
   - "Controls & Input":


### PR DESCRIPTION
  PR: Refactoring de la Documentation et Standardisation de l'Outillage (Mars 2026)

 # Résumé
  Cette PR effectue un nettoyage complet de la documentation technique et met en place un pipeline de validation automatisé pour garantir la cohérence et la qualité des fichiers Markdown à l'avenir. Elle inclut
  également une analyse stratégique pour les futures optimisations GPU (Compute Shaders).


 # Changements
  Outillage et Qualité (Tooling)
   - Intégration markdownlint : Ajout d'un validateur de syntaxe Markdown dans les hooks de pre-commit.
   - Configuration .markdownlint.json : Définition des règles métier (désactivation de la limite de longueur de ligne, gestion sémantique de l'emphase).
   - Recettes Justfile :
   - just format-docs : Automatise le formatage via Prettier.
   - just lint-docs : Valide la conformité de tous les documents.
   - just lint-deps / just lint-clean : Gestion propre des dépendances pour le linter.


 # Refactoring Massif de la Documentation
   - Formatage Prettier : Normalisation de l'intégralité des fichiers .md (espacements, indentations de listes, blocs de code).
   - Corrections Manuelles : Résolution de centaines d'erreurs de syntaxe (MD022, MD032, MD046) pour satisfaire le linter.
   - Parité Justfile/Makefile : Synchronisation des recettes de build et de test pour garantir un workflow identique quel que soit l'outil utilisé.


 # Analyse Technique (Nouveau)
   - docs/postprocess_optimizations_2026-03.md : Analyse détaillée des gains potentiels liés au passage vers les Compute Shaders (Bloom SPD, Auto-Exposure) avec les leçons apprises sur le rendu mathématique
     ISO.


  # Comment valider ?
   - Vérifier le linter : Lancer just lint-docs (doit retourner Passed).
   - Tester le formatage : Lancer just format-docs (vérifier qu'aucun changement inattendu n'est produit par Prettier).
   - Consulter la nouvelle documentation : Lancer just docs-serve et vérifier l'indexation de l'analyse de Mars 2026.


  # Note technique
  Les sous-modules (deps/tracy et docs/doxygen-awesome-css) ont été explicitement préservés et nettoyés pour ne contenir aucune modification accidentelle liée aux scripts de formatage global.