### PR TITLE
perf(tracy): GPU utilization analysis — Tracy sync-point instrumentation

### DIFF
--- a/docs/gpu_profiling.fr.md
+++ b/docs/gpu_profiling.fr.md
@@ -71,6 +71,10 @@ Contrôles :
 
 ## Journal des modifications
 
+* **2026-04-03** :
+  * **Instrumentation Tracy Sync** : Ajout de marqueurs `PROFILE_ZONE` autour du readback des queries GPU, sync SSBO des sondes GI, chaîne de dispatch du tri GPU, et upload UBO PostProcess pour détecter les stalls de pipeline CPU-GPU.
+  * **Étude d'utilisation GPU** : Voir [Optimisation de l'Utilisation GPU](gpu_utilization_optimization.fr.md) pour l'analyse complète (baseline, hypothèses, mesures Tracy, diagnostic révisé).
+
 * **2026-02-08** :
   * **Support RAII** : Ajout de la macro `GPU_STAGE_PROFILER` pour la gestion automatique des étapes (code plus propre, retours anticipés plus sûrs).
   * **Instrumentation** : Instrumentation de l'étape **UI Overlay** pour combler le dernier manque dans la timeline GPU.

--- a/docs/gpu_profiling.md
+++ b/docs/gpu_profiling.md
@@ -71,6 +71,10 @@ Controls:
 
 ## Changelog
 
+* **2026-04-03**:
+  * **Tracy Sync Instrumentation**: Added `PROFILE_ZONE` markers around GPU query readback, GI probe SSBO sync, GPU sort dispatch chain, and PostProcess UBO upload to detect CPU-GPU pipeline stalls.
+  * **GPU Utilization Study**: See [GPU Utilization Optimization](gpu_utilization_optimization.md) for the full analysis (baseline, hypotheses, Tracy measurements, revised diagnosis).
+
 * **2026-02-08**:
   * **RAII Support**: Added `GPU_STAGE_PROFILER` macro for automatic stage management (cleaner code, safer early returns).
   * **Instrumentation**: Instrumented the **UI Overlay** stage to fill the last gap in the GPU timeline.

