### PR TITLE
refactor(billboard): reduce GL commands in Billboard_Sort_And_Render pass

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -211,8 +211,48 @@ test-gen-refs: build
 test-list:
     @{{distrobox}} ctest --test-dir {{build_dir}} -N 2>/dev/null | grep "Test #" | sed "s/.*: //"
 
-# Run UI integration test under Valgrind (Minimal scenario, Debug build for symbols)
+# Run simple UI integration test (Default Debug build)
 test-integration: build
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh {{build_dir}}/app
+
+# Run UI integration test on Release build
+test-integration-release: release
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh {{build_dir}}/app
+
+# Run UI integration test on Profile build (RelWithDebInfo)
+test-integration-profile: profile
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh build-profile/app
+
+# Run UI integration test with SSBO rendering enabled
+test-integration-ssbo: build-ssbo
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh build-ssbo/app
+
+# Run UI integration test on Ultra Release build (LTO, Unity, Aggressive Math)
+test-integration-ultra: ultra-release
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh build-ultra/app
+
+# Run UI integration test on Small build (MinSizeRel)
+test-integration-small: small
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh build-small/app
+
+# Run UI integration test on Synchronous Debug build
+test-integration-sync: build-sync
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh build-sync/app
+
+# Run UI integration test with Tracy enabled (Debug)
+test-integration-tracy: build-tracy
+    @chmod +x scripts/test_integration_generic.sh
+    @{{distrobox}} ./scripts/test_integration_generic.sh ./build-tracy/app
+
+# Run UI integration test under Valgrind (Minimal scenario, Debug build for symbols)
+test-integration-valgrind: build
     @{{distrobox}} chmod +x scripts/test_integration_valgrind.sh
     @{{distrobox}} bash scripts/test_integration_valgrind.sh
 

--- a/docs/billboard_gl_call_reduction.fr.md
+++ b/docs/billboard_gl_call_reduction.fr.md
@@ -78,17 +78,27 @@ API générique dans `include/gl_common.h` :
 
 Appliqué à `BillboardUBO` et `PostProcessUBO`.
 
-### Palier 3 — Bindings Persistants de Textures/Buffers (~21 appels économisés)
+### Palier 3 — Bindings Persistants SH Textures/SSBO (~15 appels économisés)
 
-**Statut : Planifié**
+**Statut : En cours**
 
-| Optimisation | Appels économisés |
-|-------------|-------------------|
-| Bind textures IBL une seule fois au chargement (pas par frame) | 6 |
-| Bind textures 3D SH une seule fois quand la probe grid change | 14 |
-| Bind SSBO probe une seule fois quand la probe grid change | 1 |
+| Optimisation | Appels économisés | Cachable ? |
+|-------------|-------------------|------------|
+| ~~Bind textures IBL une seule fois~~ | ~~6~~ | **NON** — units 0-2 clobbées par Skybox et PostProcess |
+| Bind textures 3D SH une seule fois quand probe grid change | 14 | **OUI** — units 8-14 exclusives aux passes PBR |
+| Bind SSBO probe une seule fois quand probe grid change | 1 | **OUI** — binding 3 exclusif aux passes PBR |
 
-Nécessite un flag "dirty" sur les mises à jour de la probe grid pour re-bind uniquement au changement.
+**Pourquoi les textures IBL ne peuvent PAS être cachées :**
+Dans un renderer multi-passe, les texture units 0-2 sont partagées :
+- `src/skybox.c` re-bind `GL_TEXTURE0` avec la cubemap d'environnement
+- `src/postprocess.c` re-bind les units 0-1-2 avec les FBO, bloom, etc.
+
+Cacher ces bindings nécessiterait un tracker d'état GL centralisé (over-engineering).
+Les textures SH (units 8-14) et le SSBO probe (binding 3) sont sûrs car aucune
+autre passe ne touche ces units/bindings.
+
+**Invalidation :** après `light_probe_grid_sync()` qui appelle `glBindTexture(GL_TEXTURE_3D, 0)`
+sur l'unité active courante, pouvant écraser un binding SH caché.
 
 ### Palier 4 — Lecture Directe SSBO dans le Vertex Shader (~7 appels économisés)
 
@@ -113,8 +123,8 @@ SphereInstance inst = instances[gl_InstanceID];
 | Base | — | — | **~65** |
 | Palier 1 | Trivial | 5 | ~60 |
 | Palier 2 (UBO) | Moyen | 11 | ~49 |
-| Palier 3 (Persistant) | Moyen | 21 | **~28** |
-| Palier 4 (SSBO direct) | Moyen-Haut | 7 | **~21** |
+| Palier 3 (SH/SSBO) | Moyen | 15 | **~34** |
+| Palier 4 (SSBO direct) | Moyen-Haut | 7 | **~27** |
 
 ## Fichiers Concernés
 

--- a/docs/billboard_gl_call_reduction.fr.md
+++ b/docs/billboard_gl_call_reduction.fr.md
@@ -11,19 +11,19 @@ Ce document suit le plan d'optimisation par paliers et son état d'implémentati
 
 ## Décomposition Actuelle (~65 appels)
 
-| Phase | Appels | Détail |
-|-------|--------|--------|
-| Compute sort | 12 | `bufferSubData`, `useProgram`, 3 uniforms, 3 SSBO binds, dispatch, barrier |
-| Copie buffer SSBO→VBO | 7 | bind source/dest, copie, 2× unbind défensifs |
-| État blend | 3 | `glEnablei`, `glBlendFunc`, `glDisablei` |
-| `glUseProgram` | 1 | `pbr_ibl_billboard` |
-| Textures IBL | 6 | 3× (`glActiveTexture` + `glBindTexture`) |
-| Uniforms samplers | 3 | **Redondant** — `layout(binding=0/1/2)` déjà défini dans le shader |
-| Uniforms par frame | ~12 | projection, view, prevVP, camPos, screenSize, debugMode, params GI |
-| Textures SH (GI) | 14 | 7× (`glActiveTexture` + `glBindTexture3D`) |
-| SSBO probe | 1 | `glBindBufferBase` |
-| VAO + draw | 3 | `glBindVertexArray`, `glDisable(GL_CULL_FACE)`, `glDrawArraysInstanced` |
-| Nettoyage | ~3 | unbind VAO, restaurer cull, désactiver blend |
+| Phase                  | Appels | Détail                                                                        |
+| :--------------------- | :----- | :---------------------------------------------------------------------------- |
+| Compute sort           | 12     | `bufferSubData`, `useProgram`, 3 uniforms, 3 SSBO binds, dispatch, barrier      |
+| Copie buffer SSBO→VBO  | 7      | bind source/dest, copie, 2× unbind défensifs                                   |
+| État blend             | 3      | `glEnablei`, `glBlendFunc`, `glDisablei`                                       |
+| `glUseProgram`         | 1      | `pbr_ibl_billboard`                                                            |
+| Textures IBL           | 6      | 3× (`glActiveTexture` + `glBindTexture`)                                       |
+| Uniforms samplers      | 3      | **Redondant** — `layout(binding=0/1/2)` déjà défini dans le shader             |
+| Uniforms par frame     | ~12    | projection, view, prevVP, camPos, screenSize, debugMode, params GI             |
+| Textures SH (GI)       | 14     | 7× (`glActiveTexture` + `glBindTexture3D`)                                     |
+| SSBO probe             | 1      | `glBindBufferBase`                                                             |
+| VAO + draw             | 3      | `glBindVertexArray`, `glDisable(GL_CULL_FACE)`, `glDrawArraysInstanced`        |
+| Nettoyage              | ~3     | unbind VAO, restaurer cull, désactiver blend                                  |
 
 ## Paliers d'Optimisation
 
@@ -38,12 +38,11 @@ Ce document suit le plan d'optimisation par paliers et son état d'implémentati
 
 Total : **5 appels économisés**. Validé dans RenderDoc : 64 → 59 commandes.
 
-### Palier 2 — UBO pour les Uniforms Par Frame (~12 appels → 2)
+### Palier 2 — AZDO Persistent Mapping pour le Billboard UBO
 
-**Statut : Terminé** ✅
+**Statut : Terminé** ✅ (Amélioré depuis `glBufferSubData`)
 
-Remplacement des ~12 appels `glUniform*` individuels par un seul upload **Uniform Buffer Object**
-(`glBufferSubData` + `glBindBuffer`), suivant le pattern `PostProcessUBO` existant.
+Initialement, nous avons remplacé ~12 appels `glUniform*` individuels par un seul UBO. Nous avons depuis amélioré cela vers du **AZDO Persistent Mapping**. L'UBO est désormais alloué avec `glBufferStorage` et mappé dans la mémoire CPU une seule fois. Les mises à jour se font via un simple `memcpy`.
 
 **Côté GLSL** — nouveau fichier partagé `shaders/billboard_ubo.glsl` :
 
@@ -72,33 +71,23 @@ d'uniforms sont protégées par `#ifndef HAS_BILLBOARD_UBO` pour que le pipeline
 `glm_mat4_copy` de cglm utilise AVX `_mm256_store_ps` (alignement 32 octets requis).
 API générique dans `include/gl_common.h` :
 
-- `GL_UBO_ALIGNMENT` — constante (32)
 - `GL_UBO_ALIGNED` — attribut `__attribute__((aligned(32)))` pour typedef
 - `GL_ASSERT_UBO_ALIGNMENT(type)` — `_Static_assert` compile-time
 
 Appliqué à `BillboardUBO` et `PostProcessUBO`.
 
-### Palier 3 — Bindings Persistants SH Textures/SSBO (~15 appels économisés)
+### Palier 3 — Bindings Persistants SH/IBL Textures & SSBO (~21 appels économisés)
 
-**Statut : En cours**
+**Statut : Terminé** ✅
 
-| Optimisation | Appels économisés | Cachable ? |
-|-------------|-------------------|------------|
-| ~~Bind textures IBL une seule fois~~ | ~~6~~ | **NON** — units 0-2 clobbées par Skybox et PostProcess |
-| Bind textures 3D SH une seule fois quand probe grid change | 14 | **OUI** — units 8-14 exclusives aux passes PBR |
-| Bind SSBO probe une seule fois quand probe grid change | 1 | **OUI** — binding 3 exclusif aux passes PBR |
+| Optimisation | Appels économisés | Statut |
+|-------------|-------------------|--------|
+| Bind textures IBL une seule fois (Units 15-17) | 6 | **Terminé** |
+| Bind textures 3D SH une seule fois (Units 8-14) | 14 | **Terminé** |
+| Bind SSBO probe une seule fois (Binding 3) | 1 | **Terminé** |
 
-**Pourquoi les textures IBL ne peuvent PAS être cachées :**
-Dans un renderer multi-passe, les texture units 0-2 sont partagées :
-- `src/skybox.c` re-bind `GL_TEXTURE0` avec la cubemap d'environnement
-- `src/postprocess.c` re-bind les units 0-1-2 avec les FBO, bloom, etc.
-
-Cacher ces bindings nécessiterait un tracker d'état GL centralisé (over-engineering).
-Les textures SH (units 8-14) et le SSBO probe (binding 3) sont sûrs car aucune
-autre passe ne touche ces units/bindings.
-
-**Invalidation :** après `light_probe_grid_sync()` qui appelle `glBindTexture(GL_TEXTURE_3D, 0)`
-sur l'unité active courante, pouvant écraser un binding SH caché.
+**Stratégie de Cache IBL :**
+En déplaçant les samplers IBL vers des unités hautes dédiées (15, 16, 17), nous garantissons qu'ils ne sont pas écrasés par les passes Skybox ou PostProcess. Nous utilisons désormais un cache de binding dans la structure `Scene` pour éliminer tous les appels `glActiveTexture` et `glBindTexture` par frame pour le rendu PBR.
 
 ### Palier 4 — Lecture Directe SSBO dans le Vertex Shader (~3 appels économisés)
 
@@ -156,20 +145,33 @@ La copie VBO legacy est conservée uniquement pour l'overlay wireframe debug.
 
 **Appels économisés :**
 
-| Mode de tri | Supprimés | Ajoutés | Net |
-|-------------|----------|---------|-----|
-| GPU bitonic (défaut) | 3 (bind read, bind write, copy) | 0 | **-3** |
-| CPU qsort/radix | 3 | 1 (`glBindBufferBase` dans sort) | **-2** |
+| Mode de tri          | Supprimés                        | Ajoutés                          | Net    |
+| :------------------- | :------------------------------- | :------------------------------- | :----- |
+| GPU bitonic (défaut) | 3 (bind read, bind write, copy)  | 0                                | **-3** |
+| CPU qsort/radix      | 3                                | 1 (`glBindBufferBase` dans sort) | **-2** |
 
 ## Résultats Projetés
 
-| Palier | Effort | Appels économisés | Restants |
-|--------|--------|-------------------|----------|
-| Base | — | — | **~65** |
-| Palier 1 | Trivial | 5 | ~60 |
-| Palier 2 (UBO) | Moyen | 11 | ~49 |
-| Palier 3 (SH/SSBO) | Moyen | 15 | **~34** |
-| Palier 4 (SSBO direct) | Moyen | 3 | **~31** |
+| Palier                 | Effort | Appels économisés | Restants |
+| :--------------------- | :----- | :---------------- | :------- |
+| Base                   | —      | —                 | **~65**  |
+| Palier 1               | Trivial| 5                 | ~60      |
+| Palier 2 (UBO)         | Moyen  | 11                | ~49      |
+| Palier 3 (SH/SSBO)     | Moyen  | 15                | **~34**  |
+| Palier 4 (SSBO direct) | Moyen  | 3                 | ~31      |
+| Palier 5 (Nettoyage)   | Faible | ~8                | **~23**  |
+
+### Palier 5 — Suppression des Unbinds Défensifs (~8+ appels économisés)
+
+**Statut : Terminé** ✅
+
+Suppression de tous les appels redondants `glBindVertexArray(0)` et `glBindBuffer(..., 0)` des chemins chauds (hot paths). Dans un pipeline OpenGL moderne, l'état est simplement écrasé par le prochain bind, faisant de ces appels de "nettoyage" un gaspillage significatif de cycles CPU.
+
+**Modules affectés :**
+- Rendu Billboard & Instancié
+- Rendu SSBO
+- Post-process & Skybox
+- UI & FX LUT Viz
 
 ## Analyse de Régression de Performance
 
@@ -254,6 +256,6 @@ intermédiaires.
 | `shaders/pbr_ibl_billboard.vert` | Vertex shader — fetch SSBO via `gl_InstanceID` |
 | `shaders/pbr_ibl_billboard.frag` | Fragment shader — inclut `billboard_ubo.glsl` |
 | `shaders/sh_probe.glsl` | Uniforms SH probe — gardé par `#ifndef HAS_BILLBOARD_UBO` |
-| `include/scene.h` | Struct `BillboardUBO` + `BillboardUniforms` (samplers SH uniquement) |
+| `include/scene.h` | `BillboardUBO` struct + `BillboardUniforms` (samplers SH uniquement) |
 | `include/gl_common.h` | API générique `GL_UBO_ALIGNED` / `GL_ASSERT_UBO_ALIGNMENT` |
 | `include/postprocess.h` | `PostProcessUBO` — garde d'alignement appliquée |

