### PR TITLE
🚀 Amélioration de la Précision et de la Couverture du Profileur GPU

### DIFF
--- a/include/scene.h
+++ b/include/scene.h
@@ -4,6 +4,7 @@
 #include "app_settings.h"
 #include "billboard_rendering.h"
 #include "gl_common.h"
+#include "gpu_profiler.h"
 #include "ibl_coordinator.h"
 #include "icosphere.h"
 #include "instanced_rendering.h"
@@ -252,8 +253,9 @@ const char* aa_mode_to_string(AAMode mode);
  * @param width Viewport width.
  * @param height Viewport height.
  */
-void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
-                  mat4 previous_view_proj, int width, int height);
+void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
+                  vec3 camera_pos, mat4 previous_view_proj, int width,
+                  int height);
 
 /**
  * @brief Updates GPU buffers for dynamic geometry (e.g. LOD changes).

--- a/src/app.c
+++ b/src/app.c
@@ -204,6 +204,16 @@ void app_run(App* app)
 			app->resize_pending = 0;
 		}
 
+		bool profiling_enabled =
+		    (app->timeline_ui.visible || app->log_gpu_metrics != 0 ||
+		     effect_benchmark_is_running(&app->effect_bench)) != 0;
+		gpu_profiler_set_enabled(&app->gpu_profiler, profiling_enabled);
+		gpu_profiler_begin_frame(&app->gpu_profiler, app->frame_count);
+
+		/* 1. Global Measure (includes CPU update and GPU swap) */
+		GPU_STAGE_PROFILER(&app->gpu_profiler, "Total Frame",
+		                   GPU_PROFILER_TOTAL_FRAME_COLOR);
+
 		app->frame_count++;
 		double current_time = glfwGetTime();
 		app->delta_time = current_time - app->last_frame_time;