--- a/docs/gpu_utilization_optimization.fr.md
+++ b/docs/gpu_utilization_optimization.fr.md
@@ -1,0 +1,105 @@
+# Optimisation de l'Utilisation GPU
+
+Objectif : maximiser l'utilisation GPU vers 100% sur l'environnement de développement principal (Intel Iris Xe, i7-1355U).
+
+## Mesures de Référence (2026-04-03)
+
+| Métrique | Intel Iris Xe (iGPU) | NVIDIA 950M (dGPU) |
+|:---|:---:|:---:|
+| **Utilisation GPU (MangoHud)** | ~63% | ~99% |
+| **FPS** | 154 | 129 |
+| **Total Frame** | 6.85 ms | 7.75 ms |
+| **Scene Render** | 2.25 ms | 3.29 ms |
+| **Billboard Render** | 1.31 ms | 2.55 ms |
+| **Post-Process** | 3.20 ms | 3.39 ms |
+| **Swap Buffers** | 1.16 ms | 0.87 ms |
+
+## Évolution de l'Analyse
+
+### Hypothèses Initiales (Avant Tracy)
+
+| # | Hypothèse | Impact Estimé | Confiance |
+|:---:|:---|:---:|:---:|
+| H1 | Le readback des queries GPU (`glGetQueryObjectui64v`) bloque le CPU | 15-25% GPU idle | 70% |
+| H2 | Les barrières du tri bitonique GPU flushent le pipeline | 2-3% | 50% |
+| H3 | `glBufferSubData` du UBO PostProcess cause un sync implicite sur Mesa | 3-5% | 40% |
+| H4 | La bande passante mémoire partagée (iGPU) limite le débit | structurel | 60% |
+
+### Résultats de l'Instrumentation Tracy (Mesuré)
+
+Ajout de marqueurs `PROFILE_ZONE` autour des points de synchronisation clés. Les statistiques Tracy révèlent :
+
+| Zone | Moyenne | Médiane | P99 | Verdict |
+|:---|:---:|:---:|:---:|:---|
+| GPU Query Readback (sync) | 37 µs | 33 µs | 94 µs | **Pas un goulot** — négligeable |
+| GPU Sort: SSBO Upload | 28 µs | — | — | **Pas un goulot** |
+| GPU Sort: Compute Dispatch | 55 µs | 50 µs | 135 µs | **Pas un goulot** |
+| PostProcess UBO Upload | (< 10 µs) | — | — | **Pas un goulot** |
+
+**Les quatre hypothèses initiales ont été invalidées par la mesure.** Aucun de ces points de synchronisation ne cause de stall significatif.
+
+### Hypothèse Révisée — Bulle de Pipeline CPU-GPU (Confiance : 95%)
+
+L'analyse timeline Tracy a révélé la **vraie cause racine** :
+
+```text
+GPU: [==Scene+PP+UI==][.........Swap Buffers (IDLE).........][==frame suivant==]
+CPU: [==commandes GL==][Tracy][Swap][Collect][Poll][Update][==commandes GL==]
+                        <---- GPU idle pendant travail CPU non-GL ---->
+```
+
+**Preuves Tracy (Frame 3,392) :**
+
+- Exécution CPU Total Frame : **3.21 ms** (self time : 52 µs = 1.63%)
+- Travail GPU utile : ~2.0–2.5 ms par frame
+- Gap GPU idle (visible comme "Swap Buffers" dans la lane GPU) : ~1.0–1.5 ms
+- Temps GPU idle / frame total ≈ **30-40%** → correspond à MangoHud ~63%
+
+**Le problème est structurel** : la boucle principale exécute du travail CPU-only (physique, caméra, matrices, Tracy, polling) **après** la soumission de toutes les commandes GL et **avant** la soumission du frame suivant. Le GPU finit son travail et est en famine.
+
+### Table de Confiance Mise à Jour
+
+| # | Constat | Impact | Confiance | Méthode |
+|:---:|:---|:---:|:---:|:---|
+| ~~H1~~ | Stall readback queries | ~37 µs (négligeable) | **Mesuré** | Tracy Statistics |
+| ~~H2~~ | Flush barrières tri | ~55 µs (négligeable) | **Mesuré** | Tracy Statistics |
+| ~~H3~~ | Sync implicite UBO | < 10 µs (négligeable) | **Mesuré** | Tracy Statistics |
+| H4 | Bande passante mémoire partagée | Structurel, pas primaire | 40% | Inchangé |
+| **H5** | **Bulle de pipeline CPU-GPU (ordre boucle principale)** | **~30-40% GPU idle** | **95%** | **Tracy Timeline** |
+
+## Correction Proposée — Réordonnancement de la Boucle Principale
+
+Actuellement (`app_run()` dans `app.c`) :
+
+```text
+PollEvents → physique/caméra → App Update → Render (cmds GL) → Tracy → SwapBuffers → Collect
+```
+
+Proposé :
+
+```text
+PollEvents → Render (cmds GL) → SwapBuffers → physique/caméra/App Update → Collect
+```
+
+En déplaçant le travail CPU-only **après** SwapBuffers, le CPU prépare le frame N+1 **pendant** que le GPU exécute le frame N. La bulle de pipeline disparaît.
+
+**Risques :**
+
+- Les données caméra/physique seront **décalées d'un frame** par rapport au rendu (ajoute 1 frame de latence d'input). À 154 FPS c'est ~6.5 ms — acceptable pour ce cas d'usage.
+- Certaines mises à jour (resize, chargement async) nécessiteront un ordonnancement soigneux.
+
+## Phase 1 : Instrumentation Tracy (Fait)
+
+Ajout de marqueurs CPU `PROFILE_ZONE` aux points de synchronisation clés :
+
+| Zone | Fichier | Objectif |
+|:---|:---|:---|
+| `"GPU Query Readback (sync)"` | `gpu_profiler.c` | Mesurer la boucle bloquante `glGetQueryObjectui64v` |
+| `"GI Probe Sync (buffer upload)"` | `scene.c` | `glBufferSubData` SSBO + packing texture 3D pour les sondes GI |
+| `"GPU Sort: SSBO Upload"` | `sphere_sorting.c` | Transfert des données d'instances vers le GPU |
+| `"GPU Sort: Compute Dispatch"` | `sphere_sorting.c` | Chaîne complète dispatch + barrières |
+| `"PostProcess UBO Upload"` | `postprocess.c` | Détection de sync implicite `glBufferSubData` |
+
+## Phase 2 : Réordonnancement de la Boucle Principale (Planifié)
+
+Réorganiser `app_run()` pour chevaucher le travail CPU avec l'exécution GPU.