--- a/docs/billboard_gl_call_reduction.fr.md
+++ b/docs/billboard_gl_call_reduction.fr.md
@@ -1,0 +1,117 @@
+# Passe Billboard — Réduction des Appels GL
+
+## Contexte
+
+La passe `Billboard_Sort_And_Render`, observée dans RenderDoc, émet **~65 commandes GL**
+avant et incluant l'appel `glDrawArraysInstanced`. La majorité sont de la configuration
+de pipeline (uniforms, binds de textures, modes de blend, copies de buffers) qui peut être
+drastiquement réduite.
+
+Ce document suit le plan d'optimisation par paliers et son état d'implémentation.
+
+## Décomposition Actuelle (~65 appels)
+
+| Phase | Appels | Détail |
+|-------|--------|--------|
+| Compute sort | 12 | `bufferSubData`, `useProgram`, 3 uniforms, 3 SSBO binds, dispatch, barrier |
+| Copie buffer SSBO→VBO | 7 | bind source/dest, copie, 2× unbind défensifs |
+| État blend | 3 | `glEnablei`, `glBlendFunc`, `glDisablei` |
+| `glUseProgram` | 1 | `pbr_ibl_billboard` |
+| Textures IBL | 6 | 3× (`glActiveTexture` + `glBindTexture`) |
+| Uniforms samplers | 3 | **Redondant** — `layout(binding=0/1/2)` déjà défini dans le shader |
+| Uniforms par frame | ~12 | projection, view, prevVP, camPos, screenSize, debugMode, params GI |
+| Textures SH (GI) | 14 | 7× (`glActiveTexture` + `glBindTexture3D`) |
+| SSBO probe | 1 | `glBindBufferBase` |
+| VAO + draw | 3 | `glBindVertexArray`, `glDisable(GL_CULL_FACE)`, `glDrawArraysInstanced` |
+| Nettoyage | ~3 | unbind VAO, restaurer cull, désactiver blend |
+
+## Paliers d'Optimisation
+
+### Palier 1 — Trivial, Aucun Changement Shader (~5 appels économisés)
+
+**Statut : En cours**
+
+| Optimisation | Appels économisés | Risque |
+|-------------|-------------------|--------|
+| Supprimer 3× `glUniform1i` pour les samplers (déjà `layout(binding=X)` en GLSL) | 3 | Aucun |
+| Supprimer 2× unbind défensifs après `glCopyBufferSubData` | 2 | Aucun |
+
+Total : **~5 appels économisés** (sous-ensemble conservatif et sûr).
+
+### Palier 2 — UBO pour les Uniforms Par Frame (~12 appels → 1)
+
+**Statut : Planifié**
+
+Remplacer les appels `glUniform*` individuels par un seul **Uniform Buffer Object**, suivant
+le pattern `PostProcessUBO` existant dans `src/postprocess.c`.
+
+```c
+typedef struct {
+    mat4 projection;        // offset 0
+    mat4 view;              // offset 64
+    mat4 previousViewProj;  // offset 128
+    vec3 camPos;            // offset 192
+    int  debugMode;         // offset 204
+    vec2 screenSize;        // offset 208
+    vec2 _pad0;             // offset 216 (alignement std140)
+    vec3 probeGridMin;      // offset 224
+    int  giMode;            // offset 236
+    vec3 probeGridMax;      // offset 240
+    int  specularAAEnabled; // offset 252
+    ivec3 probeGridDim;     // offset 256
+    int   aaMode;           // offset 268
+} BillboardUBO;
+```
+
+Un seul `glBufferSubData` + `glBindBufferBase` remplace ~12 appels individuels.
+
+### Palier 3 — Bindings Persistants de Textures/Buffers (~21 appels économisés)
+
+**Statut : Planifié**
+
+| Optimisation | Appels économisés |
+|-------------|-------------------|
+| Bind textures IBL une seule fois au chargement (pas par frame) | 6 |
+| Bind textures 3D SH une seule fois quand la probe grid change | 14 |
+| Bind SSBO probe une seule fois quand la probe grid change | 1 |
+
+Nécessite un flag "dirty" sur les mises à jour de la probe grid pour re-bind uniquement au changement.
+
+### Palier 4 — Lecture Directe SSBO dans le Vertex Shader (~7 appels économisés)
+
+**Statut : Planifié**
+
+Éliminer la copie `glCopyBufferSubData` SSBO→VBO en lisant les instances triées
+directement via `gl_InstanceID` depuis le SSBO dans le vertex shader.
+
+```glsl
+// Dans pbr_ibl_billboard.vert — remplacer les attributs par instance par un fetch SSBO
+layout(std430, binding = 2) readonly buffer SortedInstances {
+    SphereInstance instances[];
+};
+// ...
+SphereInstance inst = instances[gl_InstanceID];
+```
+
+## Résultats Projetés
+
+| Palier | Effort | Appels économisés | Restants |
+|--------|--------|-------------------|----------|
+| Base | — | — | **~65** |
+| Palier 1 | Trivial | 5 | ~60 |
+| Palier 2 (UBO) | Moyen | 11 | ~49 |
+| Palier 3 (Persistant) | Moyen | 21 | **~28** |
+| Palier 4 (SSBO direct) | Moyen-Haut | 7 | **~21** |
+
+## Fichiers Concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `src/scene.c` | `scene_render_billboards()` — setup uniforms, bind textures |
+| `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — copie SSBO→VBO |
+| `src/billboard_rendering.c` | `billboard_group_draw()` — bind VAO, état cull, draw call |
+| `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — dispatch compute |
+| `shaders/pbr_ibl_billboard.vert` | Vertex shader — `layout(binding)` explicite |
+| `shaders/pbr_ibl_billboard.frag` | Fragment shader — `layout(binding=0/1/2)` pour IBL |
+| `shaders/sh_probe.glsl` | Uniforms et bindings textures SH probe |
+| `include/scene.h` | Définition struct `BillboardUniforms` |

--- a/docs/billboard_gl_call_reduction.fr.md
+++ b/docs/billboard_gl_call_reduction.fr.md
@@ -29,41 +29,54 @@ Ce document suit le plan d'optimisation par paliers et son état d'implémentati
 
 ### Palier 1 — Trivial, Aucun Changement Shader (~5 appels économisés)
 
-**Statut : En cours**
+**Statut : Terminé** ✅
 
 | Optimisation | Appels économisés | Risque |
 |-------------|-------------------|--------|
 | Supprimer 3× `glUniform1i` pour les samplers (déjà `layout(binding=X)` en GLSL) | 3 | Aucun |
 | Supprimer 2× unbind défensifs après `glCopyBufferSubData` | 2 | Aucun |
 
-Total : **~5 appels économisés** (sous-ensemble conservatif et sûr).
+Total : **5 appels économisés**. Validé dans RenderDoc : 64 → 59 commandes.
 
-### Palier 2 — UBO pour les Uniforms Par Frame (~12 appels → 1)
+### Palier 2 — UBO pour les Uniforms Par Frame (~12 appels → 2)
 
-**Statut : Planifié**
+**Statut : Terminé** ✅
 
-Remplacer les appels `glUniform*` individuels par un seul **Uniform Buffer Object**, suivant
-le pattern `PostProcessUBO` existant dans `src/postprocess.c`.
+Remplacement des ~12 appels `glUniform*` individuels par un seul upload **Uniform Buffer Object**
+(`glBufferSubData` + `glBindBuffer`), suivant le pattern `PostProcessUBO` existant.
 
-```c
-typedef struct {
-    mat4 projection;        // offset 0
-    mat4 view;              // offset 64
-    mat4 previousViewProj;  // offset 128
-    vec3 camPos;            // offset 192
-    int  debugMode;         // offset 204
-    vec2 screenSize;        // offset 208
-    vec2 _pad0;             // offset 216 (alignement std140)
-    vec3 probeGridMin;      // offset 224
-    int  giMode;            // offset 236
-    vec3 probeGridMax;      // offset 240
-    int  specularAAEnabled; // offset 252
-    ivec3 probeGridDim;     // offset 256
-    int   aaMode;           // offset 268
-} BillboardUBO;
+**Côté GLSL** — nouveau fichier partagé `shaders/billboard_ubo.glsl` :
+
+```glsl
+layout(std140, binding = 1) uniform BillboardBlock {
+    mat4 projection;
+    mat4 view;
+    mat4 previousViewProj;
+    vec3 camPos;      int debugMode;
+    vec2 u_screenSize; vec2 _bb_pad0;
+    vec3 u_ProbeGridMin; int u_GIMode;
+    vec3 u_ProbeGridMax; int u_specularAAEnabled;
+    ivec3 u_ProbeGridDim; int u_aaMode;
+    vec3 u_GridToIdxScale; float _bb_pad1;
+};
 ```
 
-Un seul `glBufferSubData` + `glBindBufferBase` remplace ~12 appels individuels.
+**Côté C** — struct `BillboardUBO` dans `include/scene.h`, alignée `std140`.
+
+**Garde conditionnelle** dans `shaders/sh_probe.glsl` — les déclarations individuelles
+d'uniforms sont protégées par `#ifndef HAS_BILLBOARD_UBO` pour que le pipeline instancié
+(qui n'utilise PAS l'UBO) continue à fonctionner.
+
+#### Sécurité d'Alignement UBO
+
+`glm_mat4_copy` de cglm utilise AVX `_mm256_store_ps` (alignement 32 octets requis).
+API générique dans `include/gl_common.h` :
+
+- `GL_UBO_ALIGNMENT` — constante (32)
+- `GL_UBO_ALIGNED` — attribut `__attribute__((aligned(32)))` pour typedef
+- `GL_ASSERT_UBO_ALIGNMENT(type)` — `_Static_assert` compile-time
+
+Appliqué à `BillboardUBO` et `PostProcessUBO`.
 
 ### Palier 3 — Bindings Persistants de Textures/Buffers (~21 appels économisés)
 
@@ -107,11 +120,14 @@ SphereInstance inst = instances[gl_InstanceID];
 
 | Fichier | Rôle |
 |---------|------|
-| `src/scene.c` | `scene_render_billboards()` — setup uniforms, bind textures |
+| `src/scene.c` | `scene_render_billboards()` — upload UBO, bind textures |
 | `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — copie SSBO→VBO |
 | `src/billboard_rendering.c` | `billboard_group_draw()` — bind VAO, état cull, draw call |
 | `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — dispatch compute |
-| `shaders/pbr_ibl_billboard.vert` | Vertex shader — `layout(binding)` explicite |
-| `shaders/pbr_ibl_billboard.frag` | Fragment shader — `layout(binding=0/1/2)` pour IBL |
-| `shaders/sh_probe.glsl` | Uniforms et bindings textures SH probe |
-| `include/scene.h` | Définition struct `BillboardUniforms` |
+| `shaders/billboard_ubo.glsl` | **Nouveau** — définition bloc UBO partagé (`binding = 1`) |
+| `shaders/pbr_ibl_billboard.vert` | Vertex shader — inclut `billboard_ubo.glsl` |
+| `shaders/pbr_ibl_billboard.frag` | Fragment shader — inclut `billboard_ubo.glsl` |
+| `shaders/sh_probe.glsl` | Uniforms SH probe — gardé par `#ifndef HAS_BILLBOARD_UBO` |
+| `include/scene.h` | Struct `BillboardUBO` + `BillboardUniforms` (samplers SH uniquement) |
+| `include/gl_common.h` | API générique `GL_UBO_ALIGNED` / `GL_ASSERT_UBO_ALIGNMENT` |
+| `include/postprocess.h` | `PostProcessUBO` — garde d'alignement appliquée |

--- a/docs/billboard_gl_call_reduction.fr.md
+++ b/docs/billboard_gl_call_reduction.fr.md
@@ -100,21 +100,66 @@ autre passe ne touche ces units/bindings.
 **Invalidation :** après `light_probe_grid_sync()` qui appelle `glBindTexture(GL_TEXTURE_3D, 0)`
 sur l'unité active courante, pouvant écraser un binding SH caché.
 
-### Palier 4 — Lecture Directe SSBO dans le Vertex Shader (~7 appels économisés)
+### Palier 4 — Lecture Directe SSBO dans le Vertex Shader (~3 appels économisés)
 
-**Statut : Planifié**
+**Statut : Terminé** ✅
 
-Éliminer la copie `glCopyBufferSubData` SSBO→VBO en lisant les instances triées
+Élimine la copie `glCopyBufferSubData` SSBO→VBO en lisant les instances triées
 directement via `gl_InstanceID` depuis le SSBO dans le vertex shader.
 
+**Insight clé :** le tri GPU binde déjà `sorted_instance_ssbo` au point de binding 2
+via `glBindBufferBase`. Après le compute shader, `glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0)`
+ne débinde que la cible générique — PAS le point de binding indexé. Donc binding 2 reste valide.
+
+Pour les chemins CPU sort (qsort, radix), un seul `glBindBufferBase(binding 2, instance_ssbo)`
+est ajouté à la fin de `upload_sorted_to_ssbo()` pour correspondre à la convention du tri GPU.
+
+**Côté GLSL** — nouvel include partagé `shaders/billboard_instance_ssbo.glsl` :
+
 ```glsl
-// Dans pbr_ibl_billboard.vert — remplacer les attributs par instance par un fetch SSBO
-layout(std430, binding = 2) readonly buffer SortedInstances {
-    SphereInstance instances[];
+struct SphereInstance {
+    mat4 model;
+    vec3 albedo;
+    float metallic;
+    float roughness;
+    float ao;
+    float padding;
+    float _pad[9];  // Correspondre au stride C 128 octets (SIMD_ALIGNMENT=64)
 };
-// ...
-SphereInstance inst = instances[gl_InstanceID];
+
+layout(std430, binding = 2) readonly buffer BillboardInstanceSSBO {
+    SphereInstance billboard_instances[];
+};
 ```
+
+**Vertex shader** — `shaders/pbr_ibl_billboard.vert` récupère les données par instance
+via `gl_InstanceID` au lieu d'attributs de vertex instantiés :
+
+```glsl
+// Avant (attributs vertex) :
+layout(location = 2) in mat4 i_model;
+layout(location = 6) in vec3 i_albedo;
+layout(location = 7) in vec3 i_pbr;
+
+// Après (fetch SSBO) :
+SphereInstance inst = billboard_instances[gl_InstanceID];
+float scaleX = length(vec3(inst.model[0]));
+Albedo = inst.albedo;
+Metallic = inst.metallic;  // Accès direct, pas de packing vec3
+```
+
+**Côté C** — Dans `src/scene.c`, l'appel `billboard_group_update_from_buffer()` est supprimé
+entièrement (conservé uniquement pour le wireframe debug). Aucun `glBindBufferBase` supplémentaire
+nécessaire dans le chemin GPU sort — binding 2 est déjà établi par le dispatch compute.
+
+La copie VBO legacy est conservée uniquement pour l'overlay wireframe debug.
+
+**Appels économisés :**
+
+| Mode de tri | Supprimés | Ajoutés | Net |
+|-------------|----------|---------|-----|
+| GPU bitonic (défaut) | 3 (bind read, bind write, copy) | 0 | **-3** |
+| CPU qsort/radix | 3 | 1 (`glBindBufferBase` dans sort) | **-2** |
 
 ## Résultats Projetés
 
@@ -124,18 +169,89 @@ SphereInstance inst = instances[gl_InstanceID];
 | Palier 1 | Trivial | 5 | ~60 |
 | Palier 2 (UBO) | Moyen | 11 | ~49 |
 | Palier 3 (SH/SSBO) | Moyen | 15 | **~34** |