@@ -280,6 +290,8 @@ void app_run(App* app)
 		}
 
 		{
+			GPU_STAGE_PROFILER(&app->gpu_profiler, "Swap Buffers",
+			                   GPU_PROFILER_UI_COLOR);
 			PROFILE_ZONE(swap_ctx, "GLFW SwapBuffers");
 			glfwSwapBuffers(app->window);
 			PROFILE_ZONE_END(swap_ctx);

--- a/src/effect_benchmark.c
+++ b/src/effect_benchmark.c
@@ -69,7 +69,7 @@ static const int BENCHMARKABLE_COUNT =
 static float find_composite_duration(const GPUProfiler* profiler)
 {
 	for (int i = 0; i < profiler->stage_count; ++i) {
-		if (strcmp(profiler->stages[i].name, "Final Composite") == 0) {
+		if (strcmp(profiler->stages[i].name, "Post-Process") == 0) {
 			return profiler->stages[i].duration_ms;
 		}
 	}

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -792,10 +792,6 @@ void postprocess_end(PostProcess* post_processing)
 	 * Exposure, Tonemapping, FXAA, Vignette, Grain, etc.
 	 * The cost of Motion Blur fragment work is measured HERE. */
 	{
-		GPU_STAGE_PROFILER(post_processing->gpu_profiler,
-		                   "Final Composite",
-		                   GPU_PROFILER_COMPOSITE_COLOR);
-
 		gl_debug_push_group("PostFX_Final_Composite");
 
 		/* Retour au framebuffer par défaut */

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -18,8 +18,6 @@ void renderer_draw_frame(struct App* app_ref, Scene* scene,
 	bool profiling_enabled =
 	    (timeline_ui->visible || log_gpu_metrics != 0 ||
 	     effect_benchmark_is_running(effect_bench)) != 0;
-	gpu_profiler_set_enabled(profiler, profiling_enabled);
-	gpu_profiler_begin_frame(profiler, frame_count);
 	postprocess_update_readbacks(postprocess, frame_count);
 
 	PROFILE_FRAME_MARK;
@@ -29,10 +27,6 @@ void renderer_draw_frame(struct App* app_ref, Scene* scene,
 		action_notifier_push(notifier, "FX Benchmark: Done (see log)",
 		                     NOTIF_DUR_LONG);
 	}
-
-	// 2. Démarrer la mesure globale de la frame
-	GPU_STAGE_PROFILER(profiler, "Total Frame",
-	                   GPU_PROFILER_TOTAL_FRAME_COLOR);
 
 	gl_debug_push_group("Render_Frame");
 
@@ -56,11 +50,15 @@ void renderer_draw_frame(struct App* app_ref, Scene* scene,
 	glm_mat4_mul(proj, view, view_proj);
 	glm_mat4_inv(view_proj, inv_view_proj);
 
-	gl_debug_push_group("Scene_Render");
-	scene_render(scene, view, proj, camera_pos,
-	             postprocess->motion_blur_fx.previous_view_proj, width,
-	             height);
-	gl_debug_pop_group();
+	{
+		GPU_STAGE_PROFILER(profiler, "Scene Render",
+		                   GPU_PROFILER_SCENE_COLOR);
+		gl_debug_push_group("Scene_Render");
+		scene_render(scene, profiler, view, proj, camera_pos,
+		             postprocess->motion_blur_fx.previous_view_proj,
+		             width, height);
+		gl_debug_pop_group();
+	}
 
 	gl_debug_push_group("Post_Processing");
 	postprocess_end(postprocess);

--- a/src/scene.c
+++ b/src/scene.c
@@ -821,8 +821,9 @@ static inline void stencil_begin_object_pass(void)
 	glStencilMask(DEFAULT_STENCIL_MASK);
 }
 
-void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
-                  mat4 previous_view_proj, int width, int height)
+void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
+                  vec3 camera_pos, mat4 previous_view_proj, int width,
+                  int height)
 {
 	mat4 view_proj;
 	mat4 inv_view_proj;
@@ -842,6 +843,8 @@ void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
 	if (scene->show_envmap) {
+		GPU_STAGE_PROFILER(profiler, "Environment",
+		                   GPU_PROFILER_ENV_COLOR);
 		gl_debug_push_group("Skybox_Pass");
 		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 		glDisable(GL_DEPTH_TEST);
@@ -858,31 +861,45 @@ void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
 		if (scene->billboard_mode) {
 			gl_debug_push_group("Billboard_Sort_And_Render");
 			GLuint sorted_ssbo = 0;
-			switch (scene->sorting_mode) {
-				case SORTING_MODE_CPU_QSORT:
-					sorted_ssbo = sphere_sorter_sort_cpu(
-					    &scene->sphere_sorter,
-					    scene->sphere_instances,
-					    scene->sphere_instance_count,
-					    camera_pos);
-					break;
-				case SORTING_MODE_CPU_RADIX:
-					sorted_ssbo =
-					    sphere_sorter_sort_cpu_radix(
-					        &scene->sphere_sorter,
-					        scene->sphere_instances,
-					        scene->sphere_instance_count,
-					        camera_pos);
-					break;
-				case SORTING_MODE_GPU_BITONIC:
-				default:
-					sorted_ssbo = sphere_sorter_sort_gpu(
-					    &scene->sphere_sorter,
-					    scene->sphere_instances,
-					    scene->sphere_instance_count,
-					    camera_pos);
-					break;
+
+			/* 1. Sorting Pass (CPU or GPU) */
+			{
+				GPU_STAGE_PROFILER(
+				    profiler, "Sphere Sort",
+				    GPU_PROFILER_MOTION_BLUR_COLOR);
+
+				switch (scene->sorting_mode) {
+					case SORTING_MODE_CPU_QSORT:
+						sorted_ssbo =
+						    sphere_sorter_sort_cpu(
+						        &scene->sphere_sorter,
+						        scene->sphere_instances,
+						        scene
+						            ->sphere_instance_count,
+						        camera_pos);
+						break;
+					case SORTING_MODE_CPU_RADIX:
+						sorted_ssbo =
+						    sphere_sorter_sort_cpu_radix(
+						        &scene->sphere_sorter,
+						        scene->sphere_instances,
+						        scene
+						            ->sphere_instance_count,
+						        camera_pos);
+						break;
+					case SORTING_MODE_GPU_BITONIC:
+					default:
+						sorted_ssbo =
+						    sphere_sorter_sort_gpu(
+						        &scene->sphere_sorter,
+						        scene->sphere_instances,
+						        scene
+						            ->sphere_instance_count,
+						        camera_pos);
+						break;
+				}
 			}
+
 			/* Tier 4: Sorted SSBO already bound at binding 2 by
 			 * sort functions — vertex shader reads it directly
 			 * via gl_InstanceID (no VBO copy needed). */
@@ -897,17 +914,27 @@ void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
 				    scene->sphere_instance_count);
 			}
 
-			glEnablei(GL_BLEND, 0);
-			glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-			glDisablei(GL_BLEND, 1);
+			/* 2. Actual Billboard Rendering */
+			{
+				GPU_STAGE_PROFILER(profiler, "Billboard Render",
+				                   GPU_PROFILER_SCENE_COLOR);
 
-			scene_render_billboards(scene, view, proj, camera_pos,
-			                        previous_view_proj, width,
-			                        height);
+				glEnablei(GL_BLEND, 0);
+				glBlendFunc(GL_SRC_ALPHA,
+				            GL_ONE_MINUS_SRC_ALPHA);
+				glDisablei(GL_BLEND, 1);
 
-			glDisablei(GL_BLEND, 0);
+				scene_render_billboards(
+				    scene, view, proj, camera_pos,
+				    previous_view_proj, width, height);
+
+				glDisablei(GL_BLEND, 0);
+			}
+
 			gl_debug_pop_group();
 		} else {
+			GPU_STAGE_PROFILER(profiler, "Instanced Render",
+			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
 			glPolygonMode(GL_FRONT_AND_BACK,
 			              scene->wireframe ? GL_LINE : GL_FILL);
@@ -929,11 +956,29 @@ void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
 
 		if (scene->billboard_mode) {
 			gl_debug_push_group("Billboard_Render");
-			scene_render_billboards(scene, view, proj, camera_pos,
-			                        previous_view_proj, width,
-			                        height);
+
+			/* 1. Dummy sort (legacy/fallback path) */
+			{
+				GPU_STAGE_PROFILER(
+				    profiler, "Sphere Sort",
+				    GPU_PROFILER_MOTION_BLUR_COLOR);
+				/* In fallback path, sorting is handled outside
+				 * or not at all */
+			}
+
+			/* 2. Actual Billboard Rendering */
+			{
+				GPU_STAGE_PROFILER(profiler, "Billboard Render",
+				                   GPU_PROFILER_SCENE_COLOR);
+				scene_render_billboards(
+				    scene, view, proj, camera_pos,
+				    previous_view_proj, width, height);
+			}
+
 			gl_debug_pop_group();
 		} else {
+			GPU_STAGE_PROFILER(profiler, "Instanced Render",
+			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
 			glPolygonMode(GL_FRONT_AND_BACK,
 			              scene->wireframe ? GL_LINE : GL_FILL);
@@ -947,6 +992,7 @@ void scene_render(Scene* scene, mat4 view, mat4 proj, vec3 camera_pos,
 		}
 
 		glDisable(GL_STENCIL_TEST);
+	}
 
 #endif
 


### PR DESCRIPTION
# 🚀 Amélioration de la Précision et de la Couverture du Profileur GPU
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8646e2ed-b53b-4163-b1dc-2a90222c6d21" />

Cette PR corrige les écarts de mesure entre le profileur interne et MangoHud, comble les "vides" dans la timeline des métriques et améliore la granularité du profiling pour le rendu des sphères translucides.

## 🛠️ Modifications principales

### 1. Parité avec MangoHud (Frametime global)
- Déplacement du bloc de mesure **"Total Frame"** et de [gpu_profiler_begin_frame](src/gpu_profiler.c:96:0-196:1) dans la boucle principale ([app_run](src/app.c:185:0-305:1)).
- Inclusion de `glfwSwapBuffers` dans la mesure globale via un nouvel étage **"Swap Buffers"**.
- **Résultat** : Le frametime interne correspond désormais aux mesures externes (ex: 5.1ms au lieu de 4.2ms) car il inclut la latence du pilote et de la synchronisation verticale.

### 2. Couverture complète de la Timeline
- Ajout de l'étage **"Scene Render"** dans le rendu principal.
- Ajout de l'étage **"Environment"** pour isoler le coût du rendu de la Skybox/IBL.
- Suppression des zones vides dans le HUD : 100% de la frame GPU est maintenant documentée.

### 3. Analyse du Goulot d'Étranglement (Tri CPU vs GPU)
- Division de l'ancienne étape "Sorted Spheres" en deux sous-étapes :
    - **"Sphere Sort"** : Mesure le temps d'attente du GPU pendant le tri CPU (Radix/QSort) et le temps d'upload des données.
    - **"Billboard Render"** : Mesure le temps d'exécution réel du shader de rendu des sphères.
- Cela permet d'identifier immédiatement si une baisse de performance est due à l'algorithme de tri (CPU) ou à la complexité des pixels (GPU).

### 4. Simplification du Post-Process
- Fusion de l'étape **"Final Composite"** dans son parent **"Post-Process"** pour réduire la redondance visuelle dans le HUD.
- Mise à jour de l'outil `EffectBenchmark` pour utiliser la nouvelle structure de nommage.

## 📊 Impact sur le HUD
- Les barres de métriques remplissent désormais toute la largeur du bloc "Total Frame".
- Les couleurs et l'arborescence ont été ajustées pour une lecture plus intuitive des dépendances de rendu.