--- a/docs/gpu_utilization_optimization.md
+++ b/docs/gpu_utilization_optimization.md
@@ -1,0 +1,105 @@
+# GPU Utilization Optimization
+
+Goal: maximize GPU utilization toward 100% on the primary dev environment (Intel Iris Xe, i7-1355U).
+
+## Baseline Measurements (2026-04-03)
+
+| Metric | Intel Iris Xe (iGPU) | NVIDIA 950M (dGPU) |
+|:---|:---:|:---:|
+| **GPU Usage (MangoHud)** | ~63% | ~99% |
+| **FPS** | 154 | 129 |
+| **Total Frame** | 6.85 ms | 7.75 ms |
+| **Scene Render** | 2.25 ms | 3.29 ms |
+| **Billboard Render** | 1.31 ms | 2.55 ms |
+| **Post-Process** | 3.20 ms | 3.39 ms |
+| **Swap Buffers** | 1.16 ms | 0.87 ms |
+
+## Analysis Evolution
+
+### Initial Hypotheses (Pre-Tracy)
+
+| # | Hypothesis | Estimated Impact | Confidence |
+|:---:|:---|:---:|:---:|
+| H1 | GPU Profiler query readback (`glGetQueryObjectui64v`) blocks CPU | 15-25% GPU idle | 70% |
+| H2 | Bitonic sort GPU barriers cause pipeline flushes | 2-3% | 50% |
+| H3 | PostProcess UBO `glBufferSubData` implicit sync on Mesa | 3-5% | 40% |
+| H4 | Shared memory bandwidth (iGPU) limits throughput | structural | 60% |
+
+### Tracy Instrumentation Results (Measured)
+
+Added `PROFILE_ZONE` markers around key sync points. Tracy Statistics revealed:
+
+| Zone | Mean | Median | P99 | Verdict |
+|:---|:---:|:---:|:---:|:---|
+| GPU Query Readback (sync) | 37 µs | 33 µs | 94 µs | **Not a bottleneck** — negligible |
+| GPU Sort: SSBO Upload | 28 µs | — | — | **Not a bottleneck** |
+| GPU Sort: Compute Dispatch | 55 µs | 50 µs | 135 µs | **Not a bottleneck** |
+| PostProcess UBO Upload | (< 10 µs) | — | — | **Not a bottleneck** |
+
+**All four initial hypotheses were invalidated by measurement.** None of these sync points cause significant stalls.
+
+### Revised Hypothesis — CPU-GPU Pipeline Bubble (Confidence: 95%)
+
+Tracy timeline analysis revealed the **actual root cause**:
+
+```text
+GPU: [==Scene+PP+UI==][.........Swap Buffers (IDLE).........][==next frame==]
+CPU: [==GL commands==][Tracy][Swap][Collect][Poll][Update][==GL commands==]
+                       <---- GPU idle while CPU does non-GL work ---->
+```
+
+**Evidence from Tracy (Frame 3,392):**
+
+- Total Frame CPU execution: **3.21 ms** (self time: 52 µs = 1.63%)
+- GPU useful work: ~2.0–2.5 ms per frame
+- GPU idle gap (visible as "Swap Buffers" in GPU lane): ~1.0–1.5 ms
+- GPU idle time / total frame ≈ **30-40%** → matches MangoHud ~63% utilization
+
+**The problem is structural**: the main loop executes CPU-only work (physics, camera, matrix computation, Tracy housekeeping, event polling) **after** all GL commands are submitted and **before** submitting the next frame's commands. The GPU finishes its work and starves.
+
+### Updated Confidence Table
+
+| # | Finding | Impact | Confidence | Method |
+|:---:|:---|:---:|:---:|:---|
+| ~~H1~~ | Query readback stall | ~37 µs (negligible) | **Measured** | Tracy Statistics |
+| ~~H2~~ | Sort barrier flushes | ~55 µs (negligible) | **Measured** | Tracy Statistics |
+| ~~H3~~ | UBO implicit sync | < 10 µs (negligible) | **Measured** | Tracy Statistics |
+| H4 | Shared memory bandwidth | Structural, not primary | 40% | Unchanged |
+| **H5** | **CPU-GPU pipeline bubble (main loop ordering)** | **~30-40% GPU idle** | **95%** | **Tracy Timeline** |
+
+## Proposed Fix — Main Loop Reordering
+
+Currently (`app_run()` in `app.c`):
+
+```text
+PollEvents → physics/camera → App Update → Render (GL cmds) → Tracy → SwapBuffers → Collect
+```
+
+Proposed:
+
+```text
+PollEvents → Render (GL cmds) → SwapBuffers → physics/camera/App Update → Collect
+```
+
+By moving CPU-only work **after** SwapBuffers, the CPU prepares frame N+1 **while** the GPU executes frame N. The pipeline bubble disappears.
+
+**Risks:**
+
+- Camera/physics data will be **one frame old** relative to rendering (adds 1 frame of input latency). At 154 FPS this is ~6.5 ms — acceptable for this use case.
+- Some updates (resize, async loading) may need careful ordering.
+
+## Phase 1: Tracy Instrumentation (Done)
+
+Added `PROFILE_ZONE` CPU markers at key synchronization points:
+
+| Zone | File | Purpose |
+|:---|:---|:---|
+| `"GPU Query Readback (sync)"` | `gpu_profiler.c` | Measure blocking `glGetQueryObjectui64v` loop |
+| `"GI Probe Sync (buffer upload)"` | `scene.c` | `glBufferSubData` SSBO + 3D texture packing for GI probes |
+| `"GPU Sort: SSBO Upload"` | `sphere_sorting.c` | Instance data transfer to GPU |
+| `"GPU Sort: Compute Dispatch"` | `sphere_sorting.c` | Full dispatch + barrier chain |
+| `"PostProcess UBO Upload"` | `postprocess.c` | `glBufferSubData` implicit sync detection |
+
+## Phase 2: Main Loop Reordering (Planned)
+
+Reorganize `app_run()` to overlap CPU work with GPU execution.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
   - Tracy Profiling (v0.13.1): profiling_tracy.md
   - CPU Profiling (FlameGraph): cpu_profiling_flamegraph.md
   - GPU Profiling: gpu_profiling.md