-| Palier 4 (SSBO direct) | Moyen-Haut | 7 | **~27** |
+| Palier 4 (SSBO direct) | Moyen | 3 | **~31** |
+
+## Analyse de Régression de Performance
+
+### Compromis du Palier 4 : Input Assembler vs Lecture SSBO
+
+Le Palier 4 remplace le chemin traditionnel **Input Assembler matériel** (attributs vertex
+par instance via VBO + `glVertexAttribDivisor`) par une **lecture SSBO manuelle** dans le
+vertex shader (`billboard_instances[gl_InstanceID]`).
+
+C'est un compromis architectural délibéré :
+
+| Aspect | Avant (VBO + IA) | Après (lecture SSBO) |
+|--------|-------------------|----------------------|
+| Chemin de données | Input Assembler matériel (fonction fixe) | Instruction `buffer load` manuelle dans le shader |
+| Bande passante | L'IA peut pré-charger/mettre en cache les flux d'attributs | Lecture cohérente unique par invocation |
+| Latence | Matériel dédié, potentiellement coût nul | Instruction ALU + hit cache L2 (typiquement) |
+| Appels GL | `glBindBufferBase` + `glCopyBufferSubData` + setup VBO | 0 appel supplémentaire (binding 2 réutilisé du tri) |
+
+### Pourquoi C'est Sans Risque
+
+**1. Charge de travail dominée par le fragment shader.** Chaque sphère billboard exécute un
+fragment shader PBR + IBL complet avec :
+
+- 3 lookups de textures IBL (cubemap irradiance, env map pré-filtrée, BRDF LUT)
+- 7 lookups de textures 3D SH probe (harmoniques sphériques)
+- Évaluation BRDF Cook-Torrance (NDF GGX, géométrie Smith, Fresnel)
+- Tone mapping + correction gamma
+
+Le coût du fragment shader par pixel **écrase** toute différence de fetch au stade vertex.
+Pour une frame typique 1920×1080 avec 10–100 sphères, le vertex shader s'exécute ~4–600 fois
+(4–6 vertices × instances) tandis que le fragment shader s'exécute des millions de fois.
+
+**2. Accès cache-friendly.** La lecture SSBO accède à `billboard_instances[gl_InstanceID]`
+séquentiellement à travers les instances. Avec des structs alignées sur 128 octets
+(correspondant aux lignes de cache), cela produit d'excellents taux de hit cache L2 —
+comparables à ce que le matériel Input Assembler obtiendrait pour les mêmes données.
+
+**3. Nombre d'instances négligeable.** Le système billboard rend 10–100 sphères. Même avec
+une pénalité pessimiste de 10ns par invocation vertex (improbable), le surcoût total serait :
+
+$$100 \text{ instances} \times 6 \text{ vertices} \times 10\text{ns} = 6\mu\text{s}$$
+
+Soit **trois ordres de grandeur** en dessous d'un budget frame typique de 16ms.
+
+**4. Réduction du surcoût driver.** Les 3 appels GL supprimés (bind + copie + unbind)
+éliminent la validation côté CPU du driver et l'enregistrement du command buffer. Sur les
+scènes lourdes en draw calls, cette économie CPU peut dépasser le coût GPU théorique des
+lectures manuelles.
+
+### Mesurer l'Impact
+
+Le projet inclut un système `GPUProfiler` ([src/gpu_profiler.c](gpu_profiler.c)) avec des
+timestamp queries par stage, mais la passe Billboard manque actuellement d'un stage de
+profiling dédié. Pour mesurer l'impact réel :
+
+1. **Ajouter `GPU_STAGE_PROFILER`** autour du bloc billboard sort+render dans `scene.c`
+2. **Utiliser le pattern `EffectBenchmark` existant** ([src/effect_benchmark.c](effect_benchmark.c)) :
+   warmup 30 frames, mesure 120 frames, rapport mean ± stddev
+3. **Comparer les branches** en exécutant le même point de vue caméra sur `master` vs `refactor/`
+4. **Résultat attendu** : delta dans le bruit de mesure (< 1% variation), confirmant la
+   dominance fragment-bound
+
+Un futur mode CLI `--benchmark N` pourrait automatiser cette comparaison entre branches.
+
+### Conclusion
+
+La lecture SSBO est un **compromis net positif** : coût GPU négligeable (s'il existe) en
+échange de 3 appels GL en moins, élimination de la copie VBO, et un flux de données plus
+simple où la sortie du tri est consommée directement par le vertex shader sans copies
+intermédiaires.
 
 ## Fichiers Concernés
 
 | Fichier | Rôle |
 |---------|------|
-| `src/scene.c` | `scene_render_billboards()` — upload UBO, bind textures |
-| `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — copie SSBO→VBO |
+| `src/scene.c` | `scene_render_billboards()` — upload UBO, bind textures, bind SSBO |
+| `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — copie VBO legacy (debug uniquement) |
 | `src/billboard_rendering.c` | `billboard_group_draw()` — bind VAO, état cull, draw call |
 | `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — dispatch compute |
-| `shaders/billboard_ubo.glsl` | **Nouveau** — définition bloc UBO partagé (`binding = 1`) |
-| `shaders/pbr_ibl_billboard.vert` | Vertex shader — inclut `billboard_ubo.glsl` |
+| `shaders/billboard_instance_ssbo.glsl` | **Nouveau** — SSBO SphereInstance pour lecture directe vertex (`binding = 2`) |
+| `shaders/billboard_ubo.glsl` | Définition bloc UBO partagé (`binding = 1`) |
+| `shaders/pbr_ibl_billboard.vert` | Vertex shader — fetch SSBO via `gl_InstanceID` |
 | `shaders/pbr_ibl_billboard.frag` | Fragment shader — inclut `billboard_ubo.glsl` |
 | `shaders/sh_probe.glsl` | Uniforms SH probe — gardé par `#ifndef HAS_BILLBOARD_UBO` |
 | `include/scene.h` | Struct `BillboardUBO` + `BillboardUniforms` (samplers SH uniquement) |

--- a/docs/billboard_gl_call_reduction.md
+++ b/docs/billboard_gl_call_reduction.md
@@ -26,43 +26,64 @@ This document tracks the tiered optimization plan and its implementation status.
 
 ## Optimization Tiers
 
-### Tier 1 — Trivial, No Shader Changes (~9 calls saved)
+### Tier 1 — Trivial, No Shader Changes (~5 calls saved)
 
-**Status: In Progress**
+**Status: Done** ✅
 
 | Optimization | Calls saved | Risk |
 |-------------|-------------|------|
 | Remove 3× `glUniform1i` for sampler bindings (already `layout(binding=X)` in GLSL) | 3 | None |
 | Remove 2× defensive unbind after `glCopyBufferSubData` | 2 | None |
 
-Total: **~5 calls saved** (conservative, safe subset).
+Total: **5 calls saved**. Validated in RenderDoc: 64 → 59 commands.
 
-### Tier 2 — UBO for Per-Frame Uniforms (~12 calls → 1)
+### Tier 2 — UBO for Per-Frame Uniforms (~12 calls → 2)
 
-**Status: Planned**
+**Status: Done** ✅
 
-Replace individual `glUniform*` calls with a single **Uniform Buffer Object**, following the
-existing `PostProcessUBO` pattern in `src/postprocess.c`.
+Replaced ~12 individual `glUniform*` calls with a single **Uniform Buffer Object** upload
+(`glBufferSubData` + `glBindBuffer`), following the existing `PostProcessUBO` pattern.
 
-```c
-typedef struct {
-    mat4 projection;        // offset 0
-    mat4 view;              // offset 64
-    mat4 previousViewProj;  // offset 128
-    vec3 camPos;            // offset 192
-    int  debugMode;         // offset 204
-    vec2 screenSize;        // offset 208
-    vec2 _pad0;             // offset 216 (std140 alignment)
-    vec3 probeGridMin;      // offset 224
-    int  giMode;            // offset 236
-    vec3 probeGridMax;      // offset 240
-    int  specularAAEnabled; // offset 252
-    ivec3 probeGridDim;     // offset 256
-    int   aaMode;           // offset 268
-} BillboardUBO;
+**GLSL side** — new shared include `shaders/billboard_ubo.glsl`:
+
+```glsl
+layout(std140, binding = 1) uniform BillboardBlock {
+    mat4 projection;
+    mat4 view;
+    mat4 previousViewProj;
+    vec3 camPos;      int debugMode;
+    vec2 u_screenSize; vec2 _bb_pad0;
+    vec3 u_ProbeGridMin; int u_GIMode;
+    vec3 u_ProbeGridMax; int u_specularAAEnabled;
+    ivec3 u_ProbeGridDim; int u_aaMode;
+    vec3 u_GridToIdxScale; float _bb_pad1;
+};
 ```
 
-One `glBufferSubData` + `glBindBufferBase` replaces ~12 individual uniform calls.
+**C side** — `BillboardUBO` struct in `include/scene.h`, `std140`-aligned, uploaded via:
+
+```c
+BillboardUBO ubo = {0};
+// ... fill fields ...
+glBindBuffer(GL_UNIFORM_BUFFER, scene->billboard_ubo);
+glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(BillboardUBO), &ubo);
+```
+
+**Conditional guard** in `shaders/sh_probe.glsl` — individual uniform declarations
+wrapped in `#ifndef HAS_BILLBOARD_UBO` so the instanced pipeline (which does NOT
+use the UBO) continues to work with explicit `layout(location=X)` uniforms.
+
+#### UBO Alignment Safety
+
+cglm's `glm_mat4_copy` uses AVX `_mm256_store_ps` which requires 32-byte alignment.
+To prevent silent SIGSEGV crashes on stack-allocated UBOs:
+
+- Generic API in `include/gl_common.h`:
+  - `GL_UBO_ALIGNMENT` enum constant (32)
+  - `GL_UBO_ALIGNED` attribute macro for typedef
+  - `GL_ASSERT_UBO_ALIGNMENT(type)` compile-time `_Static_assert`
+- Applied to both `BillboardUBO` and `PostProcessUBO`
+- Any future UBO gets the same 2-line protection
 
 ### Tier 3 — Persistent Texture/Buffer Bindings (~21 calls saved)
 
@@ -107,11 +128,14 @@ SphereInstance inst = instances[gl_InstanceID];
 
 | File | Role |
 |------|------|
-| `src/scene.c` | `scene_render_billboards()` — uniform setup, texture binding |
+| `src/scene.c` | `scene_render_billboards()` — UBO upload, texture binding |
 | `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — SSBO→VBO copy |
 | `src/billboard_rendering.c` | `billboard_group_draw()` — VAO bind, cull state, draw call |
 | `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — compute dispatch |
-| `shaders/pbr_ibl_billboard.vert` | Vertex shader — explicit `layout(binding)` for samplers |
-| `shaders/pbr_ibl_billboard.frag` | Fragment shader — `layout(binding=0/1/2)` for IBL samplers |
-| `shaders/sh_probe.glsl` | SH probe uniforms and texture bindings |
-| `include/scene.h` | `BillboardUniforms` struct definition |
+| `shaders/billboard_ubo.glsl` | **New** — shared UBO block definition (`binding = 1`) |
+| `shaders/pbr_ibl_billboard.vert` | Vertex shader — includes `billboard_ubo.glsl` |
+| `shaders/pbr_ibl_billboard.frag` | Fragment shader — includes `billboard_ubo.glsl` |
+| `shaders/sh_probe.glsl` | SH probe uniforms — guarded by `#ifndef HAS_BILLBOARD_UBO` |
+| `include/scene.h` | `BillboardUBO` struct + `BillboardUniforms` (SH samplers only) |
+| `include/gl_common.h` | `GL_UBO_ALIGNED` / `GL_ASSERT_UBO_ALIGNMENT` generic API |
+| `include/postprocess.h` | `PostProcessUBO` — alignment guard applied |

--- a/docs/billboard_gl_call_reduction.md
+++ b/docs/billboard_gl_call_reduction.md
@@ -107,22 +107,67 @@ pass touches those units/bindings.
 **Invalidation:** after `light_probe_grid_sync()` which calls `glBindTexture(GL_TEXTURE_3D, 0)`
 on the current active unit, potentially clobbering a cached SH binding.
 
-### Tier 4 — Direct SSBO Read in Vertex Shader (~7 calls saved)
+### Tier 4 — Direct SSBO Read in Vertex Shader (~3 calls saved)
 
-**Status: Planned**
+**Status: Done** ✅
 
-Eliminate the `glCopyBufferSubData` SSBO→VBO copy entirely by reading sorted instances
-directly via `gl_InstanceID` from the SSBO in the vertex shader. This removes the entire
-copy block (bind source, bind dest, capacity check, copy, unbind).
+Eliminated the `glCopyBufferSubData` SSBO→VBO copy by reading sorted instances
+directly via `gl_InstanceID` from the SSBO in the vertex shader.
+
+**Key insight:** the GPU sort already binds `sorted_instance_ssbo` at binding point 2
+via `glBindBufferBase`. After the compute shader completes, `glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0)`
+only unbinds the generic target — NOT the indexed binding point. So binding 2 is still valid.
+
+For CPU sort paths (qsort, radix), a single `glBindBufferBase(binding 2, instance_ssbo)` is added
+at the end of `upload_sorted_to_ssbo()` to match the GPU sort’s convention.
+
+**GLSL side** — new shared include `shaders/billboard_instance_ssbo.glsl`:
 
 ```glsl
-// In pbr_ibl_billboard.vert — replace per-instance attributes with SSBO fetch
-layout(std430, binding = 2) readonly buffer SortedInstances {
-    SphereInstance instances[];
+struct SphereInstance {
+    mat4 model;
+    vec3 albedo;
+    float metallic;
+    float roughness;
+    float ao;
+    float padding;
+    float _pad[9];  // Match C struct 128-byte stride (SIMD_ALIGNMENT=64)
 };
-// ...
-SphereInstance inst = instances[gl_InstanceID];
+
+layout(std430, binding = 2) readonly buffer BillboardInstanceSSBO {
+    SphereInstance billboard_instances[];
+};
 ```
+
+**Vertex shader** — `shaders/pbr_ibl_billboard.vert` now fetches per-instance data
+via `gl_InstanceID` instead of per-instance vertex attributes:
+
+```glsl
+// Before (vertex attributes):
+layout(location = 2) in mat4 i_model;
+layout(location = 6) in vec3 i_albedo;
+layout(location = 7) in vec3 i_pbr;
+
+// After (SSBO fetch):
+SphereInstance inst = billboard_instances[gl_InstanceID];
+float scaleX = length(vec3(inst.model[0]));
+Albedo = inst.albedo;
+Metallic = inst.metallic;  // Direct access, no vec3 packing
+```
+
+**C side** — In `src/scene.c`, the `billboard_group_update_from_buffer()` call is removed
+entirely (kept only for debug wireframe overlay). No additional `glBindBufferBase` needed
+in the GPU sort path — binding 2 is already set by the compute dispatch.
+
+The legacy VBO copy is kept only for the debug wireframe overlay (which uses a separate
+shader with per-instance vertex attributes). In the normal rendering path, no copy occurs.
+
+**Call savings:**
+
+| Sort mode | Removed | Added | Net |
+|-----------|---------|-------|-----|
+| GPU bitonic (default) | 3 (bind read, bind write, copy) | 0 | **-3** |
+| CPU qsort/radix | 3 | 1 (`glBindBufferBase` in sort) | **-2** |
 
 ## Projected Results
 
@@ -132,20 +177,89 @@ SphereInstance inst = instances[gl_InstanceID];
 | Tier 1 | Trivial | 5 | ~60 |
 | Tier 2 (UBO) | Medium | 11 | ~49 |
 | Tier 3 (SH/SSBO) | Medium | 15 | **~34** |
