### PR TITLE
fix(gpu): Add RenderDoc debug groups and fix F12 keybind collision

### DIFF
--- a/docs/renderdoc_guide.fr.md
+++ b/docs/renderdoc_guide.fr.md
@@ -40,6 +40,7 @@ Pour capturer une séquence de génération IBL complète :
 1. Lancer l'application via RenderDoc
 2. Appuyer sur `E` pour déclencher un changement d'environnement
 3. Appuyer sur `F12` pour capturer les frames immédiatement après (génération IBL progressive)
+   *(Note : les captures d'écran PNG natives de l'application se font désormais avec `SHIFT+F12` pour éviter les conflits)*
 4. Analyser les passes compute dans l'Event Browser
 
 ## Conseils Intel/Mesa

--- a/docs/renderdoc_guide.md
+++ b/docs/renderdoc_guide.md
@@ -37,6 +37,7 @@ Environment loading is asynchronous and is triggered via the `Page Up` / `Page D
 1.  Click **"Launch"** in RenderDoc.
 2.  In your application, get ready to switch environments.
 3.  Press **F12** (or `Print Screen`) in the application to capture a frame.
+    *   *Note: Application's native PNG screenshots have been moved to `SHIFT+F12` to avoid conflicts with RenderDoc.*
     *   *Note: Since IBL loading takes several frames (~500ms), you may need to take several successive captures to hit the exact frame where the Compute Shaders are running.*
 4.  A thumbnail appears in RenderDoc. Double-click it to open.
 

--- a/src/app_binding.c
+++ b/src/app_binding.c
@@ -206,7 +206,7 @@ void app_binding_registry_init(AppBindingRegistry* registry)
 	add_binding(GLFW_KEY_F9, 0, "Toggle Perf Mode",
 	            "Toggles Performance Mode (disables heavy effects).",
 	            BINDING_CAT_SYSTEM, BINDING_TYPE_TOGGLE);
-	add_binding(GLFW_KEY_F12, 0, "Take Screenshot",
+	add_binding(GLFW_KEY_F12, GLFW_MOD_SHIFT, "Take Screenshot",
 	            "Saves the current frame as a PNG image.",
 	            BINDING_CAT_SYSTEM, BINDING_TYPE_ACTION);
 	add_binding(GLFW_KEY_O, 0, "Cycle Sorting",

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -317,6 +317,9 @@ static bool handle_f_key_input(App* app, int key, int mods)
 			handle_f9_input(app);
 			return true;
 		case GLFW_KEY_F12: {
+			if (!check_flag(mods, GLFW_MOD_SHIFT)) {
+				return false;
+			}
 			enum { FILENAME_BUF_SIZE = 64 };
 			char filename[FILENAME_BUF_SIZE];
 			time_t now = time(NULL);

--- a/src/sphere_sorting.c
+++ b/src/sphere_sorting.c
@@ -1,6 +1,7 @@
 #include "sphere_sorting.h"
 
-#include "gl_common.h"           /* For SIMD_ALIGNMENT */
+#include "gl_common.h" /* For SIMD_ALIGNMENT */
+#include "gl_debug.h"
 #include "instanced_rendering.h" /* For SphereInstance */
 #include "log.h"
 #include "platform/platform_utils.h"
@@ -239,8 +240,11 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
 			glUniform1ui(sorter->loc_stage,
 			             3U); /* Stage 3: Single Pass */
 		}
+
+		gl_debug_push_group("GPU Sort: Single-Pass Shared Memory Sort");
 		glDispatchCompute(1, 1, 1);
 		glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+		gl_debug_pop_group();
 
 		glUseProgram(0);
 		glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
@@ -254,14 +258,18 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
 	if (sorter->loc_stage >= 0) {
 		glUniform1ui(sorter->loc_stage, 0U);
 	}
+
+	gl_debug_push_group("GPU Sort: Prepare");
 	glDispatchCompute(num_groups, 1, 1);
 	glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+	gl_debug_pop_group();
 
 	/* 4b. SORT Stage (u_stage = 1): Bitonic Sort on entries (indices) */
 	if (sorter->loc_stage >= 0) {
 		glUniform1ui(sorter->loc_stage, 1U);
 	}
 
+	gl_debug_push_group("GPU Sort: Bitonic Sort");
 	for (unsigned int k = 2U; k <= u_count_pot; k <<= 1U) {
 		for (unsigned int j = k >> 1U; j > 0U; j >>= 1U) {
 			if (sorter->loc_j >= 0) {
@@ -274,13 +282,17 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
 			glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 		}
 	}
+	gl_debug_pop_group();
 
 	/* 4c. PERMUTE Stage (u_stage = 2): Reorder instances */
 	if (sorter->loc_stage >= 0) {
 		glUniform1ui(sorter->loc_stage, 2U);
 	}
+
+	gl_debug_push_group("GPU Sort: Permute");
 	glDispatchCompute(num_groups, 1, 1);
 	glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+	gl_debug_pop_group();
 
 	glUseProgram(0);
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -692,3 +692,12 @@ void glDeleteSync(GLsync sync)
 {
 	(void)sync;
 }
+
+void gl_debug_push_group(const char* name)
+{
+	(void)name;
+}
+
+void gl_debug_pop_group(void)
+{
+}


### PR DESCRIPTION
This PR introduces a series of QoL improvements for GPU debugging using RenderDoc:

- Added OpenGL debug group markers (`glPushDebugGroup` & `glPopDebugGroup`) around the sphere sorting Compute Shader dispatches. This allows these passes to be explicitly visible and distinct inside RenderDoc's Event Browser.
- Fixed an ensuing linkage error where `gl_debug_push_group` stubs were missing in `mock_gl_standalone.c`, resolving unit test compilation failures.
- Resolved a keybind conflict by changing the application's native screenshot shortcut from `F12` to `SHIFT+F12` (leaving `F12` fully available for RenderDoc frame capturing).
- Updated the in-app Keyboard Helper overlay and MarkDown documentations (FR/EN) to reflect the new SHIFT modifier.