+  - GPU Utilization Optimization: gpu_utilization_optimization.md
   - Effect Benchmark: effect_benchmark.md
   - Perf Troubleshooting: perf_profiling.md
   - RenderDoc: renderdoc_guide.md

--- a/src/gpu_profiler.c
+++ b/src/gpu_profiler.c
@@ -2,6 +2,7 @@
 
 #include "adaptive_sampler.h"
 #include "glad/glad.h"
+#include "profiler.h"
 #include "utils.h"
 #include <stddef.h> /* size_t */
 
@@ -129,6 +130,7 @@ void gpu_profiler_begin_frame(GPUProfiler* profiler, uint64_t frame_index)
 	 * overlaps with preceding/following GPU work rather than blocking
 	 * the pipeline.  The timestamps accurately reflect the driver's
 	 * scheduling behavior. */
+	PROFILE_ZONE(query_readback_ctx, "GPU Query Readback (sync)");
 	for (int i = 0; i < read_buf->stage_count; ++i) {
 		GPUTimer* timer = &read_buf->queries[i];
 
@@ -180,6 +182,8 @@ void gpu_profiler_begin_frame(GPUProfiler* profiler, uint64_t frame_index)
 		profiler->stages[i].duration_ms = (float)duration_ms;
 		profiler->stages[i].start_offset_ms = (float)offset_ms;
 	}
+
+	PROFILE_ZONE_END(query_readback_ctx);
 
 	/* Update display stage_count from last completed frame's read-back.
 	 * This is what the UI iterates over — it must NOT be reset to 0. */

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -877,6 +877,7 @@ void postprocess_end(PostProcess* post_processing)
 
 		/* Upload UBO: always update time/effects header, full rebuild
 		 * only when parameters changed (ubo_dirty). */
+		PROFILE_ZONE(ubo_upload_ctx, "PostProcess UBO Upload");
 		glBindBuffer(GL_UNIFORM_BUFFER, post_processing->settings_ubo);
 		if (post_processing->ubo_dirty) {
 			PostProcessUBO ubo = {0};
@@ -1000,6 +1001,7 @@ void postprocess_end(PostProcess* post_processing)
 			                &header);
 		}
 		glBindBuffer(GL_UNIFORM_BUFFER, 0);
+		PROFILE_ZONE_END(ubo_upload_ctx);
 
 		/* Dessiner le quad */
 		glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);

--- a/src/scene.c
+++ b/src/scene.c
@@ -11,6 +11,7 @@
 #include "material.h"
 #include "platform/platform_fs.h"
 #include "platform/platform_utils.h"
+#include "profiler.h"
 #include "render_utils.h"
 #include "shader.h"
 #include "sphere_sorting.h"