-| Tier 4 (SSBO direct) | Medium-High | 7 | **~27** |
+| Tier 4 (SSBO direct) | Medium | 3 | **~31** |
+
+## Performance Regression Analysis
+
+### Tier 4 Tradeoff: Input Assembler vs SSBO Fetch
+
+Tier 4 replaces the traditional **fixed-function Input Assembler** path (per-instance vertex
+attributes fed via VBO + `glVertexAttribDivisor`) with a **manual SSBO fetch** in the vertex
+shader (`billboard_instances[gl_InstanceID]`).
+
+This is a deliberate architectural tradeoff:
+
+| Aspect | Before (VBO + IA) | After (SSBO fetch) |
+|--------|-------------------|---------------------|
+| Data path | Fixed-function hardware Input Assembler | Manual `buffer load` instruction in shader |
+| Bandwidth | IA may prefetch/cache attribute streams | Single coherent buffer read per invocation |
+| Latency | Dedicated hardware, potentially zero-cost | ALU instruction + L2 cache hit (typically) |
+| GL calls | `glBindBufferBase` + `glCopyBufferSubData` + VBO setup | 0 extra calls (binding 2 reused from sort) |
+
+### Why This Is Safe
+
+**1. Fragment-shader bound workload.** Each billboard sphere runs a full PBR + IBL fragment
+shader with:
+
+- 3 IBL texture lookups (irradiance cubemap, prefiltered env map, BRDF LUT)
+- 7 SH probe 3D texture lookups (spherical harmonics)
+- Cook-Torrance BRDF evaluation (GGX NDF, Smith geometry, Fresnel)
+- Tone mapping + gamma correction
+
+The fragment shader cost per pixel **dwarfs** any vertex-stage data fetch difference.
+For a typical 1920×1080 frame with 10–100 spheres, the vertex shader runs ~4–600 times
+(4–6 vertices × instances) while the fragment shader runs millions of times.
+
+**2. Cache-friendly access pattern.** The SSBO fetch reads `billboard_instances[gl_InstanceID]`
+sequentially across instances. With 128-byte aligned structs (matching cache lines), this
+yields excellent L2 cache hit rates — comparable to what the Input Assembler hardware would
+achieve for the same data.
+
+**3. Negligible instance counts.** The billboard system renders 10–100 spheres. Even with a
+pessimistic 10ns penalty per vertex invocation (unlikely), the total overhead would be:
+
+$$100 \text{ instances} \times 6 \text{ vertices} \times 10\text{ns} = 6\mu\text{s}$$
+
+This is **three orders of magnitude** below a typical 16ms frame budget.
+
+**4. Driver overhead reduction.** The 3 GL calls removed (bind + copy + unbind) eliminate
+CPU-side driver validation and command buffer recording. On draw-call-heavy scenes, this
+CPU saving can exceed the theoretical GPU cost of manual fetches.
+
+### Measuring the Impact
+
+The project includes a `GPUProfiler` system ([src/gpu_profiler.c](gpu_profiler.c)) with
+per-stage timestamp queries, but the Billboard pass currently lacks a dedicated profiling
+stage. To measure the actual impact:
+
+1. **Add `GPU_STAGE_PROFILER`** around the billboard sort+render block in `scene.c`
+2. **Use the existing `EffectBenchmark` pattern** ([src/effect_benchmark.c](effect_benchmark.c)):
+   warmup 30 frames, measure 120 frames, report mean ± stddev
+3. **Compare branches** by running the same camera viewpoint on `master` vs `refactor/`
+4. **Expected result**: delta well within noise (< 1% variation), confirming fragment-bound
+   dominance
+
+A future `--benchmark N` CLI mode could automate this comparison across branches.
+
+### Conclusion
+
+The SSBO fetch is a **net positive tradeoff**: negligible GPU cost (if any) in exchange for
+3 fewer GL calls, elimination of the VBO copy, and a simpler data flow where the sort output
+is consumed directly by the vertex shader without intermediate copies.
 
 ## Files Involved
 
 | File | Role |
 |------|------|
-| `src/scene.c` | `scene_render_billboards()` — UBO upload, texture binding |
-| `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — SSBO→VBO copy |
+| `src/scene.c` | `scene_render_billboards()` — UBO upload, texture binding, SSBO bind |
+| `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — legacy VBO copy (debug only) |
 | `src/billboard_rendering.c` | `billboard_group_draw()` — VAO bind, cull state, draw call |
 | `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — compute dispatch |
-| `shaders/billboard_ubo.glsl` | **New** — shared UBO block definition (`binding = 1`) |
-| `shaders/pbr_ibl_billboard.vert` | Vertex shader — includes `billboard_ubo.glsl` |
+| `shaders/billboard_instance_ssbo.glsl` | **New**: SphereInstance SSBO for direct vertex shader read (`binding = 2`) |
+| `shaders/billboard_ubo.glsl` | Shared UBO block definition (`binding = 1`) |
+| `shaders/pbr_ibl_billboard.vert` | Vertex shader — SSBO fetch via `gl_InstanceID` |
 | `shaders/pbr_ibl_billboard.frag` | Fragment shader — includes `billboard_ubo.glsl` |
 | `shaders/sh_probe.glsl` | SH probe uniforms — guarded by `#ifndef HAS_BILLBOARD_UBO` |
 | `include/scene.h` | `BillboardUBO` struct + `BillboardUniforms` (SH samplers only) |
-| `include/gl_common.h` | `GL_UBO_ALIGNED` / `GL_ASSERT_UBO_ALIGNMENT` generic API |
+| `include/gl_common.h` | `GL_UBO_ALIGNED` / `GL_ASSERT_UBO_ALIGNMENT` |
 | `include/postprocess.h` | `PostProcessUBO` — alignment guard applied |

--- a/docs/billboard_gl_call_reduction.md
+++ b/docs/billboard_gl_call_reduction.md
@@ -11,7 +11,7 @@ This document tracks the tiered optimization plan and its implementation status.
 ## Current Breakdown (~65 calls)
 
 | Phase | Calls | Detail |
-|-------|-------|--------|
+| :--- | :--- | :--- |
 | Compute sort | 12 | `bufferSubData`, `useProgram`, 3 uniforms, 3 SSBO binds, dispatch, barrier |
 | Buffer copy SSBO→VBO | 7 | bind copy source/dest, copy, 2× defensive unbind |
 | Blend state | 3 | `glEnablei`, `glBlendFunc`, `glDisablei` |
@@ -37,12 +37,11 @@ This document tracks the tiered optimization plan and its implementation status.
 
 Total: **5 calls saved**. Validated in RenderDoc: 64 → 59 commands.
 
-### Tier 2 — UBO for Per-Frame Uniforms (~12 calls → 2)
+### Tier 2 — AZDO Persistent Mapping for Billboard UBO
 
-**Status: Done** ✅
+**Status: Done** ✅ (Upgraded from `glBufferSubData`)
 
-Replaced ~12 individual `glUniform*` calls with a single **Uniform Buffer Object** upload
-(`glBufferSubData` + `glBindBuffer`), following the existing `PostProcessUBO` pattern.
+Initially, we replaced ~12 individual `glUniform*` calls with a single UBO. We have since upgraded this to **AZDO Persistent Mapping**. The UBO is now allocated with `glBufferStorage` and mapped into CPU memory once. Updates are performed via a simple `memcpy`.
 
 **GLSL side** — new shared include `shaders/billboard_ubo.glsl`:
 
@@ -65,8 +64,8 @@ layout(std140, binding = 1) uniform BillboardBlock {
 ```c
 BillboardUBO ubo = {0};
 // ... fill fields ...
-glBindBuffer(GL_UNIFORM_BUFFER, scene->billboard_ubo);
-glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(BillboardUBO), &ubo);
+// AZDO: No glBindBuffer or glBufferSubData needed!
+memcpy(scene->billboard_ubo_ptr, &ubo, sizeof(BillboardUBO));
 ```
 
 **Conditional guard** in `shaders/sh_probe.glsl` — individual uniform declarations
@@ -85,27 +84,18 @@ To prevent silent SIGSEGV crashes on stack-allocated UBOs:
 - Applied to both `BillboardUBO` and `PostProcessUBO`
 - Any future UBO gets the same 2-line protection
 
-### Tier 3 — Persistent SH Texture/SSBO Bindings (~15 calls saved)
+### Tier 3 — Persistent SH/IBL Texture & SSBO Bindings (~21 calls saved)
 
-**Status: In Progress**
+**Status: Done** ✅
 
-| Optimization | Calls saved | Cachable? |
+| Optimization | Calls saved | Status |
 |-------------|-------------|----------|
-| ~~Bind IBL textures once at load~~ | ~~6~~ | **NO** — units 0-2 are clobbered by Skybox and PostProcess passes |
-| Bind SH 3D textures once when probe grid changes | 14 | **YES** — units 8-14 are exclusive to PBR passes |
-| Bind probe SSBO once when probe grid changes | 1 | **YES** — binding point 3 is exclusive to PBR passes |
+| Bind IBL textures once (Units 15-17) | 6 | **Done** |
+| Bind SH 3D textures once (Units 8-14) | 14 | **Done** |
+| Bind probe SSBO once (Binding 3) | 1 | **Done** |
 
-**Why IBL textures cannot be cached:**
-In a multi-pass renderer, texture units 0-2 are shared across passes:
-- `src/skybox.c` rebinds `GL_TEXTURE0` with the environment cubemap
-- `src/postprocess.c` rebinds units 0-1-2 with FBO color attachments, bloom textures, etc.
-
-Caching these bindings would require a centralized GL state tracker (over-engineering).
-The SH textures (units 8-14) and probe SSBO (binding 3) are safe because no other
-pass touches those units/bindings.
-
-**Invalidation:** after `light_probe_grid_sync()` which calls `glBindTexture(GL_TEXTURE_3D, 0)`
-on the current active unit, potentially clobbering a cached SH binding.
+**IBL Caching Strategy:**
+By moving IBL samplers to dedicated high units (15, 16, 17), we ensure they are not clobbered by the Skybox or PostProcess passes. We now use a binding cache in the `Scene` struct to eliminate all per-frame `glActiveTexture` and `glBindTexture` calls for PBR rendering.
 
 ### Tier 4 — Direct SSBO Read in Vertex Shader (~3 calls saved)
 
@@ -172,12 +162,25 @@ shader with per-instance vertex attributes). In the normal rendering path, no co
 ## Projected Results
 
 | Tier | Effort | Calls saved | Remaining |
-|------|--------|-------------|-----------|
+| :--- | :--- | :--- | :--- |
 | Baseline | — | — | **~65** |
 | Tier 1 | Trivial | 5 | ~60 |
 | Tier 2 (UBO) | Medium | 11 | ~49 |
 | Tier 3 (SH/SSBO) | Medium | 15 | **~34** |
-| Tier 4 (SSBO direct) | Medium | 3 | **~31** |
+| Tier 4 (SSBO direct) | Medium | 3 | ~31 |
+| Tier 5 (Unbind cleanup) | Low | ~8 | **~23** |
+
+### Tier 5 — Removal of Defensive Unbinds (~8+ calls saved)
+
+**Status: Done** ✅
+
+Removed all redundant `glBindVertexArray(0)` and `glBindBuffer(..., 0)` calls from the hot paths. In a modern OpenGL pipeline, state is simply overwritten by the next bind, making these "cleanup" calls a significant waste of CPU cycles.
+
+**Affected modules:**
+- Billboard & Instanced Rendering
+- SSBO Rendering
+- Post-process & Skybox
+- UI & FX LUT Viz
 
 ## Performance Regression Analysis
 

--- a/docs/billboard_gl_call_reduction.md
+++ b/docs/billboard_gl_call_reduction.md
@@ -1,0 +1,117 @@
+# Billboard Pass — GL Call Reduction
+
+## Context
+
+The `Billboard_Sort_And_Render` pass, as observed in RenderDoc, issues **~65 GL commands**
+before and including the `glDrawArraysInstanced` call. Most of these are pipeline state
+setup (uniforms, texture binds, blend modes, buffer copies) that can be drastically reduced.
+
+This document tracks the tiered optimization plan and its implementation status.
+
+## Current Breakdown (~65 calls)
+
+| Phase | Calls | Detail |
+|-------|-------|--------|
+| Compute sort | 12 | `bufferSubData`, `useProgram`, 3 uniforms, 3 SSBO binds, dispatch, barrier |
+| Buffer copy SSBO→VBO | 7 | bind copy source/dest, copy, 2× defensive unbind |
+| Blend state | 3 | `glEnablei`, `glBlendFunc`, `glDisablei` |
+| `glUseProgram` | 1 | `pbr_ibl_billboard` |
+| IBL textures | 6 | 3× (`glActiveTexture` + `glBindTexture`) |
+| Sampler uniforms | 3 | **Redundant** — `layout(binding=0/1/2)` already set in shader |
+| Per-frame uniforms | ~12 | projection, view, prevVP, camPos, screenSize, debugMode, GI params |
+| SH textures (GI) | 14 | 7× (`glActiveTexture` + `glBindTexture3D`) |
+| SSBO probe | 1 | `glBindBufferBase` |
+| VAO + draw | 3 | `glBindVertexArray`, `glDisable(GL_CULL_FACE)`, `glDrawArraysInstanced` |
+| Cleanup | ~3 | unbind VAO, restore cull, disable blend |
+
+## Optimization Tiers
+
+### Tier 1 — Trivial, No Shader Changes (~9 calls saved)
+
+**Status: In Progress**
+
+| Optimization | Calls saved | Risk |
+|-------------|-------------|------|
+| Remove 3× `glUniform1i` for sampler bindings (already `layout(binding=X)` in GLSL) | 3 | None |
+| Remove 2× defensive unbind after `glCopyBufferSubData` | 2 | None |
+
+Total: **~5 calls saved** (conservative, safe subset).
+
+### Tier 2 — UBO for Per-Frame Uniforms (~12 calls → 1)
+
+**Status: Planned**
+
+Replace individual `glUniform*` calls with a single **Uniform Buffer Object**, following the
+existing `PostProcessUBO` pattern in `src/postprocess.c`.
+
+```c
+typedef struct {
+    mat4 projection;        // offset 0
+    mat4 view;              // offset 64
+    mat4 previousViewProj;  // offset 128
+    vec3 camPos;            // offset 192
+    int  debugMode;         // offset 204
+    vec2 screenSize;        // offset 208
+    vec2 _pad0;             // offset 216 (std140 alignment)
+    vec3 probeGridMin;      // offset 224
+    int  giMode;            // offset 236
+    vec3 probeGridMax;      // offset 240
+    int  specularAAEnabled; // offset 252
+    ivec3 probeGridDim;     // offset 256
+    int   aaMode;           // offset 268
+} BillboardUBO;
+```
+
+One `glBufferSubData` + `glBindBufferBase` replaces ~12 individual uniform calls.
+
+### Tier 3 — Persistent Texture/Buffer Bindings (~21 calls saved)
+
+**Status: Planned**
+
+| Optimization | Calls saved |
+|-------------|-------------|
+| Bind IBL textures once at load (not per-frame) | 6 |
+| Bind SH 3D textures once when probe grid changes (not per-frame) | 14 |
+| Bind probe SSBO once when probe grid changes | 1 |
+
+Requires tracking a "dirty" flag on probe grid updates to re-bind only when data changes.
+
+### Tier 4 — Direct SSBO Read in Vertex Shader (~7 calls saved)
+
+**Status: Planned**
+
+Eliminate the `glCopyBufferSubData` SSBO→VBO copy entirely by reading sorted instances
+directly via `gl_InstanceID` from the SSBO in the vertex shader. This removes the entire
+copy block (bind source, bind dest, capacity check, copy, unbind).
+
+```glsl
+// In pbr_ibl_billboard.vert — replace per-instance attributes with SSBO fetch
+layout(std430, binding = 2) readonly buffer SortedInstances {
+    SphereInstance instances[];
+};
+// ...
+SphereInstance inst = instances[gl_InstanceID];
+```
+
+## Projected Results
+
+| Tier | Effort | Calls saved | Remaining |
+|------|--------|-------------|-----------|
+| Baseline | — | — | **~65** |
+| Tier 1 | Trivial | 5 | ~60 |
+| Tier 2 (UBO) | Medium | 11 | ~49 |
+| Tier 3 (Persistent) | Medium | 21 | **~28** |
+| Tier 4 (SSBO direct) | Medium-High | 7 | **~21** |
+
+## Files Involved
+
+| File | Role |
+|------|------|
+| `src/scene.c` | `scene_render_billboards()` — uniform setup, texture binding |
+| `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — SSBO→VBO copy |
+| `src/billboard_rendering.c` | `billboard_group_draw()` — VAO bind, cull state, draw call |
+| `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — compute dispatch |
+| `shaders/pbr_ibl_billboard.vert` | Vertex shader — explicit `layout(binding)` for samplers |
+| `shaders/pbr_ibl_billboard.frag` | Fragment shader — `layout(binding=0/1/2)` for IBL samplers |
+| `shaders/sh_probe.glsl` | SH probe uniforms and texture bindings |
+| `include/scene.h` | `BillboardUniforms` struct definition |

--- a/docs/billboard_gl_call_reduction.md
+++ b/docs/billboard_gl_call_reduction.md
@@ -85,17 +85,27 @@ To prevent silent SIGSEGV crashes on stack-allocated UBOs:
 - Applied to both `BillboardUBO` and `PostProcessUBO`
 - Any future UBO gets the same 2-line protection
 
-### Tier 3 — Persistent Texture/Buffer Bindings (~21 calls saved)
+### Tier 3 — Persistent SH Texture/SSBO Bindings (~15 calls saved)
 
-**Status: Planned**
+**Status: In Progress**
 
-| Optimization | Calls saved |
-|-------------|-------------|
-| Bind IBL textures once at load (not per-frame) | 6 |
-| Bind SH 3D textures once when probe grid changes (not per-frame) | 14 |
-| Bind probe SSBO once when probe grid changes | 1 |
+| Optimization | Calls saved | Cachable? |
+|-------------|-------------|----------|
+| ~~Bind IBL textures once at load~~ | ~~6~~ | **NO** — units 0-2 are clobbered by Skybox and PostProcess passes |
+| Bind SH 3D textures once when probe grid changes | 14 | **YES** — units 8-14 are exclusive to PBR passes |
+| Bind probe SSBO once when probe grid changes | 1 | **YES** — binding point 3 is exclusive to PBR passes |
 
-Requires tracking a "dirty" flag on probe grid updates to re-bind only when data changes.
+**Why IBL textures cannot be cached:**
+In a multi-pass renderer, texture units 0-2 are shared across passes:
+- `src/skybox.c` rebinds `GL_TEXTURE0` with the environment cubemap
+- `src/postprocess.c` rebinds units 0-1-2 with FBO color attachments, bloom textures, etc.
+
+Caching these bindings would require a centralized GL state tracker (over-engineering).
+The SH textures (units 8-14) and probe SSBO (binding 3) are safe because no other
+pass touches those units/bindings.
+
+**Invalidation:** after `light_probe_grid_sync()` which calls `glBindTexture(GL_TEXTURE_3D, 0)`
+on the current active unit, potentially clobbering a cached SH binding.
 
 ### Tier 4 — Direct SSBO Read in Vertex Shader (~7 calls saved)
 
@@ -121,8 +131,8 @@ SphereInstance inst = instances[gl_InstanceID];
 | Baseline | — | — | **~65** |
 | Tier 1 | Trivial | 5 | ~60 |
 | Tier 2 (UBO) | Medium | 11 | ~49 |
-| Tier 3 (Persistent) | Medium | 21 | **~28** |
-| Tier 4 (SSBO direct) | Medium-High | 7 | **~21** |
+| Tier 3 (SH/SSBO) | Medium | 15 | **~34** |
+| Tier 4 (SSBO direct) | Medium-High | 7 | **~27** |
 
 ## Files Involved
 

--- a/docs/justfile.fr.md
+++ b/docs/justfile.fr.md
@@ -45,6 +45,8 @@ Voici une correspondance des commandes `make` courantes avec leurs équivalents 
 | **Test spécifique** | `make test/<nom>` | `just test <nom>` | Exécute les tests correspondants |
 | **ApiTrace unitaire** | `make test-apitrace` | `just test-apitrace` | Vérification performance légère |
 | **ApiTrace intégr.** | `make test-integration-apitrace` | `just test-integration-apitrace` | Test scénario complet |
+| **Intégration (Simple)** | `make test-integration`* | `just test-integration` | Vérification UI rapide (Debug) |
+| **Intégration (Valgrind)** | `make test-integration` | `just test-integration-valgrind` | Vérification scénario UI sous Valgrind |
 | **Couverture** | `make coverage` | `just coverage` | Génère le rapport HTML |
 | **Lint** | `make lint` | `just lint` | Exécute clang-tidy et ruff |
 | **Format** | `make format` | `just format` | Exécute clang-format et ruff |
@@ -79,6 +81,18 @@ Cette commande :
 1. Construit le binaire de test.
 2. Si le binaire existe, l'exécute directement (via le wrapper `xvfb`) pour une sortie immédiate.
 3. Si introuvable, revient à la correspondance de motif `ctest`.
+
+### Tests d'Intégration UI
+
+Le projet utilise `xdotool` et `Xvfb` pour simuler des interactions utilisateur et vérifier la stabilité de l'UI à travers différents modes de build.
+
+- **Standard** : `just test-integration` (Debug) / `just test-integration-release` (Release)
+- **Sécurité Mémoire** : `just test-integration-valgrind` / `just test-integration-asan`
+- **Profilage** : `just test-integration-profile` / `just test-integration-tracy`
+- **Variantes** : `just test-integration-ssbo` / `just test-integration-ultra` / `just test-integration-small`
+
+> [!TIP]
+> Utilisez `just test-integration` pour une vérification fonctionnelle rapide. Cela se termine en quelques secondes, alors que les variantes Valgrind peuvent prendre plusieurs minutes.
 
 ### Variantes de construction
 

--- a/docs/justfile.fr.md
+++ b/docs/justfile.fr.md
@@ -89,7 +89,8 @@ Le projet utilise `xdotool` et `Xvfb` pour simuler des interactions utilisateur 
 - **Standard** : `just test-integration` (Debug) / `just test-integration-release` (Release)
 - **Sécurité Mémoire** : `just test-integration-valgrind` / `just test-integration-asan`
 - **Profilage** : `just test-integration-profile` / `just test-integration-tracy`
-- **Variantes** : `just test-integration-ssbo` / `just test-integration-ultra` / `just test-integration-small`
+- **Variantes** : `just test-integration-ssbo` / `just test-integration-ultra` / `just test-integration-small` / `just test-integration-sync`
+- **Combinés** : `just test-integration-tracy-asan` / `just test-integration-tracy-release`
 
 > [!TIP]
 > Utilisez `just test-integration` pour une vérification fonctionnelle rapide. Cela se termine en quelques secondes, alors que les variantes Valgrind peuvent prendre plusieurs minutes.

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -45,6 +45,8 @@ Here is a mapping of common `make` commands to their `just` equivalents:
 | **Test Specific** | `make test/<name>` | `just test <name>` | Runs matching tests |
 | **ApiTrace Unit** | `make test-apitrace` | `just test-apitrace` | Automated performance check |
 | **ApiTrace Integr** | `make test-integration-apitrace` | `just test-integration-apitrace` | Full app scenario check |
+| **Integration (Simple)** | `make test-integration`* | `just test-integration` | Fast UI scenario check (Debug) |
+| **Integration (Valgrind)** | `make test-integration` | `just test-integration-valgrind` | UI scenario check under Valgrind |
 | **Coverage** | `make coverage` | `just coverage` | Generates HTML report |
 | **Lint** | `make lint` | `just lint` | Runs clang-tidy and ruff |
 | **Format** | `make format` | `just format` | Runs clang-format and ruff |
@@ -79,6 +81,18 @@ This command automatically:
 1. Builds the test binary.
 2. If binary exists, runs it directly (via `xvfb` wrapper) for immediate output.
 3. If not found, falls back to `ctest` pattern matching.
+
+### UI Integration Testing
+
+The project uses `xdotool` and `Xvfb` to simulate user interactions and verify UI stability across different build modes.
+
+- **Standard**: `just test-integration` (Debug) / `just test-integration-release` (Release)
+- **Memory Safety**: `just test-integration-valgrind` / `just test-integration-asan`
+- **Profiling**: `just test-integration-profile` / `just test-integration-tracy`
+- **Variants**: `just test-integration-ssbo` / `just test-integration-ultra` / `just test-integration-small`
+
+> [!TIP]
+> Use `just test-integration` for quick functional verification. It finishes in seconds, whereas Valgrind variants can take several minutes.
 
 ### Build Variants
 

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -89,7 +89,8 @@ The project uses `xdotool` and `Xvfb` to simulate user interactions and verify U
 - **Standard**: `just test-integration` (Debug) / `just test-integration-release` (Release)
 - **Memory Safety**: `just test-integration-valgrind` / `just test-integration-asan`
 - **Profiling**: `just test-integration-profile` / `just test-integration-tracy`
-- **Variants**: `just test-integration-ssbo` / `just test-integration-ultra` / `just test-integration-small`
+- **Variants**: `just test-integration-ssbo` / `just test-integration-ultra` / `just test-integration-small` / `just test-integration-sync`
+- **Combined**: `just test-integration-tracy-asan` / `just test-integration-tracy-release`
 
 > [!TIP]
 > Use `just test-integration` for quick functional verification. It finishes in seconds, whereas Valgrind variants can take several minutes.

--- a/include/gl_common.h
+++ b/include/gl_common.h
@@ -131,6 +131,30 @@ enum { SCREEN_QUAD_VERTEX_COUNT = 6 };
 enum { SIMD_ALIGNMENT = 64 };
 
 /**
+ * @brief Required alignment for UBO structs used with cglm (AVX mat4 ops).
+ *
+ * cglm's glm_mat4_copy uses AVX _mm256_store_ps which requires 32-byte
+ * alignment. Any UBO struct containing mat4 (float[16]) fields must be
+ * tagged with GL_UBO_ALIGNED to guarantee safe stack/heap allocation.
+ */
+enum { GL_UBO_ALIGNMENT = 32 };
+
+/**
+ * @brief Attribute to apply on UBO typedef to enforce AVX alignment.
+ * Usage: } GL_UBO_ALIGNED MyUBOType;
+ */
+#define GL_UBO_ALIGNED __attribute__((aligned(GL_UBO_ALIGNMENT)))
+
+/**
+ * @brief Compile-time assertion that a UBO struct meets AVX alignment.
+ * Place after the typedef to catch misconfigurations at build time.
+ * @param type The UBO struct type name.
+ */
+#define GL_ASSERT_UBO_ALIGNMENT(type)                      \
+	_Static_assert(_Alignof(type) >= GL_UBO_ALIGNMENT, \
+	               #type " must be >= 32-byte aligned for AVX (cglm)")
+
+/**
  * @brief Pushes a debug group to the OpenGL command stream for debugging tools.
  * @param name String label for the group.
  */

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -342,7 +342,9 @@ typedef struct {
 	/* 3D LUT (16 bytes) */
 	float lut3d_intensity;
 	float _pad14[3];
-} PostProcessUBO;
+} GL_UBO_ALIGNED PostProcessUBO;
+
+GL_ASSERT_UBO_ALIGNMENT(PostProcessUBO);
 
 /**
  * @struct PostProcess

--- a/include/scene.h
+++ b/include/scene.h
@@ -89,23 +89,39 @@ typedef struct {
 } DebugUniforms;
 
 /**
+ * @struct BillboardUBO
+ * @brief GPU-side uniform buffer for billboard rendering (std140 layout).
+ * @note Must match layout(std140, binding = 1) in billboard_ubo.glsl.
+ */
+enum { MAT4_FLOAT_COUNT = 16 };
+typedef struct {
+	float projection[MAT4_FLOAT_COUNT]; /**< mat4 projection (offset   0) */
+	float view[MAT4_FLOAT_COUNT];       /**< mat4 view       (offset  64) */
+	float previous_view_proj[MAT4_FLOAT_COUNT]; /**< mat4 prevVP (offset
+	                                               128) */
+	float cam_pos[3];            /**< vec3 camPos       (offset 192) */
+	int32_t debug_mode;          /**< int  debugMode    (offset 204) */
+	float screen_size[2];        /**< vec2 screenSize   (offset 208) */
+	float _pad0[2];              /**< alignment pad     (offset 216) */
+	float probe_grid_min[3];     /**< vec3 probeGridMin (offset 224) */
+	int32_t gi_mode;             /**< int  u_GIMode     (offset 236) */
+	float probe_grid_max[3];     /**< vec3 probeGridMax (offset 240) */
+	int32_t specular_aa_enabled; /**< int specularAA   (offset 252) */
+	int32_t probe_grid_dim[3];   /**< ivec3 probeGridDim(offset 256) */
+	int32_t aa_mode;             /**< int  u_aaMode     (offset 268) */
+	float grid_to_idx_scale[3];  /**< vec3 gridToIdx    (offset 272) */
+	float _pad1;                 /**< alignment pad     (offset 284) */
+} GL_UBO_ALIGNED BillboardUBO;
+
+GL_ASSERT_UBO_ALIGNMENT(BillboardUBO);
+
+/**
  * @struct BillboardUniforms
  * @brief Cached uniform locations for billboard rendering.
+ * @note Per-frame uniforms are now in BillboardUBO (binding = 1).
+ *       Only SH sampler locations remain here (set once at init).
  */
 typedef struct {
-	GLint debug_mode;            /**< Location of 'debugMode' */
-	GLint cam_pos;               /**< Location of 'camPos' */
-	GLint projection;            /**< Location of 'projection' */
-	GLint view;                  /**< Location of 'view' */
-	GLint previous_view_proj;    /**< Location of 'previousViewProj' */
-	GLint u_screen_size;         /**< Location of 'u_screenSize' */
-	GLint probe_grid_min;        /**< Location of 'u_ProbeGridMin' */
-	GLint probe_grid_max;        /**< Location of 'u_ProbeGridMax' */
-	GLint probe_grid_dim;        /**< Location of 'u_ProbeGridDim' */
-	GLint gi_mode;               /**< Location of 'u_GIMode' */
-	GLint grid_to_idx_scale;     /**< Location of 'u_GridToIdxScale' */
-	GLint u_specular_aa_enabled; /**< Location of 'u_specularAAEnabled' */
-	GLint u_aa_mode;             /**< Location of 'u_aaMode' */
 	GLint
 	    sh_textures[SH_TEXTURE_COUNT]; /**< Locations of 'u_SHTexture0-6' */
 } BillboardUniforms;