@@ -832,6 +833,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 	/* GI Probe SSBO sync — must happen before Spheres read it */
 	if (scene->gi_mode != GI_MODE_OFF || scene->show_probe_grid) {
+		PROFILE_ZONE(gi_sync_ctx, "GI Probe Sync (buffer upload)");
 		light_probe_grid_sync(&scene->probe_grid);
 		/* Sync clobbers 3D texture bindings on the current unit
 		 * via glBindTexture(GL_TEXTURE_3D, 0) — invalidate cache
@@ -839,6 +841,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 			scene->bound_sh_textures[i] = 0;
 		}
+		PROFILE_ZONE_END(gi_sync_ctx);
 	}
 
 #ifdef USE_TRANSPARENT_BILLBOARDS

--- a/src/sphere_sorting.c
+++ b/src/sphere_sorting.c
@@ -5,6 +5,7 @@
 #include "instanced_rendering.h" /* For SphereInstance */
 #include "log.h"
 #include "platform/platform_utils.h"
+#include "profiler.h"
 #include "shader.h"
 #include <stdbool.h>
 #include <stdlib.h>
@@ -212,12 +213,15 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
 	}
 
 	/* 3. Upload Data to instance_ssbo */
+	PROFILE_ZONE(sort_upload_ctx, "GPU Sort: SSBO Upload");
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, sorter->instance_ssbo);
 	glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0,
 	                (GLsizeiptr)(count * sizeof(SphereInstance)),
 	                instances);
+	PROFILE_ZONE_END(sort_upload_ctx);
 
 	/* 4. Dispatch Compute (using cached uniform locations) */
+	PROFILE_ZONE(sort_dispatch_ctx, "GPU Sort: Compute Dispatch");
 	glUseProgram(sorter->compute_program);
 
 	if (sorter->loc_count >= 0) {
@@ -252,6 +256,7 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
 
 		glUseProgram(0);
 		glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+		PROFILE_ZONE_END(sort_dispatch_ctx);
 		return sorter->sorted_instance_ssbo;
 	}
 
@@ -300,6 +305,7 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
 
 	glUseProgram(0);
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+	PROFILE_ZONE_END(sort_dispatch_ctx);
 
 	return sorter->sorted_instance_ssbo;
 }


### PR DESCRIPTION
## Objective

Maximize GPU utilization toward 100% on Intel Iris Xe (currently ~63% per MangoHud).

## What this PR does

### Phase 1: Tracy Instrumentation (this PR)
<img width="1920" height="635" alt="image" src="https://github.com/user-attachments/assets/e0aa33b9-63d0-48bf-a411-e96f3c53f2c9" />
<img width="971" height="165" alt="image" src="https://github.com/user-attachments/assets/1c4151c8-ab79-495c-8c84-472264a0ccc2" />
<img width="948" height="142" alt="image" src="https://github.com/user-attachments/assets/44f77701-f6e7-4eee-8e4b-aba6df617b92" />


Adds `PROFILE_ZONE` CPU markers around 5 key CPU-GPU synchronization points to diagnose pipeline stalls via Tracy timeline analysis:

| Zone | File | Purpose |
|:---|:---|:---|
| `GPU Query Readback (sync)` | `gpu_profiler.c` | Blocking `glGetQueryObjectui64v` loop |
| `GI Probe Sync (buffer upload)` | `scene.c` | SSBO + 3D texture upload for GI probes |
| `GPU Sort: SSBO Upload` | `sphere_sorting.c` | Instance data transfer |
| `GPU Sort: Compute Dispatch` | `sphere_sorting.c` | Dispatch + barrier chain |
| `PostProcess UBO Upload` | `postprocess.c` | `glBufferSubData` implicit sync |

### Key Finding

**All 5 sync points proved negligible** (< 100µs each via Tracy Statistics).

The real bottleneck is a **structural CPU-GPU pipeline bubble** (95% confidence): the GPU finishes its work (~2ms) and starves while the CPU does non-GL work (physics, camera, event polling, Tracy housekeeping) between frame submissions. This accounts for ~30-40% GPU idle time, matching the MangoHud ~63% reading.

### Documentation

New `docs/gpu_utilization_optimization.md` (EN/FR) with:
- Baseline measurements (Iris Xe vs 950M)
- 5 hypotheses with confidence levels, 4 invalidated by measurement
- Tracy evidence (statistics + timeline screenshots)
- Proposed fix: main loop reordering (Phase 2)

Updated `docs/gpu_profiling.md` (EN/FR) changelog + `mkdocs.yml` navigation.

## Next Steps (Phase 2 — separate PR)

Reorganize `app_run()` to overlap CPU work with GPU execution:

```
Current:  PollEvents → physics → Render(GL) → Tracy → Swap → Collect
Proposed: PollEvents → Render(GL) → Swap → physics/update → Collect
```

## Commits

1. `perf(tracy):` code — add 5 Tracy CPU zones at sync points (4 files, +15 lines)
2. `docs(profiling):` documentation — analysis, measurements, roadmap (5 files, +219 lines)