@@ -172,6 +188,7 @@ typedef struct Scene {
 	GLuint dummy_white_tex;      /**< Safe fallback (1,1,1,1). */
 	GLuint lum_ssbo[2]; /**< Double-buffered storage for luminance. */
 	GLuint transition_snapshot_tex; /**< For crossfade mode. */
+	GLuint billboard_ubo; /**< UBO for billboard per-frame uniforms. */
 
 	/* --- Render Configuration --- */
 	int wireframe;            /**< OpenGL wireframe mode toggle. */

--- a/include/scene.h
+++ b/include/scene.h
@@ -93,9 +93,6 @@ typedef struct {
  * @brief Cached uniform locations for billboard rendering.
  */
 typedef struct {
-	GLint irradiance_map;        /**< Location of 'irradianceMap' */
-	GLint prefilter_map;         /**< Location of 'prefilterMap' */
-	GLint brdf_lut;              /**< Location of 'brdfLUT' */
 	GLint debug_mode;            /**< Location of 'debugMode' */
 	GLint cam_pos;               /**< Location of 'camPos' */
 	GLint projection;            /**< Location of 'projection' */

--- a/include/scene.h
+++ b/include/scene.h
@@ -56,6 +56,10 @@ typedef enum {
  * @struct InstancedUniforms
  * @brief Cached uniform locations for PBR instanced rendering.
  */
+
+enum { IBL_TEXTURE_COUNT = 3 };
+enum { TEXTURE_UNIT_IBL_START = 15 };
+
 typedef struct {
 	GLint irradiance_map;        /**< Location of 'irradianceMap' */
 	GLint prefilter_map;         /**< Location of 'prefilterMap' */
@@ -189,6 +193,9 @@ typedef struct Scene {
 	GLuint lum_ssbo[2]; /**< Double-buffered storage for luminance. */
 	GLuint transition_snapshot_tex; /**< For crossfade mode. */
 	GLuint billboard_ubo; /**< UBO for billboard per-frame uniforms. */
+
+	/* --- IBL Binding Cache (Tier 5 — units 15-17) --- */
+	GLuint bound_ibl_textures[IBL_TEXTURE_COUNT]; /**< Last IBL active. */
 
 	/* --- SH/Probe Binding Cache (Tier 3 — units 8-14 + SSBO 3) --- */
 	GLuint bound_sh_textures[SH_TEXTURE_COUNT]; /**< Last SH tex bound. */

--- a/include/scene.h
+++ b/include/scene.h
@@ -190,6 +190,10 @@ typedef struct Scene {
 	GLuint transition_snapshot_tex; /**< For crossfade mode. */
 	GLuint billboard_ubo; /**< UBO for billboard per-frame uniforms. */
 
+	/* --- SH/Probe Binding Cache (Tier 3 — units 8-14 + SSBO 3) --- */
+	GLuint bound_sh_textures[SH_TEXTURE_COUNT]; /**< Last SH tex bound. */
+	GLuint bound_probe_ssbo; /**< Last probe SSBO bound. */
+
 	/* --- Render Configuration --- */
 	int wireframe;            /**< OpenGL wireframe mode toggle. */
 	int billboard_mode;       /**< Toggle for billboard rendering path. */

--- a/include/scene.h
+++ b/include/scene.h
@@ -192,7 +192,8 @@ typedef struct Scene {
 	GLuint dummy_white_tex;      /**< Safe fallback (1,1,1,1). */
 	GLuint lum_ssbo[2]; /**< Double-buffered storage for luminance. */
 	GLuint transition_snapshot_tex; /**< For crossfade mode. */
-	GLuint billboard_ubo; /**< UBO for billboard per-frame uniforms. */
+	GLuint billboard_ubo;    /**< UBO for billboard per-frame uniforms. */
+	void* billboard_ubo_ptr; /**< Persistent mapped CPU pointer for UBO. */
 
 	/* --- IBL Binding Cache (Tier 5 — units 15-17) --- */
 	GLuint bound_ibl_textures[IBL_TEXTURE_COUNT]; /**< Last IBL active. */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
   - Fullscreen Deadlock: fullscreen_deadlock.md
   - SIMD Optimization: simd_optimization.md
   - GPU Sphere Sorting: gpu_sorting.md
+  - Billboard GL Call Reduction: billboard_gl_call_reduction.md
   - Mesa F32-to-F16 Analysis: mesa_f32_to_f16_analysis.md
 - Guides:
   - Justfile Guide: justfile.md

--- a/scripts/integration_scenarios.sh
+++ b/scripts/integration_scenarios.sh
@@ -19,6 +19,8 @@ run_scenario_full() {
 
     echo "=> Log on GPU Metrics (F4)"
     xdotool key --delay 200 F4
+    sleep 2
+    xdotool key --delay 200 F4
     sleep 1
 
     echo "=> Resetting Camera (R)"

--- a/scripts/test_integration_generic.sh
+++ b/scripts/test_integration_generic.sh
@@ -54,16 +54,25 @@ echo "Starting Integration Test Scenario..."
 run_scenario_full
 
 if wait $APP_PID; then
-    echo "SUCCESS: App exited cleanly and AddressSanitizer found no errors."
+    echo "SUCCESS: App exited cleanly."
     EXIT_CODE=0
 else
-    echo "FAILURE: AddressSanitizer reported errors or app crashed!"
+    echo "FAILURE: App crashed or exited with error!"
     EXIT_CODE=1
 fi
 
-echo "---------------------------------------------------"
-echo "AddressSanitizer / LeakSanitizer Report Summary (from $LOG_FILE):"
-grep -E "ERROR: (Address|Leak)Sanitizer" $LOG_FILE || echo "No ASan/LSan errors found in log."
-echo "---------------------------------------------------"
+# Optional: Report summary (Conditional on ASan presence)
+if nm -u "$APP_PATH" 2>/dev/null | grep -q "__asan_init"; then
+    echo "---------------------------------------------------"
+    echo "AddressSanitizer / LeakSanitizer Report Summary (from $LOG_FILE):"
+    grep -E "ERROR: (Address|Leak)Sanitizer" $LOG_FILE || echo "No ASan/LSan errors found in log."
+    echo "---------------------------------------------------"
+else
+    # For non-ASan builds, just show the last few lines of the log to confirm clean exit
+    echo "---------------------------------------------------"
+    echo "Integration Test Log Summary (tail of $LOG_FILE):"
+    tail -n 5 "$LOG_FILE"
+    echo "---------------------------------------------------"
+fi
 
 exit $EXIT_CODE

--- a/shaders/billboard_instance_ssbo.glsl
+++ b/shaders/billboard_instance_ssbo.glsl
@@ -1,0 +1,19 @@
+// billboard_instance_ssbo.glsl — Direct SSBO access for sorted billboard
+// instances. Eliminates the SSBO→VBO copy by reading instance data directly via
+// gl_InstanceID. Must match the C SphereInstance struct layout exactly (128
+// bytes per element with SIMD_ALIGNMENT=64 padding).
+
+struct SphereInstance {
+	mat4 model;
+	vec3 albedo;
+	float metallic;
+	float roughness;
+	float ao;
+	float padding;
+	float _pad[9];
+};
+
+layout(std430, binding = 2) readonly buffer BillboardInstanceSSBO
+{
+	SphereInstance billboard_instances[];
+};

--- a/shaders/billboard_ubo.glsl
+++ b/shaders/billboard_ubo.glsl
@@ -1,0 +1,23 @@
+// billboard_ubo.glsl — Shared UBO for billboard rendering pipeline
+// Must be included BEFORE pbr_functions.glsl / sh_probe.glsl
+
+#define HAS_BILLBOARD_UBO
+
+layout(std140, binding = 1) uniform BillboardBlock
+{
+	mat4 projection;
+	mat4 view;
+	mat4 previousViewProj;
+	vec3 camPos;
+	int debugMode;
+	vec2 u_screenSize;
+	vec2 _bb_pad0;
+	vec3 u_ProbeGridMin;
+	int u_GIMode;
+	vec3 u_ProbeGridMax;
+	bool u_specularAAEnabled;
+	ivec3 u_ProbeGridDim;
+	int u_aaMode;
+	vec3 u_GridToIdxScale;
+	float _bb_pad1;
+};

--- a/shaders/pbr_ibl_billboard.frag
+++ b/shaders/pbr_ibl_billboard.frag
@@ -17,9 +17,9 @@ layout(location = 8) in vec4
 
 @header "billboard_ubo.glsl"
 
-    layout(binding = 0) uniform sampler2D irradianceMap;
-layout(binding = 1) uniform sampler2D prefilterMap;
-layout(binding = 2) uniform sampler2D brdfLUT;
+    layout(binding = 15) uniform sampler2D irradianceMap;
+layout(binding = 16) uniform sampler2D prefilterMap;
+layout(binding = 17) uniform sampler2D brdfLUT;
 
 // Include common PBR functions
 @header "pbr_functions.glsl";

--- a/shaders/pbr_ibl_billboard.frag
+++ b/shaders/pbr_ibl_billboard.frag
@@ -15,16 +15,11 @@ flat layout(location = 7) in float AO;
 layout(location = 8) in vec4
     CurrentClipPos;  // Interpolated clip pos of the quad (juste pour l'AA)
 
-layout(location = 12) uniform vec3 camPos;
-layout(binding = 0) uniform sampler2D irradianceMap;
+@header "billboard_ubo.glsl"
+
+    layout(binding = 0) uniform sampler2D irradianceMap;
 layout(binding = 1) uniform sampler2D prefilterMap;
 layout(binding = 2) uniform sampler2D brdfLUT;
-layout(location = 13) uniform int debugMode;
-
-layout(location = 0) uniform mat4 projection;
-layout(location = 4) uniform mat4 view;
-layout(location = 8) uniform mat4 previousViewProj;
-layout(location = 14) uniform vec2 u_screenSize;
 
 // Include common PBR functions
 @header "pbr_functions.glsl";

--- a/shaders/pbr_ibl_billboard.vert
+++ b/shaders/pbr_ibl_billboard.vert
@@ -25,12 +25,10 @@ layout(location = 8) out vec4
 // out vec4 PreviousClipPos;  <-- SUPPRIMÉ : Le calcul vertex est faux pour un
 // billboard
 
-layout(location = 0) uniform mat4 projection;
-layout(location = 4) uniform mat4 view;
-// uniform mat4 previousViewProj; <-- Inutile ici désormais
-
-// Header pour la fonction computeBillboardSphere
+/* clang-format off */
+@header "billboard_ubo.glsl"
 @header "projection_utils.glsl"
+    /* clang-format on */
 
     void
     main()

--- a/shaders/pbr_ibl_billboard.vert
+++ b/shaders/pbr_ibl_billboard.vert
@@ -3,10 +3,7 @@
 layout(location = 0) in vec3 in_position;  // Quad vertex in local space (+-0.5)
 layout(location = 1) in vec3 in_normal;    // Unused
 
-// Per-instance attributes
-layout(location = 2) in mat4 i_model;   // Instance Model Matrix
-layout(location = 6) in vec3 i_albedo;  // Instance Albedo
-layout(location = 7) in vec3 i_pbr;  // Instance PBR (Metallic, Roughness, AO)
+// Per-instance data fetched from SSBO via gl_InstanceID (Tier 4)
 
 layout(location = 0) out vec3 WorldPos;  // Point on the billboard plane
 layout(location = 1) out vec3 Normal;    // Synchronized (unused)
@@ -26,6 +23,7 @@ layout(location = 8) out vec4
 // billboard
 
 /* clang-format off */
+@header "billboard_instance_ssbo.glsl"
 @header "billboard_ubo.glsl"
 @header "projection_utils.glsl"
     /* clang-format on */
@@ -33,14 +31,17 @@ layout(location = 8) out vec4
     void
     main()
 {
+	// Fetch instance data from sorted SSBO (no VBO copy needed)
+	SphereInstance inst = billboard_instances[gl_InstanceID];
+
 	// 1. Extraction de l'échelle (Rayon)
-	float scaleX = length(vec3(i_model[0]));
-	float scaleY = length(vec3(i_model[1]));
-	float scaleZ = length(vec3(i_model[2]));
+	float scaleX = length(vec3(inst.model[0]));
+	float scaleY = length(vec3(inst.model[1]));
+	float scaleZ = length(vec3(inst.model[2]));
 	float maxScale = max(scaleX, max(scaleY, scaleZ));
 
 	SphereRadius = maxScale;
-	SphereCenter = vec3(i_model[3]);
+	SphereCenter = vec3(inst.model[3]);
 
 	// 2. Calcul de la géométrie du Billboard (Méthode Exacte ou
 	// Conservative) Cette fonction remplit clipPos et WorldPos
@@ -49,10 +50,10 @@ layout(location = 8) out vec4
 	                       projection, clipPos, WorldPos);
 
 	// 3. Transmission des matériaux
-	Albedo = i_albedo;
-	Metallic = i_pbr.x;
-	Roughness = i_pbr.y;
-	AO = i_pbr.z;
+	Albedo = inst.albedo;
+	Metallic = inst.metallic;
+	Roughness = inst.roughness;
+	AO = inst.ao;
 
 	// Normale "face caméra" pour le quad (la vraie normale sera calculée
 	// par raytracing)

--- a/shaders/pbr_ibl_instanced.frag
+++ b/shaders/pbr_ibl_instanced.frag
@@ -13,9 +13,9 @@ layout(location = 6) in vec4 CurrentClipPos;
 layout(location = 7) in vec4 PreviousClipPos;
 
 layout(location = 12) uniform vec3 camPos;
-layout(binding = 0) uniform sampler2D irradianceMap;
-layout(binding = 1) uniform sampler2D prefilterMap;
-layout(binding = 2) uniform sampler2D brdfLUT;
+layout(binding = 15) uniform sampler2D irradianceMap;
+layout(binding = 16) uniform sampler2D prefilterMap;
+layout(binding = 17) uniform sampler2D brdfLUT;
 layout(location = 13) uniform int debugMode;
 
 // Include common PBR functions

--- a/shaders/sh_probe.glsl
+++ b/shaders/sh_probe.glsl
@@ -1,5 +1,6 @@
 // sh_probe.glsl
 
+#ifndef HAS_BILLBOARD_UBO
 layout(location = 15) uniform vec3 u_ProbeGridMin;
 layout(location = 16) uniform vec3 u_ProbeGridMax;
 layout(location = 17) uniform ivec3 u_ProbeGridDim;
@@ -7,6 +8,7 @@ layout(location = 18) uniform int u_GIMode;  // 0: OFF, 1: 3D Texture, 2: SSBO
 layout(location = 19) uniform vec3 u_GridToIdxScale;
 layout(location = 20) uniform bool u_specularAAEnabled;
 layout(location = 21) uniform int u_aaMode;  // 0: Screen-space, 1: Curvature
+#endif
 
 /* 7x 3D textures for SH coefficients (Units 8-14)
    - Tex 0-5: Coeffs 0-7 (RGBA16F, each holds 4 channels)

--- a/src/billboard_rendering.c
+++ b/src/billboard_rendering.c
@@ -87,9 +87,6 @@ void billboard_group_update_from_buffer(BillboardGroup* group,
 
 	glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0,
 	                    size);
-
-	glBindBuffer(GL_COPY_READ_BUFFER, 0);
-	glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
 }
 
 static void setup_billboard_instance_attributes(void)

--- a/src/billboard_rendering.c
+++ b/src/billboard_rendering.c
@@ -164,8 +164,6 @@ void billboard_group_draw(BillboardGroup* group)
 	if (culling_was_enabled) {
 		glEnable(GL_CULL_FACE);
 	}
-
-	glBindVertexArray(0);
 }
 
 void billboard_group_cleanup(BillboardGroup* group)
@@ -184,7 +182,6 @@ void billboard_group_draw_debug_fill(BillboardGroup* group)
 
 	glBindVertexArray(group->vao);
 	glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, group->instance_count);
-	glBindVertexArray(0);
 }
 
 void billboard_group_draw_debug_quads(BillboardGroup* group)
@@ -201,7 +198,6 @@ void billboard_group_draw_debug_quads(BillboardGroup* group)
 	// render_utils_create_wire_quad_vbo puts 4 vertices. We'll use
 	// GL_LINE_LOOP to close it.
 	glDrawArraysInstanced(GL_LINE_LOOP, 0, 4, group->instance_count);
-	glBindVertexArray(0);
 }
 
 void billboard_group_draw_debug_boxes(BillboardGroup* group)
@@ -214,5 +210,4 @@ void billboard_group_draw_debug_boxes(BillboardGroup* group)
 	// Cube VBO has 24 vertices (GL_LINES)
 	glDrawArraysInstanced(GL_LINES, 0, WIRE_CUBE_VERTEX_COUNT,
 	                      group->instance_count);
-	glBindVertexArray(0);
 }

--- a/src/effects/fx_lut_viz.c
+++ b/src/effects/fx_lut_viz.c
@@ -124,7 +124,6 @@ void fx_lut_viz_render(PostProcess* post_processing)
 	glBindVertexArray(viz->vao);
 	glDrawArrays(GL_POINTS, 0,
 	             viz->grid_size * viz->grid_size * viz->grid_size);
-	glBindVertexArray(0);
 
 	glUseProgram(0);
 }

--- a/src/instanced_rendering.c
+++ b/src/instanced_rendering.c
@@ -69,7 +69,6 @@ void instanced_group_draw(InstancedGroup* group, size_t index_count)
 	glBindVertexArray(group->vao);
 	glDrawElementsInstanced(GL_TRIANGLES, (GLsizei)index_count,
 	                        GL_UNSIGNED_INT, 0, group->instance_count);
-	glBindVertexArray(0);
 }
 
 void instanced_group_cleanup(InstancedGroup* group)

--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -701,8 +701,6 @@ void light_probe_render_debug(LightProbeGrid* grid, mat4 view, mat4 proj)
 	glDrawArraysInstanced(GL_TRIANGLES, 0, GI_DEBUG_PROBE_VERTICES,
 	                      grid->total_probes);
 
-	glBindVertexArray(0);
-
 	/* Render AABB Wireframe */
 	if (grid->aabb_shader == NULL) {
 		grid->aabb_shader = shader_load("shaders/debug_line.vert",
@@ -743,7 +741,6 @@ void light_probe_render_debug(LightProbeGrid* grid, mat4 view, mat4 proj)
 
 		glBindVertexArray(grid->aabb_vao);
 		glDrawArrays(GL_LINES, 0, GI_WIRE_CUBE_VERTICES);
-		glBindVertexArray(0);
 	}
 
 	glUseProgram(0);

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -1022,7 +1022,6 @@ void postprocess_end(PostProcess* post_processing)
 	}
 
 	/* Unbind shared VAO after all fullscreen passes are complete */
-	glBindVertexArray(0);
 
 	/* Réactiver le depth test */
 	glEnable(GL_DEPTH_TEST);

--- a/src/scene.c
+++ b/src/scene.c
@@ -604,6 +604,30 @@ void scene_update_gpu_buffers(Scene* scene)
 	glBindVertexArray(0);
 }
 
+/**
+ * @brief Binds SH 3D textures (units 8-14) and probe SSBO only when changed.
+ * Units 8-14 and SSBO binding 3 are exclusive to PBR passes — safe to cache.
+ * Invalidated after light_probe_grid_sync() which clobbers GL_TEXTURE_3D.
+ */
+static void scene_bind_probe_textures(Scene* scene)
+{
+	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
+		GLuint tex = scene->probe_grid.sh_textures[i];
+		if (tex != scene->bound_sh_textures[i]) {
+			glActiveTexture(
+			    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_SH_START + i));
+			glBindTexture(GL_TEXTURE_3D, tex);
+			scene->bound_sh_textures[i] = tex;
+		}
+	}
+
+	if (scene->probe_grid.ssbo != scene->bound_probe_ssbo) {
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3,
+		                 scene->probe_grid.ssbo);
+		scene->bound_probe_ssbo = scene->probe_grid.ssbo;
+	}
+}
+
 static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
                                     vec3 camera_pos, mat4 previous_view_proj,
                                     int width, int height)
@@ -611,6 +635,8 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 	Shader* current_shader = scene->pbr_billboard_shader;
 	shader_use(current_shader);
 
+	/* IBL textures must be re-bound every frame: units 0-2 are
+	 * clobbered by skybox + post-process passes between frames. */
 	render_utils_bind_texture_safe(GL_TEXTURE0, scene->irradiance_tex,
 	                               scene->dummy_black_tex);
 	render_utils_bind_texture_safe(GL_TEXTURE1, scene->spec_prefiltered_tex,
@@ -644,15 +670,7 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		glBindBuffer(GL_UNIFORM_BUFFER, 0);
 	}
 
-	/* Bind SH Textures */
-	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
-		glActiveTexture(
-		    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_SH_START + i));
-		glBindTexture(GL_TEXTURE_3D, scene->probe_grid.sh_textures[i]);
-	}
-
-	/* Bind Probe SSBO for GI Mode 2 (SSBO) */
-	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, scene->probe_grid.ssbo);
+	scene_bind_probe_textures(scene);
 
 	/* Debug Visualization Constants */
 	const float debug_fill_alpha = 0.10F;
@@ -735,6 +753,8 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 
 	shader_use(current_shader);
 
+	/* IBL textures must be re-bound every frame: units 0-2 are
+	 * clobbered by skybox + post-process passes between frames. */
 	render_utils_bind_texture_safe(GL_TEXTURE0, scene->irradiance_tex,
 	                               scene->dummy_black_tex);
 	render_utils_bind_texture_safe(GL_TEXTURE1, scene->spec_prefiltered_tex,
@@ -777,15 +797,7 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 	shader_set_int_loc(scene->instanced_uniforms.gi_mode,
 	                   (int)scene->gi_mode);
 
-	/* Bind SH Textures */
-	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
-		glActiveTexture(
-		    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_SH_START + i));
-		glBindTexture(GL_TEXTURE_3D, scene->probe_grid.sh_textures[i]);
-	}
-
-	/* Bind Probe SSBO for GI Mode 2 (SSBO) */
-	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, scene->probe_grid.ssbo);
+	scene_bind_probe_textures(scene);
 
 #ifdef USE_SSBO_RENDERING
 	ssbo_group_draw(&scene->ssbo_group, scene->geometry.indices.size);
@@ -814,6 +826,12 @@ void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
 	/* GI Probe SSBO sync — must happen before Spheres read it */
 	if (scene->gi_mode != GI_MODE_OFF || scene->show_probe_grid) {
 		light_probe_grid_sync(&scene->probe_grid);
+		/* Sync clobbers 3D texture bindings on the current unit
+		 * via glBindTexture(GL_TEXTURE_3D, 0) — invalidate cache
+		 * so scene_bind_probe_textures() will re-bind. */
+		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
+			scene->bound_sh_textures[i] = 0;
+		}
 	}
 
 #ifdef USE_TRANSPARENT_BILLBOARDS

--- a/src/scene.c
+++ b/src/scene.c
@@ -281,37 +281,13 @@ static int scene_init_billboard_shader(Scene* scene)
 		return 0;
 	}
 
-	scene->billboard_uniforms.debug_mode = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "debugMode");
-	scene->billboard_uniforms.cam_pos =
-	    shader_get_uniform_location(scene->pbr_billboard_shader, "camPos");
-	scene->billboard_uniforms.projection = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "projection");
-	scene->billboard_uniforms.view =
-	    shader_get_uniform_location(scene->pbr_billboard_shader, "view");
-	scene->billboard_uniforms.previous_view_proj =
-	    shader_get_uniform_location(scene->pbr_billboard_shader,
-	                                "previousViewProj");
-	scene->billboard_uniforms.u_screen_size = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "u_screenSize");
-	scene->billboard_uniforms.u_specular_aa_enabled =
-	    shader_get_uniform_location(scene->pbr_billboard_shader,
-	                                "u_specularAAEnabled");
-	scene->billboard_uniforms.u_aa_mode = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "u_aaMode");
-
-	/* Probe Grid */
-	scene->billboard_uniforms.probe_grid_min = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "u_ProbeGridMin");
-	scene->billboard_uniforms.probe_grid_max = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "u_ProbeGridMax");
-	scene->billboard_uniforms.probe_grid_dim = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "u_ProbeGridDim");
-	scene->billboard_uniforms.gi_mode = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "u_GIMode");
-	scene->billboard_uniforms.grid_to_idx_scale =
-	    shader_get_uniform_location(scene->pbr_billboard_shader,
-	                                "u_GridToIdxScale");
+	/* Create UBO for billboard per-frame uniforms (binding = 1) */
+	glGenBuffers(1, &scene->billboard_ubo);
+	glBindBuffer(GL_UNIFORM_BUFFER, scene->billboard_ubo);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(BillboardUBO), NULL,
+	             GL_DYNAMIC_DRAW);
+	glBindBufferBase(GL_UNIFORM_BUFFER, 1, scene->billboard_ubo);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 	/* Set Billboard SH Sampler Indices (units 8-14) */
 	{
@@ -529,6 +505,7 @@ static void scene_cleanup_buffers(Scene* scene)
 	GL_SAFE_DELETE_BUFFER(scene->wire_quad_vbo);
 	GL_SAFE_DELETE_BUFFER(scene->quad_vbo);
 	GL_SAFE_DELETE_BUFFERS(2, scene->lum_ssbo);
+	GL_SAFE_DELETE_BUFFER(scene->billboard_ubo);
 }
 
 static void scene_cleanup_textures(Scene* scene)
@@ -641,44 +618,31 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 	render_utils_bind_texture_safe(GL_TEXTURE2, scene->brdf_lut_tex,
 	                               scene->dummy_black_tex);
 
-	/* Sampler-to-unit mapping is handled by layout(binding=X) in the
-	 * fragment shader — no glUniform1i needed for irradianceMap,
-	 * prefilterMap, brdfLUT. */
-	shader_set_int_loc(scene->billboard_uniforms.debug_mode,
-	                   scene->pbr_debug_mode);
-	shader_set_vec3_loc(scene->billboard_uniforms.cam_pos, camera_pos);
-	shader_set_mat4_loc(scene->billboard_uniforms.projection, (float*)proj);
-	shader_set_mat4_loc(scene->billboard_uniforms.view, (float*)view);
-	shader_set_mat4_loc(scene->billboard_uniforms.previous_view_proj,
-	                    (float*)previous_view_proj);
+	/* Upload all per-frame uniforms via UBO (binding = 1) */
+	{
+		BillboardUBO ubo = {0};
+		glm_mat4_copy(proj, (vec4*)ubo.projection);
+		glm_mat4_copy(view, (vec4*)ubo.view);
+		glm_mat4_copy(previous_view_proj,
+		              (vec4*)ubo.previous_view_proj);
+		glm_vec3_copy(camera_pos, ubo.cam_pos);
+		ubo.debug_mode = scene->pbr_debug_mode;
+		ubo.screen_size[0] = (float)width;
+		ubo.screen_size[1] = (float)height;
+		glm_vec3_copy(scene->probe_grid.aabb_min, ubo.probe_grid_min);
+		ubo.gi_mode = (int32_t)scene->gi_mode;
+		glm_vec3_copy(scene->probe_grid.aabb_max, ubo.probe_grid_max);
+		ubo.specular_aa_enabled = scene->specular_aa_enabled;
+		ubo.probe_grid_dim[0] = scene->probe_grid.grid_dim[0];
+		ubo.probe_grid_dim[1] = scene->probe_grid.grid_dim[1];
+		ubo.probe_grid_dim[2] = scene->probe_grid.grid_dim[2];
+		ubo.aa_mode = scene->aa_mode;
 
-	float screen_size[2] = {(float)width, (float)height};
-	shader_set_vec2_loc(scene->billboard_uniforms.u_screen_size,
-	                    screen_size);
-
-	if (scene->billboard_uniforms.u_specular_aa_enabled != -1) {
-		glUniform1i(scene->billboard_uniforms.u_specular_aa_enabled,
-		            scene->specular_aa_enabled);
+		glBindBuffer(GL_UNIFORM_BUFFER, scene->billboard_ubo);
+		glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(BillboardUBO),
+		                &ubo);
+		glBindBuffer(GL_UNIFORM_BUFFER, 0);
 	}
-	if (scene->billboard_uniforms.u_aa_mode != -1) {
-		glUniform1i(scene->billboard_uniforms.u_aa_mode,
-		            scene->aa_mode);
-	}
-
-	/* Probe Grid spatial bounds and GI Toggle */
-	shader_set_vec3_loc(scene->billboard_uniforms.probe_grid_min,
-	                    scene->probe_grid.aabb_min);
-	shader_set_vec3_loc(scene->billboard_uniforms.probe_grid_max,
-	                    scene->probe_grid.aabb_max);
-
-	if (scene->billboard_uniforms.probe_grid_dim != -1) {
-		glUniform3i(scene->billboard_uniforms.probe_grid_dim,
-		            scene->probe_grid.grid_dim[0],
-		            scene->probe_grid.grid_dim[1],
-		            scene->probe_grid.grid_dim[2]);
-	}
-	shader_set_int_loc(scene->billboard_uniforms.gi_mode,
-	                   (int)scene->gi_mode);
 
 	/* Bind SH Textures */
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {

--- a/src/scene.c
+++ b/src/scene.c
@@ -281,12 +281,6 @@ static int scene_init_billboard_shader(Scene* scene)
 		return 0;
 	}
 
-	scene->billboard_uniforms.irradiance_map = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "irradianceMap");
-	scene->billboard_uniforms.prefilter_map = shader_get_uniform_location(
-	    scene->pbr_billboard_shader, "prefilterMap");
-	scene->billboard_uniforms.brdf_lut =
-	    shader_get_uniform_location(scene->pbr_billboard_shader, "brdfLUT");
 	scene->billboard_uniforms.debug_mode = shader_get_uniform_location(
 	    scene->pbr_billboard_shader, "debugMode");
 	scene->billboard_uniforms.cam_pos =
@@ -647,9 +641,9 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 	render_utils_bind_texture_safe(GL_TEXTURE2, scene->brdf_lut_tex,
 	                               scene->dummy_black_tex);
 
-	shader_set_int_loc(scene->billboard_uniforms.irradiance_map, 0);
-	shader_set_int_loc(scene->billboard_uniforms.prefilter_map, 1);
-	shader_set_int_loc(scene->billboard_uniforms.brdf_lut, 2);
+	/* Sampler-to-unit mapping is handled by layout(binding=X) in the
+	 * fragment shader — no glUniform1i needed for irradianceMap,
+	 * prefilterMap, brdfLUT. */
 	shader_set_int_loc(scene->billboard_uniforms.debug_mode,
 	                   scene->pbr_debug_mode);
 	shader_set_vec3_loc(scene->billboard_uniforms.cam_pos, camera_pos);

--- a/src/scene.c
+++ b/src/scene.c
@@ -246,6 +246,10 @@ static void scene_init_state(Scene* scene)
 	scene->irradiance_tex = 0;
 	scene->transition_snapshot_tex = 0;
 
+	for (int i = 0; i < IBL_TEXTURE_COUNT; i++) {
+		scene->bound_ibl_textures[i] = 0;
+	}
+
 	scene_scan_hdr_files(scene);
 	// Initial load of default map is handled by app or caller
 	// We just setup the state here.
@@ -350,12 +354,6 @@ static int scene_init_instanced_shader(Scene* scene, Shader** out_shader)
 	*out_shader = scene->pbr_instanced_shader;
 #endif
 
-	scene->instanced_uniforms.irradiance_map =
-	    shader_get_uniform_location(*out_shader, "irradianceMap");
-	scene->instanced_uniforms.prefilter_map =
-	    shader_get_uniform_location(*out_shader, "prefilterMap");
-	scene->instanced_uniforms.brdf_lut =
-	    shader_get_uniform_location(*out_shader, "brdfLUT");
 	scene->instanced_uniforms.debug_mode =
 	    shader_get_uniform_location(*out_shader, "debugMode");
 	scene->instanced_uniforms.cam_pos =
@@ -628,6 +626,25 @@ static void scene_bind_probe_textures(Scene* scene)
 	}
 }
 
+static void scene_bind_ibl_textures(Scene* scene)
+{
+	GLuint textures[IBL_TEXTURE_COUNT] = {
+	    scene->irradiance_tex ? scene->irradiance_tex
+	                          : scene->dummy_black_tex,
+	    scene->spec_prefiltered_tex ? scene->spec_prefiltered_tex
+	                                : scene->dummy_black_tex,
+	    scene->brdf_lut_tex ? scene->brdf_lut_tex : scene->dummy_black_tex};
+
+	for (int i = 0; i < IBL_TEXTURE_COUNT; i++) {
+		if (textures[i] != scene->bound_ibl_textures[i]) {
+			glActiveTexture(
+			    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_IBL_START + i));
+			glBindTexture(GL_TEXTURE_2D, textures[i]);
+			scene->bound_ibl_textures[i] = textures[i];
+		}
+	}
+}
+
 static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
                                     vec3 camera_pos, mat4 previous_view_proj,
                                     int width, int height)
@@ -635,14 +652,7 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 	Shader* current_shader = scene->pbr_billboard_shader;
 	shader_use(current_shader);
 
-	/* IBL textures must be re-bound every frame: units 0-2 are
-	 * clobbered by skybox + post-process passes between frames. */
-	render_utils_bind_texture_safe(GL_TEXTURE0, scene->irradiance_tex,
-	                               scene->dummy_black_tex);
-	render_utils_bind_texture_safe(GL_TEXTURE1, scene->spec_prefiltered_tex,
-	                               scene->dummy_black_tex);
-	render_utils_bind_texture_safe(GL_TEXTURE2, scene->brdf_lut_tex,
-	                               scene->dummy_black_tex);
+	scene_bind_ibl_textures(scene);
 
 	/* Upload all per-frame uniforms via UBO (binding = 1) */
 	{
@@ -753,18 +763,8 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 
 	shader_use(current_shader);
 
-	/* IBL textures must be re-bound every frame: units 0-2 are
-	 * clobbered by skybox + post-process passes between frames. */
-	render_utils_bind_texture_safe(GL_TEXTURE0, scene->irradiance_tex,
-	                               scene->dummy_black_tex);
-	render_utils_bind_texture_safe(GL_TEXTURE1, scene->spec_prefiltered_tex,
-	                               scene->dummy_black_tex);
-	render_utils_bind_texture_safe(GL_TEXTURE2, scene->brdf_lut_tex,
-	                               scene->dummy_black_tex);
+	scene_bind_ibl_textures(scene);
 
-	shader_set_int_loc(scene->instanced_uniforms.irradiance_map, 0);
-	shader_set_int_loc(scene->instanced_uniforms.prefilter_map, 1);
-	shader_set_int_loc(scene->instanced_uniforms.brdf_lut, 2);
 	shader_set_int_loc(scene->instanced_uniforms.debug_mode,
 	                   scene->pbr_debug_mode);
 	shader_set_vec3_loc(scene->instanced_uniforms.cam_pos, camera_pos);

--- a/src/scene.c
+++ b/src/scene.c
@@ -877,9 +877,19 @@ void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
 					    camera_pos);
 					break;
 			}
-			billboard_group_update_from_buffer(
-			    &scene->billboard_group, sorted_ssbo,
-			    scene->sphere_instance_count);
+			/* Tier 4: Sorted SSBO already bound at binding 2 by
+			 * sort functions — vertex shader reads it directly
+			 * via gl_InstanceID (no VBO copy needed). */
+			scene->billboard_group.instance_count =
+			    scene->sphere_instance_count;
+
+			/* Legacy VBO copy only for debug wireframe overlay
+			 * (debug_line_shader reads per-instance attributes) */
+			if (scene->wireframe) {
+				billboard_group_update_from_buffer(
+				    &scene->billboard_group, sorted_ssbo,
+				    scene->sphere_instance_count);
+			}
 
 			glEnablei(GL_BLEND, 0);
 			glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/scene.c
+++ b/src/scene.c
@@ -230,6 +230,7 @@ static void scene_init_state(Scene* scene)
 	scene->sorting_mode = SORTING_MODE_GPU_BITONIC;
 	scene->gi_mode = GI_MODE_OFF;
 	scene->show_probe_grid = 0;
+	scene->billboard_ubo_ptr = NULL;
 
 	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 	memset(&scene->sphere_sorter, 0, sizeof(SphereSorter));
@@ -288,8 +289,12 @@ static int scene_init_billboard_shader(Scene* scene)
 	/* Create UBO for billboard per-frame uniforms (binding = 1) */
 	glGenBuffers(1, &scene->billboard_ubo);
 	glBindBuffer(GL_UNIFORM_BUFFER, scene->billboard_ubo);
-	glBufferData(GL_UNIFORM_BUFFER, sizeof(BillboardUBO), NULL,
-	             GL_DYNAMIC_DRAW);
+	GLbitfield flags = (GLbitfield)GL_MAP_WRITE_BIT |
+	                   (GLbitfield)GL_MAP_PERSISTENT_BIT |
+	                   (GLbitfield)GL_MAP_COHERENT_BIT;
+	glBufferStorage(GL_UNIFORM_BUFFER, sizeof(BillboardUBO), NULL, flags);
+	scene->billboard_ubo_ptr =
+	    glMapBufferRange(GL_UNIFORM_BUFFER, 0, sizeof(BillboardUBO), flags);
 	glBindBufferBase(GL_UNIFORM_BUFFER, 1, scene->billboard_ubo);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
@@ -674,10 +679,11 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		ubo.probe_grid_dim[2] = scene->probe_grid.grid_dim[2];
 		ubo.aa_mode = scene->aa_mode;
 
-		glBindBuffer(GL_UNIFORM_BUFFER, scene->billboard_ubo);
-		glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(BillboardUBO),
-		                &ubo);
-		glBindBuffer(GL_UNIFORM_BUFFER, 0);
+		if (scene->billboard_ubo_ptr) {
+			// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+			memcpy(scene->billboard_ubo_ptr, &ubo,
+			       sizeof(BillboardUBO));
+		}
 	}
 
 	scene_bind_probe_textures(scene);

--- a/src/skybox.c
+++ b/src/skybox.c
@@ -61,7 +61,6 @@ void skybox_render(Skybox* skybox, Shader* shader, GLuint env_map,
 	/* Draw fullscreen quad */
 	glBindVertexArray(skybox->vao);
 	glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
-	glBindVertexArray(0);
 
 	/* Restore default depth test */
 	glDepthFunc(GL_LESS);

--- a/src/sphere_sorting.c
+++ b/src/sphere_sorting.c
@@ -112,6 +112,10 @@ static GLuint upload_sorted_to_ssbo(SphereSorter* sorter, int count)
 		                sorter->temp_instances);
 	}
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+
+	/* Bind sorted data at binding 2 so billboard vertex shader can
+	 * read it via gl_InstanceID (GPU sort already does this). */
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, sorter->instance_ssbo);
 	return sorter->instance_ssbo;
 }
 

--- a/src/ssbo_rendering.c
+++ b/src/ssbo_rendering.c
@@ -67,7 +67,6 @@ void ssbo_group_draw(SSBOGroup* group, size_t index_count)
 	glBindVertexArray(group->vao);
 	glDrawElementsInstanced(GL_TRIANGLES, (GLsizei)index_count,
 	                        GL_UNSIGNED_INT, 0, group->instance_count);
-	glBindVertexArray(0);
 }
 
 void ssbo_group_cleanup(SSBOGroup* group)

--- a/src/ui.c
+++ b/src/ui.c
@@ -164,7 +164,6 @@ static int setup_vertex_buffers(UIContext* ui_context)
 	    4, 3, GL_FLOAT, GL_FALSE, stride,
 	    utils_buffer_offset(offsetof(UIVertex, rect_size_x)));
 
-	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 	return 1;
@@ -352,7 +351,6 @@ void ui_flush(UIContext* ui_context)
 
 	glDrawArrays(GL_TRIANGLES, 0, ui_context->batch_count);
 
-	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glUseProgram(0);
@@ -653,7 +651,6 @@ void ui_draw_spinner(UIContext* ui_context, float center_x, float center_y,
 	glDrawArrays(GL_TRIANGLES, 0, VERTICES_PER_QUAD);
 
 	/* Cleanup */
-	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glUseProgram(0);
 


### PR DESCRIPTION
## Summary

Reduce the number of OpenGL commands in the `Billboard_Sort_And_Render` pass, as measured in RenderDoc.

**Baseline:** ~65 GL commands per frame for this pass.
<img width="808" height="531" alt="image" src="https://github.com/user-attachments/assets/cc5ac6b3-62b3-480f-a446-e2d41ab25ad4" />

## Tiered Optimization Plan

| Tier | Description | Calls Saved | Status |
|------|-------------|-------------|--------|
| **Tier 1** | Remove redundant sampler uniforms + defensive unbinds | 5 | ✅ Done |
| **Tier 2** | UBO for per-frame uniforms (~12 calls → 1) | 11 | ✅ Done |
| **Tier 3** | Cache SH textures + probe SSBO bindings | 15 | ✅ Done |
| Tier 4 | Direct SSBO read in vertex shader (eliminate copy) | 7 | 🔲 Planned |

**Target:** ~65 → ~28 GL commands (**~57% reduction**).

## Tier 1 Changes

### Redundant sampler uniforms removed
The fragment shader declares `layout(binding=0/1/2)` for `irradianceMap`, `prefilterMap`, `brdfLUT`.
The 3x `glUniform1i` calls setting the same sampler-to-unit mapping were **redundant** and have been removed.
The `BillboardUniforms` struct has been cleaned (3 members + 3 `shader_get_uniform_location` calls removed).

### Defensive unbinds removed
After `glCopyBufferSubData` (SSBO→VBO copy), 2x `glBindBuffer(..., 0)` were unnecessary defensive unbinds.
`GL_COPY_READ_BUFFER` and `GL_COPY_WRITE_BUFFER` are private binding points with no side effects.

### RenderDoc Validation
<img width="731" height="445" alt="image" src="https://github.com/user-attachments/assets/4aa94567-8d5e-4992-bfa5-cf49a3c6b5be" />

Pass reduced from **64 → 59 commands** (confirmed in capture).

## Tier 2 Changes

- Replace ~12 individual `glUniform*` calls with single `BillboardUBO` (std140, binding=1)
- New shared GLSL block: `shaders/billboard_ubo.glsl`
- `sh_probe.glsl` guarded with `#ifndef HAS_BILLBOARD_UBO`
- Generic UBO alignment API in `include/gl_common.h` (`GL_UBO_ALIGNED`, `GL_ASSERT_UBO_ALIGNMENT`)
- Applied to both `BillboardUBO` and `PostProcessUBO` — compile-time AVX safety

### RenderDoc Validation
<img width="400" height="39" alt="image" src="https://github.com/user-attachments/assets/9361b37a-befb-49e8-b735-5dacc4fac5ec" />

Pass reduced from **59 → 50 commands** (confirmed in capture).

## Tier 3 Changes

### Problem: not all bindings are cachable
Initial approach cached all texture bindings (units 0-14 + SSBO). This **broke rendering** — IBL textures on units 0-2 are clobbered between frames by Skybox (`GL_TEXTURE0`) and PostProcess passes that share the same texture units.

### Corrected scope: SH textures + probe SSBO only
| Binding | Cachable? | Reason |
|---------|-----------|--------|
| IBL textures (units 0-2) | **NO** | Skybox + PostProcess clobber these units |
| SH 3D textures (units 8-14) | **YES** | Exclusive to PBR passes, no other pass touches units 8-14 |
| Probe SSBO (binding 3) | **YES** | Exclusive to PBR passes, sort uses bindings 0-2 |

### Implementation
- `scene_bind_probe_textures()` — per-handle comparison, bind only on change
- `bound_sh_textures[7]` + `bound_probe_ssbo` added to `Scene` struct
- Cache invalidated after `light_probe_grid_sync()` (sync clobbers `GL_TEXTURE_3D` bindings via `glBindTexture(GL_TEXTURE_3D, 0)`)
- Applied to **both** billboard and instanced rendering paths

### RenderDoc Validation
<img width="391" height="22" alt="image" src="https://github.com/user-attachments/assets/33f8a2fd-07cf-413a-9404-bed78900f240" />

Pass reduced from **50 → 35 commands** in steady state (confirmed in capture).

## Tier 4 Changes

### Direct SSBO read in vertex shader (eliminate SSBO→VBO copy)

The billboard vertex shader now reads sorted instance data **directly from the SSBO** via `gl_InstanceID`, eliminating the per-frame `glCopyBufferSubData` copy entirely.

**Key insight:** the GPU bitonic sort already binds `sorted_instance_ssbo` at SSBO binding point 2 via `glBindBufferBase`. After `glUseProgram(0)`, only the generic `GL_SHADER_STORAGE_BUFFER` target is unbound — the **indexed binding point 2 remains valid**. No additional bind needed.

For CPU sort paths (qsort, radix), a single `glBindBufferBase(binding 2)` is added at the end of `upload_sorted_to_ssbo()` to match the GPU sort's convention.

### New files
- `shaders/billboard_instance_ssbo.glsl`: `SphereInstance` struct (std430, binding 2) matching the C struct's 128-byte stride with SIMD padding

### Modified files
- `shaders/pbr_ibl_billboard.vert`: replaced `layout(location = 2..7)` per-instance vertex attributes with SSBO fetch via `billboard_instances[gl_InstanceID]`
- `src/scene.c`: removed `billboard_group_update_from_buffer()` call (kept only when `scene->wireframe` for debug overlay)
- `src/sphere_sorting.c`: CPU sort paths now bind result at binding 2

### Call savings

| Sort mode | Removed | Added | Net |
|-----------|---------|-------|-----|
| GPU bitonic (default) | 3 (bind read, bind write, copy) | 0 | **-3** |
| CPU qsort/radix | 3 | 1 (`glBindBufferBase` in sort) | **-2** |

### RenderDoc Validation
<img width="378" height="29" alt="image" src="https://github.com/user-attachments/assets/23b786a1-0790-48dc-84d1-73305bd54f83" />

Pass reduced from **35 → 32 commands** (confirmed in capture).

### Cumulative results (all 4 tiers)

| Tier | Calls saved | Remaining |
|------|-------------|-----------|
| Baseline | — | **~65** |
| Tier 1 (redundant calls) | 5 | ~60 |
| Tier 2 (UBO) | 11 | ~49 |
| Tier 3 (SH/SSBO cache) | 15 | ~34 |
| **Tier 4 (SSBO direct)** | **3** | **~32** |

**Total: ~65 → ~32 commands (~51% reduction).**

## Tier 5

<img width="691" height="608" alt="image" src="https://github.com/user-attachments/assets/2885ff70-1a79-4cd8-913a-83815ceff0d5" />

```
1. Assigner des "Texture Units" dédiées pour l'IBL (Gain : -6 appels)
Le problème actuel : Les textures IBL (unités 0, 1 et 2) sont re-bindées à chaque frame car tu as documenté qu'elles étaient écrasées par le rendu de la Skybox et le Post-Process.
La solution : Le GPU possède au moins 16 à 32 unités de texture. On peut réserver fermement les unités 0, 1, 2 pour l'IBL PBR (qui est global à la scène). La Skybox et le Post-process devraient utiliser d'autres unités (ex: 15, 16).
Bénéfice : Cela évite la pollution croisée des états entre les passes. On peut ainsi mettre l'IBL dans le même système de cache que les textures SH (Tier 3) et tomber à 0 appel par frame pour le binding d'IBL dans la passe Billboard.

2. Persistent Mapped Buffers pour l'UBO (Gain : -3 appels)
Le problème actuel : Chaque mise à jour de l'UBO requiert de faire glBindBuffer + glBufferSubData + glBindBuffer(0).
La solution : Utiliser glBufferStorage avec les flags GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT lors de l'initialisation. Cela te donne un pointeur CPU (void* ptr = glMapBufferRange(...)) qui reste valide "pour toujours".
Bénéfice : Pour mettre à jour l'UBO, il te suffira de faire un simple memcpy(ptr, &ubo, sizeof(BillboardUBO)); en C. Zéro appel à OpenGL nécessaire pendant la boucle de rendu pour l'UBO.

3. Bindless Textures (GL_ARB_bindless_texture) (Gain maximal, mais technique)
La solution ultime : Plutôt que de dire au GPU "mets cette texture sur le slot N", on demande explicitement au GPU l'adresse mémoire 64-bits de la texture (glGetTextureHandleARB).
Bénéfice : Fini les glActiveTexture et glBindTexture. Les adresses 64-bits des textures (IBL et SH) sont simplement ajoutées à la struct BillboardUBO. Le shader y accède directement.
Intérêt : C'est le Graal de l'AZDO et la manière dont fonctionne Vulkan. Cela éliminerait totalement la nécessité de faire du caching d'état (Tier 3), simplifiant énormément scene.c.

4. Suppression des unbinds défensifs résiduels (Gain : -1 ou -2 appels)
A la fin de ta mise à jour UBO, tu appelles glBindBuffer(GL_UNIFORM_BUFFER, 0). À moins qu'une autre passe de ton moteur ne subisse un bug si un UBO reste bindé, cet appel est très probablement superflu. L'automate d'état d'OpenGL s'en moque. Devoir "nettoyer derrière soi" n'est généralement pas nécessaire si on re-bind toujours explicitement ce dont on a besoin avant d'utiliser.
```

## Documentation
- `docs/billboard_gl_call_reduction.md` (EN) and `.fr.md` (FR)
- Added to `mkdocs.yml` under Optimization section

## Tests
- `just format` ✅ (0 changes)
- `just lint` ✅ (58 files, 0 warnings; 26 shaders, 0 warnings)
- `just test-all` ✅ (60/60 passed — including `test_app` integration tests)