### PR TITLE
docs(project): add GitHub project management setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,41 @@
-# Suckless-Vulkan Development Guidelines
+# suckless-ogl Development Guidelines
+
+## Project Context
+
+Suckless OpenGL rendering engine in C — PBR, IBL, compute shaders, post-processing pipeline.
+Repository: [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
+
+## Roadmap & Project Tracking
+
+**CRITICAL**: At the start of every session, consult the GitHub project board and milestones:
+- Project board: https://github.com/users/yoyonel/projects/3
+- Milestones: `gh api repos/yoyonel/suckless-ogl/milestones?state=all`
+- Open issues: `gh issue list --state open`
+- Refer to [docs/github-settings.md](../../docs/github-settings.md) for label taxonomy and project structure.
+
+## Architecture Overview
+
+| Subsystem | Key Files |
+|-----------|-----------|
+| **Core App** | `app.c`, `main.c`, `cli.c` |
+| **Rendering** | `renderer.c`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
+| **PBR / IBL** | `pbr.c`, `material.c`, `ibl_coordinator.c`, `light_probes.c`, `skybox.c` |
+| **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur) |
+| **Shaders** | 55+ GLSL files in `shaders/` (vertex, fragment, compute) |
+| **Input** | `app_input.c`, `camera_input.c`, `postprocess_input.c`, `app_binding.c` |
+| **Profiling** | `gpu_profiler.c`, `perf_timer.c`, `tracy_manager.c`, `effect_benchmark.c` |
+| **Tests** | 59 test files in `tests/` (Unity framework, visual regression, benchmarks) |
+
+## Build & Test
+
+```bash
+just build          # Debug build (Clang)
+just test-all       # All unit + integration tests (CTest)
+just lint           # clang-tidy + shellcheck + yamllint + hadolint (0 warnings)
+just format         # clang-format (C/GLSL)
+just coverage-llvm  # LLVM-Cov coverage report
+just ci-docker-all  # Full local CI matrix (Docker)
+```
 
 ## 🚫 Golden Rules
 
@@ -11,90 +48,13 @@
 7. **NEVER modify reference test images** — Files matching `tests/references/ref_*.png` are the visual regression baseline from `master`. They must NEVER be replaced, overwritten, or regenerated without the user's **explicit approval and visual validation**. When in doubt, restore them from `origin/master` with `git checkout origin/master -- tests/references/ref_*.png`
 8. **MVP first** — Always start with a Minimum Viable change on a limited scope to validate the approach before scaling to the full codebase. Do NOT batch-modify all files upfront; prove the fix on one representative case, get user validation, then generalize
 
----
+## Detailed Rules (see instruction files)
 
-## 📝 Commit Discipline
+The following instruction files contain the authoritative, detailed rules. **Do not duplicate their content here.**
 
-### Separation of Concerns (SoC) for Commits
-
-Each commit must represent one coherent change and one change theme.
-
-- One concern per commit: do not mix unrelated topics (e.g., CI + feature logic + docs)
-- Split by intent: `feat`, `fix`, `refactor`, `docs`, `ci`, `build`, `test`, `chore`
-- Keep commits reviewable: small, focused, and understandable independently
-- If multiple concerns are touched, create multiple commits in a logical order
-- Commit history must explain project evolution step by step
-
-Examples:
-- ✅ `fix(coverage): remove stale python formatter call in gcovr CI script`
-- ✅ `docs(process): enforce git status checks before commit and handoff`
-- ❌ `fix: update CI + refactor engine + rewrite docs`
-
-### Conventional Commits Format
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) strictly:
-
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-**Types** (based on project specifics):
-- `feat`: New feature (keyboard control, shader, logging, etc.)
-- `fix`: Bug fix
-- `refactor`: Code restructuring without feature change
-- `test`: Test suite additions/modifications
-- `docs`: Documentation only
-- `build`: Build system, CMake, dependencies
-- `ci`: GitHub Actions, Docker, CI pipeline
-- `chore`: Dependencies, config, tooling, git config
-- `perf`: Performance optimization
-
-**Scope** (optional but recommended):
-- `logging`, `controls`, `vulkan`, `shader`, `memory`, `ci`, `docs`, `coverage`, etc.
-
-**Examples:**
-```
-feat(controls): Add F11 fullscreen toggle with state restoration
-
-fix(logging): Correct thread ID formatting in log messages
-
-docs(coverage): Add LLVM-Cov section with KPI metrics
-
-ci(github-actions): Add coverage-report-llvm job with artifact uploads
-
-refactor(engine): Extract shader compilation logic to separate function
-```
-
-### Pre-Commit Workflow
-
-1. Run `just pre-commit-install` (one-time setup)
-2. Make code changes
-3. Run `just format` → fixes formatting automatically
-4. Run `just lint` → must pass with no errors and no warnings
-5. Run `just test-all` → all tests must pass
-6. Run `just pre-push-run` → final check before commit
-7. Run `git status --short --branch` and review all local changes
-8. Ensure all remaining files are either:
-   - intentionally staged for the current commit, or
-   - explicitly deferred and communicated as next step
-9. Use `git add` + `git commit` (hooks will verify format/lint/tests)
-10. **NEVER** `git push` — wait for user approval
-
-If any hook fails:
-- Read the error message
-- Fix the issue
-- Retry the commit
-
-Warning handling policy during lint execution:
-- A lint command with `exit code 0` is NOT considered successful if warnings are present.
-- Warnings must be treated and fixed before moving to the next step or committing.
-- Use output checks when needed (example: `just lint 2>&1 | grep -i warning`) to confirm warning-free runs.
-- `clang-tidy` warnings (including `performance-*`) are blocking and must be fixed, not deferred.
-- During GitHub Actions monitoring, always run `just ci-docker-all` locally in parallel and fix local warnings/errors immediately to preempt remote failures.
+- **commit-workflow.instructions.md** — SoC commit discipline, Conventional Commits format, pre-commit workflow, branching strategy, git safety rules.
+- **testing-quality.instructions.md** — CI validation, test coverage, code quality standards, no-suppression policy, Justfile discipline, documentation gates, RenderDoc observability.
+- **github-project.instructions.md** — PR workflow, labels, milestones, project board management, issue lifecycle.
 
 ---
 
@@ -108,6 +68,7 @@ Warning handling policy during lint execution:
   - **Unit Tests**: For core logic, parsers, and parameter validation.
   - **Integration Tests**: For rendering presets, UBO synchronization, and full pipeline verification.
 - **Regression Testing**: Ensure all existing tests pass after modifications.
+
 ### Update Existing Docs
 - Feature/fix updates existing behavior → Update the relevant doc
 - Examples: `docs/tooling.md`, `docs/ci_cd.md`, `docs/runtime_controls_logging.md`
@@ -133,18 +94,8 @@ Warning handling policy during lint execution:
    - ❌ No untagged code blocks (MD040 lint fails)
 
 2. **Diagrams & Visuals** — Use mermaid for flowcharts, architecture, state diagrams
-   - Flowchart example:
-     ```mermaid
-     graph LR
-       A[Input] --> B{Process} --> C[Output]
-     ```
-   - State diagram for mode transitions (fullscreen, logging levels, etc.)
-   - Architecture diagrams for system interaction
 
 3. **Examples & Snippets** — Always tag with language and context
-   - Show command usage: `` ```bash ``
-   - Show code: `` ```cpp ``, `` ```python ``
-   - Show output: `` ```text ``
 
 4. **Table of Contents** — Maintain clear structure for `mkdocs.yml`
    - Ensure all `.md` files are indexed
@@ -157,243 +108,45 @@ Warning handling policy during lint execution:
 ### Just Recipes (Preferred)
 - **All major tasks via `just`** — No raw cmake/make commands
 - **Every recipe documented** — Docstring comments visible in `just help`
-- Examples: `just build`, `just test-all`, `just coverage-llvm`, `just lint`
 
 ### Justfile Simplicity Rule
 
 - Keep `justfile` recipes as orchestration glue (high-level command chaining).
-- Do not embed long shell loops, branching-heavy workflows, or business logic directly in `justfile`.
 - Move non-trivial shell logic to versioned scripts under `scripts/` and call them from `just` recipes.
-- Scripts referenced by `justfile` must stay small, readable, shellcheck-clean, and covered by existing lint flow.
-- Exception: 1-3 straightforward shell lines are acceptable inline when readability is clearly better than a separate script.
+- Exception: 1-3 straightforward shell lines are acceptable inline.
 
 ### CMake (Dependency Management)
-- CMake used for:
-  - Dependency discovery (`find_package`)
-  - Build configuration (`ENABLE_COVERAGE`, `ENABLE_SANITIZERS`, `ENABLE_LLVM_COV`)
-  - Target definitions (executables, libraries)
+- CMake used for: dependency discovery, build configuration, target definitions
 - Do NOT use CMake for task automation → use `just` instead
 
 ### Compiler Strategy
 - **Primary:** Clang (for LLVM tooling, coverage, sanitizers)
 - **Optional:** GCC builds supported, not required
-- **CI Matrix:** Release build with Clang; Debug with Clang
-- Future: Can add GCC dual-build if needed
 
 ### Standard Tools
-- **Format:** `clang-format` (C/C++/GLSL)
-- **Lint:** `clang-tidy` (C/C++), `shellcheck` (shell), `yamllint` (YAML), `hadolint` (Docker)
-- **Coverage:** `llvm-cov` (preferred, clang-only), `gcovr` (alternative, GCC-compatible)
+- **Format:** `clang-format` (C/GLSL)
+- **Lint:** `clang-tidy` (C), `shellcheck` (shell), `yamllint` (YAML), `hadolint` (Docker)
+- **Coverage:** `llvm-cov` (preferred), `gcovr` (alternative)
 - **Test:** CTest (CMake native)
-- **Package:** uv (Python deps in CI)
-- **Text processing:** Use standard shell tools → `sed`, `tr`, `column`, `awk`, `grep` (NOT custom Python scripts)
+- **Text processing:** `sed`, `tr`, `column`, `awk`, `grep` (NOT custom Python scripts)
 
 ### Principle: Minimize Custom Scripts
 
-**Strongly prefer existing tools over custom scripts** (Python, Bash, etc.):
-
-✅ **Use standard tools:**
-- `llvm-cov report` outputs formatted table directly (no script needed)
-- `column`, `sed`, `tr` for text transformation
-- `jq` for JSON processing (if unavoidable)
-- Built-in shell utilities
-
-❌ **Avoid custom scripts unless:**
-- No standard tool exists for the task
-- Exception is thoroughly documented
-- Script is simple, maintainable, and tested
-- Value is clear (don't script for scripts' sake)
-
-**Examples of anti-patterns:**
-- Custom Python formatter for tools that already output formatted text
-- Bash wrapper around single command
-- Re-implementing standard utilities
-
-**Benefit:** Reduce dependencies, improve maintainability, easier CI/CD portability
-
----
-
-### Principle: No Suppression of Warnings/Errors
-
-**NEVER bypass linting or compiler warnings using suppression mechanisms:**
-
-❌ **Forbidden suppression patterns:**
-- `// NOLINT`, `# noqa`, `# type: ignore`, `// NOLINTNEXTLINE`
-- `ignore:` lists in `.hadolint.yaml`, `.hadolint.yaml`, `pylintrc`, etc.
-- `ignore: DL3008 ...` params passed directly to linting actions
-- `/* clang-tidy-disable */` blocks
-- CMake `set_source_files_properties(... SKIP_LINTING ON)`
-- GitHub Actions `continue-on-error: true` to hide failures
-
-✅ **Correct approach: fix the root cause:**
-- `DL3008` (apt pin): Pin package versions explicitly in the Dockerfile
-- `DL3013/DL3813` (pip pin): Pin pip versions explicitly or use a `requirements.txt`
-- `clang-tidy` warning: Refactor the code to eliminate the pattern
-- Compiler warning: Fix the actual issue (cast, unused variable, narrowing, etc.)
-
-**Exception policy:** If suppression is the **only viable path**, it requires:
-1. An explicit comment **in the code** explaining why the fix is not possible
-2. A clear assessment confirming no alternative exists
-3. A tracking note to revisit and remove the suppression when possible
-4. User explicit validation before committing
-
-No silent suppression is ever acceptable.
-
----
-
-## 🔨 Code Quality Gate
-
-Before **every commit**, verify:
-
-```bash
-# Format all files
-just format
-
-# Lint (must pass with zero warnings)
-just lint
-
-# Run all tests
-just test-all
-
-# Optionally verify coverage
-just coverage-llvm
-```
-
-### Pre-Commit Hook Verification
-```bash
-just pre-commit-run
-```
-
-### Pre-Push Hook Verification
-```bash
-just pre-push-run
-```
-
-If any step fails → Fix and retry.
-
----
-
-## 🚢 CI/CD Validation
-
-### Local CI (Docker, mimic GitHub Actions)
-```bash
-just ci-docker-all
-```
-This runs:
-- Static checks (hadolint, actionlint)
-- Lint (in container)
-- Build + test (Release/Debug matrix)
-- Memory checks (ASan/UBSan)
-- Validation Layers (Vulkan)
-- Coverage report (LLVM-Cov)
-
-### Remote CI (GitHub Actions)
-- Automatically triggered on `push` + `pull_request` to `master`
-- Same jobs as local Docker
-- Artifacts uploaded (coverage HTML, test frames)
-
-### PR Automation (Explicit Human Order Required)
-
-This workflow is allowed **only** when the user explicitly asks for it (example: "push", "create PR", "open PR", "follow Actions").
-
-**Hard rule:**
-- Do not push branches, create PRs, or monitor GitHub Actions unless the human explicitly requests it in the current conversation.
-
-When explicitly requested, follow this sequence:
-1. Verify repository state:
-   - `git status --short --branch`
-   - confirm current branch and remote target
-2. Push feature branch (never `origin/master`):
-   - `git push -u origin <feature-branch>`
-3. Create PR with title + detailed description:
-   - Use GitHub CLI (`gh pr create`) or equivalent tool integration
-   - Base branch must be `master`
-4. **Parallel validation strategy** (CRITICAL for speed):
-   - **Immediately after push**, launch local CI in background: `just ci-docker-all` (runs full matrix locally)
-   - **Simultaneously**, monitor GitHub Actions remotely (check runs, job status)
-   - **Early problem detection**: If local CI fails → fix immediately, no need to wait for remote
-   - If error found locally → fix code → `just format && just lint && just test-all` → commit → push to re-trigger remote
-   - By the time remote CI validation completes, code is already corrected (zero wasted cycles)
-5. Monitor results:
-   - Local CI: Full verbose output on-machine for debugging
-   - Remote CI: Check all workflows and wait for terminal status (`SUCCESS` / `FAILURE`)
-   - Report a concise summary of each workflow result to the user
-6. If any workflow fails (local or remote):
-   - treat as blocked
-   - investigate, fix, re-run required checks, and update PR
-
-### Coverage Requirements
-- Minimum **70% line coverage** for commits to be acceptable
-- Use `just coverage-llvm` for detailed analysis (recommended over `gcovr`)
-- Report files: `build/coverage-llvm/coverage_report/index.html`
-
-### Failing Builds = Blocked
-- If any CI job fails (locally or remotely) → Fix before moving forward
-- No workarounds or skipping checks
-
----
-
-## 📋 Commit Checklist
-
-Before running `git commit`:
-
-- [ ] Code formatted: `just format` ✅
-- [ ] No lint errors: `just lint` ✅
-- [ ] All tests pass: `just test-all` ✅
-- [ ] Git working tree reviewed: `git status --short --branch` ✅
-- [ ] No unexpected leftovers (unstaged/untracked) without explicit handling plan
-- [ ] Docs created/updated (if feature/design change)
-- [ ] `mkdocs.yml` updated (if new doc added)
-- [ ] No local filesystem links in docs
-- [ ] Commit message follows Conventional Commits format
-- [ ] Pre-commit hooks pass: `just pre-commit-run` ✅
-
-Before handing back control in chat/prompt:
-
-- [ ] Re-check repo state with `git status --short --branch`
-- [ ] Clearly report what is done, what remains modified, and what is deferred
+Strongly prefer existing tools over custom scripts. Move complex logic to `scripts/` only when no standard tool exists.
 
 ---
 
 ## 🔄 Typical Feature Workflow
 
-1. **Create feature branch** (short-lived, <3 days)
-   ```bash
-   git checkout -b feat/my-feature
-   ```
-
-2. **Code implementation**
-   - Write code
-   - Add tests
-   - Format: `just format`
-   - Lint: `just lint`
-   - Test: `just test-all`
-
-3. **Documentation**
-   - Update existing doc OR create new `docs/<feature>.md`
-   - Update `mkdocs.yml` if new doc
-   - Verify no local links, all code blocks tagged
-
-4. **Commit with Conventional Commits**
-   ```bash
-   git commit -m "feat(scope): Short description
-
-   Longer explanation if needed.
-   Explain the why, not the how."
-   ```
-
-5. **Verify locally**
-   ```bash
-   just ci-docker-all
-   ```
-
-6. **Create PR or merge to master**
-   - Only on explicit human request
-   - GitHub Actions runs on push
-   - Monitor CI for success
-   - All checks must pass
-
-7. **NEVER** `git push origin master` — Always wait for user approval
+1. **Consult project board** — Pick an issue from the current milestone
+2. **Create feature branch** (`feat/my-feature`)
+3. **Code implementation** — Write code + tests + docs
+4. **Quality gate** — `just format && just lint && just test-all`
+5. **Commit** — SoC, Conventional Commits format
+6. **Local CI** — `just ci-docker-all`
+7. **Open PR** — Labels + milestone + project link + `Closes #N` (only on explicit user request)
+8. **Monitor CI** — Local + remote in parallel
+9. **NEVER** `git push origin master`
 
 ---
 
@@ -405,74 +158,30 @@ Before handing back control in chat/prompt:
 - **Branches:** >50%
 
 ### Measuring Coverage
-```bash
-# Recommended (LLVM-Cov with console output + HTML)
-just coverage-llvm
 
-# Alternative (GCovr, mostly for CI artifact uploads)
-just coverage
+```bash
+just coverage-llvm  # Recommended (LLVM-Cov)
+just coverage       # Alternative (GCovr)
 ```
 
 ### Reports Location
 - LLVM-Cov: `build/coverage-llvm/coverage_report/index.html`
 - GCovr: `build/coverage/reports/{coverage.txt,coverage.xml,coverage.html}`
 
-### Interpreting Results
-- Report shows all business logic files: `app_log.cpp`, `runtime_controls.cpp`, `vk_engine.cpp`, etc.
-- 0% coverage on test files is expected (tests are not tested)
-- Focus on coverage of testable modules, not shader/integration code
-
 ---
 
 ## 🐛 Debugging
 
-### Local Docker CI Equivalent
 ```bash
-# Build in container, run GCC/Clang, lint
-just ci-docker-all
-
-# Or individual steps:
-just ci-docker Release
-just ci-docker Debug
-just ci-docker lint
+just ci-docker-all              # Full local CI
+just build-asan && just test-asan  # Sanitizer debugging
+just test-validation-layers     # Vulkan validation layers
 ```
-
-### Sanitizer Debugging (ASan/UBSan)
-```bash
-just build-asan
-just test-asan
-```
-
-### Validation Layer Debugging (Vulkan)
-```bash
-just test-validation-layers
-```
-
-### RenderDoc Observability Directive (Mandatory)
-
-For every feature, fix, or refactor touching rendering, Vulkan resources, or GPU command recording:
-
-- **Always add meaningful resource names** via `vkSetDebugUtilsObjectNameEXT` (through project helper wrappers) for newly created Vulkan objects:
-   - Pipelines, pipeline layouts, render passes, framebuffers
-   - Buffers/images/image views/samplers
-   - Descriptor set layouts/pools/sets
-   - Command pools/command buffers, semaphores/fences, queues
-- **Always add meaningful labels** via `vkCmdBeginDebugUtilsLabelEXT` / `vkCmdEndDebugUtilsLabelEXT` around logical GPU blocks:
-   - Render pass setup/bindings
-   - Skybox pass, geometry pass, post-process pass
-   - Upload/copy/transition/mipmap generation phases
-- **Prefer hierarchical labels** (parent frame region + child pass regions) so Event Browser navigation is immediate.
-- **Use stable naming conventions** (`Feature_ObjectType[_Index]`) to keep captures diff-friendly across runs.
-- **Do not leave anonymous critical resources** in RenderDoc when they are part of the feature being changed.
-- **Keep docs aligned**: when adding/changing labels or naming conventions, update `docs/tracing.md` in the same change.
-
-Rationale: RenderDoc readability is a project quality requirement, not an optional debug extra.
 
 ---
 
 ## 🚫 Anti-Patterns
 
-**Don't:**
 - ❌ Commit without running `just format && just lint && just test-all`
 - ❌ Use raw `cmake` commands instead of `just` recipes
 - ❌ Push to `origin/master` without user approval
@@ -480,23 +189,16 @@ Rationale: RenderDoc readability is a project quality requirement, not an option
 - ❌ Create untagged code blocks in markdown
 - ❌ Make docs-only changes without updating `mkdocs.yml`
 - ❌ Forget to update docs when changing behavior
-- ❌ Ignore failing CI checks — fix them, don't skip
-
-**Do:**
-- ✅ Use `just` for all development tasks
-- ✅ Follow Conventional Commits format
-- ✅ Keep docs in sync with code
-- ✅ Run local CI (`just ci-docker-all`) before claiming "done"
-- ✅ Use mermaid diagrams for complex explanations
-- ✅ Tag all code blocks with language
-- ✅ Verify coverage >78% on changes
+- ❌ Ignore failing CI checks
+- ❌ Start work without checking the project board
 
 ---
 
 ## 📞 Questions?
 
-If unsure about commit message format, documentation structure, or CI/CD flow:
 - Check existing commits: `git log --oneline`
 - Check existing docs: `docs/` folder
 - Run `just help` for available recipes
 - Consult `mkdocs.yml` for doc structure
+- Review project board: https://github.com/users/yoyonel/projects/3
+- Label reference: [docs/github-settings.md](../../docs/github-settings.md)

--- a/.github/instructions/commit-workflow.instructions.md
+++ b/.github/instructions/commit-workflow.instructions.md
@@ -1,0 +1,108 @@
+---
+description: "Use when making commits, creating branches, or planning work iterations. Covers SoC commit discipline, Conventional Commits format, pre-commit workflow, and branching strategy."
+applyTo: ["src/**/*.c", "include/**/*.h", "shaders/**", "tests/**/*.c", "Justfile", "CMakeLists.txt"]
+---
+# Commit & Workflow Discipline
+
+## Separation of Concerns (SoC) — MANDATORY
+
+Every commit must have a **single concern**. Never mix:
+- Application code (`feat:`, `fix:`, `refactor:`) with CI (`ci:`) or docs (`docs:`)
+- Test changes (`test:`) with the code they test (separate commits when possible)
+- Script/tooling changes (`chore:`) with application logic
+
+## Conventional Commits Format
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) strictly:
+
+```text
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Types** (based on project specifics):
+- `feat`: New feature (keyboard control, shader, logging, etc.)
+- `fix`: Bug fix
+- `refactor`: Code restructuring without feature change
+- `test`: Test suite additions/modifications
+- `docs`: Documentation only
+- `build`: Build system, CMake, dependencies
+- `ci`: GitHub Actions, Docker, CI pipeline
+- `chore`: Dependencies, config, tooling, git config
+- `perf`: Performance optimization
+
+**Scope** (optional but recommended):
+- `logging`, `controls`, `shader`, `memory`, `ci`, `docs`, `coverage`, `rendering`, `postprocess`, `ibl`, `profiling`, etc.
+
+**Examples:**
+
+```text
+feat(controls): Add F11 fullscreen toggle with state restoration
+
+fix(logging): Correct thread ID formatting in log messages
+
+docs(coverage): Add LLVM-Cov section with KPI metrics
+
+ci(github-actions): Add coverage-report-llvm job with artifact uploads
+
+refactor(engine): Extract shader compilation logic to separate function
+```
+
+## Pre-Commit Workflow
+
+1. Run `just pre-commit-install` (one-time setup)
+2. Make code changes
+3. Run `just format` → fixes formatting automatically
+4. Run `just lint` → must pass with no errors and no warnings
+5. Run `just test-all` → all tests must pass
+6. Run `just pre-push-run` → final check before commit
+7. Run `git status --short --branch` and review all local changes
+8. Ensure all remaining files are either:
+   - intentionally staged for the current commit, or
+   - explicitly deferred and communicated as next step
+9. Use `git add` + `git commit` (hooks will verify format/lint/tests)
+10. **NEVER** `git push` — wait for user approval
+
+If any hook fails:
+- Read the error message
+- Fix the issue
+- Retry the commit
+
+### Warning Handling Policy
+
+- A lint command with `exit code 0` is NOT considered successful if warnings are present.
+- Warnings must be treated and fixed before moving to the next step or committing.
+- Use output checks when needed: `just lint 2>&1 | grep -i warning`
+- `clang-tidy` warnings (including `performance-*`) are blocking and must be fixed, not deferred.
+- During GitHub Actions monitoring, always run `just ci-docker-all` locally in parallel and fix local warnings/errors immediately to preempt remote failures.
+
+## Git Safety Rules
+
+- **Never `git push` without explicit user authorization**
+- **Never `git push --force`** without explicit user authorization
+- **Never `git push origin master`** — all changes go through feature branches + PRs
+- **Never delete untracked files** without asking
+- Prefer `git stash` over discarding changes
+
+## Commit Checklist
+
+Before running `git commit`:
+
+- [ ] Code formatted: `just format` ✅
+- [ ] No lint errors or warnings: `just lint` ✅
+- [ ] All tests pass: `just test-all` ✅
+- [ ] Git working tree reviewed: `git status --short --branch` ✅
+- [ ] No unexpected leftovers (unstaged/untracked) without explicit handling plan
+- [ ] Docs created/updated (if feature/design change)
+- [ ] `mkdocs.yml` updated (if new doc added)
+- [ ] No local filesystem links in docs
+- [ ] Commit message follows Conventional Commits format
+- [ ] Pre-commit hooks pass: `just pre-commit-run` ✅
+
+Before handing back control in chat/prompt:
+
+- [ ] Re-check repo state with `git status --short --branch`
+- [ ] Clearly report what is done, what remains modified, and what is deferred

--- a/.github/instructions/github-project.instructions.md
+++ b/.github/instructions/github-project.instructions.md
@@ -1,0 +1,64 @@
+---
+description: "Use when creating PRs, closing issues, updating milestones, or managing GitHub project board items. Covers label assignment, project tracking, and milestone lifecycle."
+---
+# GitHub Project Management
+
+## Session Startup (MANDATORY)
+
+At the start of **every** session, run:
+
+```bash
+gh issue list --state open
+gh api repos/yoyonel/suckless-ogl/milestones?state=all --jq '.[] | "\(.number) \(.title) \(.state) \(.open_issues)/\(.open_issues + .closed_issues)"'
+```
+
+Review the project board: https://github.com/users/yoyonel/projects/3
+
+## PR Workflow
+
+Every PR **MUST** have:
+- **Labels**: at least one scope label (`scope:*`, `subsystem:*`) + one type label (`bug`, `enhancement`, `refactor`, `quality`, `security`, `documentation`)
+- **Milestone**: linked to the relevant phase
+- **Project**: added to "suckless-ogl Roadmap" (project #3)
+- **Linked issues**: use `Closes #N` in PR body for auto-closing
+
+Label reference: see [docs/github-settings.md](../../docs/github-settings.md).
+
+## Issue Lifecycle
+
+1. When starting work on an issue: move to **In Progress** on the project board
+2. Create a feature branch: `feat/<description>`, `fix/<description>`, etc.
+3. Implement in small, focused commits (SoC)
+4. Open PR with labels + milestone + project link + `Closes #N`
+5. CI must be green before merge (local `just ci-docker-all` + remote GitHub Actions)
+6. After merge: verify the linked issue auto-closed; if not, close manually
+7. When all issues in a milestone are closed: close the milestone
+
+## Branch Naming
+
+| Prefix | Usage |
+|--------|-------|
+| `feat/<description>` | New features (shader, effect, control, UI) |
+| `fix/<description>` | Bug fixes |
+| `refactor/<description>` | Code restructuring |
+| `perf/<description>` | Performance optimization |
+| `docs/<description>` | Documentation-only changes |
+| `ci/<description>` | CI/CD pipeline changes |
+| `test/<description>` | Test additions/modifications |
+
+## Milestone Lifecycle
+
+- Milestones represent **themed phases** of the project roadmap
+- Each milestone has a description stating its scope and acceptance criteria
+- A milestone is closed when **all its issues are resolved** and CI is green
+- Do not reopen closed milestones — create a new one if rework is needed
+
+## Project Board Columns
+
+| Column | Description |
+|--------|-------------|
+| **Backlog** | Issues identified but not yet prioritized |
+| **Todo** | Prioritized for the current or next milestone |
+| **In Progress** | Actively being worked on (max 2–3 items) |
+| **In Review** | PR opened, awaiting CI validation |
+| **Done** | Merged and verified |

--- a/.github/instructions/testing-quality.instructions.md
+++ b/.github/instructions/testing-quality.instructions.md
@@ -1,0 +1,112 @@
+---
+description: "Use when running tests, validating refactoring, checking code quality, or completing any task. Covers CI validation, test coverage, code quality standards, and documentation gates."
+applyTo: ["src/**/*.c", "include/**/*.h", "tests/**/*.c", "shaders/**", "Justfile", "CMakeLists.txt", "scripts/**"]
+---
+# Testing & Quality Gates
+
+## CI IS THE SINGLE SOURCE OF TRUTH (NO EXCEPTIONS)
+
+**A task (prompt, refactoring, fix, feature, docs) is NEVER complete until the CI pipeline is fully green.**
+This is an absolute, non-negotiable rule with ZERO exceptions:
+- All jobs must pass: `lint-and-format`, `test-and-coverage`, AND `build-production`
+- A red CI means the task is still **in progress**, regardless of local test results
+- Do NOT merge, do NOT close issues, do NOT mark tasks as done with red CI
+- If CI fails after merge to master, a hotfix PR is mandatory — master must be green at all times
+
+## Validation Checklist (every change)
+
+Run locally before pushing:
+
+```bash
+just format         # Auto-fix formatting (clang-format)
+just lint           # clang-tidy + shellcheck + yamllint + hadolint (0 warnings)
+just test-all       # All unit + integration tests pass (CTest)
+just ci-docker-all  # Full local CI matrix (Docker, mimics GitHub Actions)
+```
+
+After push, monitor CI: check GitHub Actions workflow status.
+
+## Test Coverage
+
+- **Never decrease test coverage.** Every new function in `src/` must have corresponding tests.
+- When refactoring: run `just test-all` before AND after — same test count, same results.
+- When adding a feature: add unit tests in the same PR. No "tests in a follow-up" pattern.
+- Track coverage: `just coverage-llvm` (preferred) or `just coverage` (gcovr).
+- **Target**: >78% lines, >85% functions, >50% branches.
+
+## Code Quality Standards
+
+- Zero `clang-tidy` warnings (`-Werror` equivalent — enforced by CI and hooks)
+- Zero `clang-format` diff (enforced by CI)
+- No warning suppression (`NOLINT`, `NOLINTNEXTLINE`) — fix root cause instead
+- `shellcheck` clean for all scripts in `scripts/`
+- `hadolint` clean for `Dockerfile` and `Dockerfile.ci`
+- `yamllint` clean for all YAML files
+
+### No Suppression Policy
+
+**NEVER bypass linting or compiler warnings using suppression mechanisms:**
+
+❌ Forbidden patterns:
+- `// NOLINT`, `// NOLINTNEXTLINE`, `/* clang-tidy-disable */`
+- `ignore:` lists in `.hadolint.yaml`, `pylintrc`, etc.
+- `continue-on-error: true` in GitHub Actions to hide failures
+- CMake `set_source_files_properties(... SKIP_LINTING ON)`
+
+✅ Correct approach: fix the root cause.
+
+**Exception policy**: If suppression is the **only viable path**, it requires:
+1. An explicit comment in the code explaining why the fix is not possible
+2. A clear assessment confirming no alternative exists
+3. A tracking note (issue) to revisit and remove the suppression
+4. User explicit validation before committing
+
+## CI/CD Validation
+
+### Local CI (Docker, mimic GitHub Actions)
+
+```bash
+just ci-docker-all
+```
+
+This runs: static checks, lint, build + test (Release/Debug), memory checks (ASan/UBSan), coverage report.
+
+### Remote CI (GitHub Actions)
+
+- Automatically triggered on `push` + `pull_request` to `master`
+- Jobs: `lint-and-format`, `test-and-coverage`, `test-windows`, `documentation`, `build-production`, `build-production-windows`
+- Artifacts: coverage HTML, test frames
+
+### Failing Builds = Blocked
+
+- If any CI job fails (locally or remotely) → Fix before moving forward
+- No workarounds or skipping checks
+
+## Justfile Discipline
+
+- Recipes are thin entry points (max ~5 lines of shell)
+- Complex logic goes to `scripts/*.sh`
+- New scripts must be executable (`chmod +x`) and have a usage comment header
+- Test new Justfile recipes locally before pushing
+
+## Documentation Gate (blocks PR merge)
+
+A PR is NOT ready for merge unless ALL applicable documentation is included:
+
+1. **Feature docs** — New features must have `docs/<feature>.md` + `docs/<feature>.fr.md`
+2. **mkdocs.yml** — Updated `nav:` section if new doc added
+3. **Keybinding sync** — `src/app_binding.c` updated if controls changed
+4. **No local filesystem links** in any documentation
+5. **All code blocks tagged** with language (`` ```bash ``, `` ```c ``, `` ```glsl ``, etc.)
+6. **Mermaid diagrams** for architecture/flow changes
+7. **Multilingual sync** — Both `.md` and `.fr.md` must exist and be consistent
+
+## RenderDoc Observability (Mandatory for rendering changes)
+
+For every feature, fix, or refactor touching rendering or GPU resources:
+
+- Add meaningful resource names via GL debug utilities for new objects
+- Add meaningful labels around logical GPU blocks (passes, phases)
+- Prefer hierarchical labels for Event Browser navigation
+- Use stable naming conventions (`Feature_ObjectType[_Index]`)
+- Update `docs/tracing.md` when changing labels or naming conventions

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -1,0 +1,177 @@
+# GitHub Settings — suckless-ogl
+
+Configuration de référence du repo [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
+
+---
+
+## Labels
+
+### Labels génériques (conservés)
+
+| Label | Couleur | Description |
+|-------|---------|-------------|
+| `bug` | `#d73a4a` | Something isn't working |
+| `documentation` | `#0075ca` | Improvements or additions to documentation |
+| `enhancement` | `#a2eeef` | New feature or request |
+
+### Labels `subsystem:*`
+
+| Label | Couleur | Description |
+|-------|---------|-------------|
+| `subsystem:rendering` | `#1d76db` | Rendering pipeline, draw calls, instancing, SSBO |
+| `subsystem:postprocess` | `#5319e7` | Post-processing effects (bloom, DoF, exposure, FXAA, etc.) |
+| `subsystem:shader` | `#006b75` | GLSL shaders, compute shaders, shader compilation |
+| `subsystem:ibl` | `#0e8a16` | Image-Based Lighting, PBR, irradiance, specular maps |
+| `subsystem:profiling` | `#e36209` | GPU profiler, Tracy, perf timers, benchmarks |
+| `subsystem:ui` | `#795548` | UI overlay, debug visualization, help screen |
+| `subsystem:input` | `#c2e0c6` | Keyboard/mouse input, camera controls, key bindings |
+| `subsystem:async` | `#bfd4f2` | Async loading, environment manager, IO |
+
+### Labels `infra:*`
+
+| Label | Couleur | Description |
+|-------|---------|-------------|
+| `infra:ci` | `#fbca04` | GitHub Actions, Docker CI, workflows |
+| `infra:build` | `#333333` | CMake, Justfile, compilation toolchain |
+| `infra:docker` | `#2b67c6` | Docker images, CI containers |
+
+### Labels `scope:*`
+
+| Label | Couleur | Description |
+|-------|---------|-------------|
+| `scope:performance` | `#e36209` | Performance optimization, GPU utilization |
+| `scope:visual-regression` | `#d4c5f9` | Visual regression testing, reference images |
+| `scope:cross-platform` | `#c5def5` | Windows/Linux portability |
+
+### Labels transversaux
+
+| Label | Couleur | Description |
+|-------|---------|-------------|
+| `quality` | `#bfdadc` | Lint, format, clang-tidy, tests, hooks |
+| `refactor` | `#c5def5` | Restructuration, architecture |
+| `security` | `#d93f0b` | Security hardening, input validation, path traversal |
+
+### Labels supprimés (defaults GitHub)
+
+Les labels par défaut suivants doivent être supprimés :
+`duplicate`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`.
+
+---
+
+## Milestones
+
+Milestones correspondant aux phases du roadmap projet.
+
+| # | Milestone | État | Description |
+|---|-----------|------|-------------|
+| 1 | **Phase 1 — Compute Pipeline Migration** | 🔵 Open | Migrate remaining raster-only post-process effects to compute shaders (auto-exposure dual-path ✅, bloom, DoF). Validate perf parity on iGPU + dGPU. |
+| 2 | **Phase 2 — Test & Quality Hardening** | 🔵 Open | Fix build blockers (missing test files), eliminate NOLINTNEXTLINE suppressions, unify integration test pipeline (PBO everywhere), achieve >85% coverage. |
+| 3 | **Phase 3 — CI Industrialization** | 🔵 Open | Branch protection rules, required status checks, PR template enforcement, Windows CI parity, coverage thresholds in CI. |
+| 4 | **Phase 4 — Advanced Rendering** | 🔵 Open | Advanced bokeh DoF, cinematic LUT pipeline, dynamic IBL probes, screen-space reflections. As documented in `docs/advanced_bokeh_effects.md`, `docs/ibl_architecture_ideas.md`. |
+| 5 | **Phase 5 — Documentation & DX** | 🔵 Open | Multilingual doc sync (all FR translations), mkdocs full coverage, API doc generation (Doxygen), developer onboarding guide. |
+
+---
+
+## Project Board
+
+| Champ | Valeur |
+|-------|--------|
+| **Nom** | suckless-ogl Roadmap |
+| **Numéro** | #3 |
+| **ID** | `PVT_kwHOAGrT4s4BUfHP` |
+| **Type** | GitHub Projects v2 (user-scoped, linked au repo) |
+| **URL** | https://github.com/users/yoyonel/projects/3 |
+
+> **Note** : Les GitHub Projects v2 sont créés au niveau utilisateur/organisation,
+> pas au niveau repo. Pour qu'un projet apparaisse dans l'onglet **Projects** d'un repo,
+> il doit être explicitement lié via l'API GraphQL `linkProjectV2ToRepository`.
+
+---
+
+## Reproduction
+
+Commandes `gh` pour recréer cette configuration :
+
+```bash
+# --- Labels ---
+# Supprimer les defaults inutiles
+for label in "duplicate" "good first issue" "help wanted" "invalid" "question" "wontfix"; do
+  gh label delete "$label" --yes 2>/dev/null
+done
+
+# Créer les labels subsystem
+gh label create "subsystem:rendering"   --color "1d76db" --description "Rendering pipeline, draw calls, instancing, SSBO"
+gh label create "subsystem:postprocess" --color "5319e7" --description "Post-processing effects (bloom, DoF, exposure, FXAA, etc.)"
+gh label create "subsystem:shader"      --color "006b75" --description "GLSL shaders, compute shaders, shader compilation"
+gh label create "subsystem:ibl"         --color "0e8a16" --description "Image-Based Lighting, PBR, irradiance, specular maps"
+gh label create "subsystem:profiling"   --color "e36209" --description "GPU profiler, Tracy, perf timers, benchmarks"
+gh label create "subsystem:ui"          --color "795548" --description "UI overlay, debug visualization, help screen"
+gh label create "subsystem:input"       --color "c2e0c6" --description "Keyboard/mouse input, camera controls, key bindings"
+gh label create "subsystem:async"       --color "bfd4f2" --description "Async loading, environment manager, IO"
+
+# Créer les labels infra
+gh label create "infra:ci"              --color "fbca04" --description "GitHub Actions, Docker CI, workflows"
+gh label create "infra:build"           --color "333333" --description "CMake, Justfile, compilation toolchain"
+gh label create "infra:docker"          --color "2b67c6" --description "Docker images, CI containers"
+
+# Créer les labels scope
+gh label create "scope:performance"         --color "e36209" --description "Performance optimization, GPU utilization"
+gh label create "scope:visual-regression"   --color "d4c5f9" --description "Visual regression testing, reference images"
+gh label create "scope:cross-platform"      --color "c5def5" --description "Windows/Linux portability"
+
+# Créer les labels transversaux
+gh label create "quality"               --color "bfdadc" --description "Lint, format, clang-tidy, tests, hooks"
+gh label create "refactor"              --color "c5def5" --description "Restructuration, architecture"
+gh label create "security"              --color "d93f0b" --description "Security hardening, input validation, path traversal"
+
+# --- Milestones ---
+gh api repos/yoyonel/suckless-ogl/milestones -f title="Phase 1 — Compute Pipeline Migration" \
+  -f description="Migrate remaining raster-only post-process effects to compute shaders. Validate perf parity on iGPU + dGPU."
+gh api repos/yoyonel/suckless-ogl/milestones -f title="Phase 2 — Test & Quality Hardening" \
+  -f description="Fix build blockers, eliminate NOLINTNEXTLINE, unify integration test pipeline, achieve >85% coverage."
+gh api repos/yoyonel/suckless-ogl/milestones -f title="Phase 3 — CI Industrialization" \
+  -f description="Branch protection, required status checks, PR template enforcement, coverage thresholds."
+gh api repos/yoyonel/suckless-ogl/milestones -f title="Phase 4 — Advanced Rendering" \
+  -f description="Advanced bokeh DoF, cinematic LUT pipeline, dynamic IBL probes, screen-space reflections."
+gh api repos/yoyonel/suckless-ogl/milestones -f title="Phase 5 — Documentation & DX" \
+  -f description="Multilingual doc sync, mkdocs full coverage, Doxygen generation, developer onboarding guide."
+
+# --- Project ---
+gh project create --owner @me --title "suckless-ogl Roadmap"
+# Puis lier au repo via GraphQL :
+# gh api graphql -f query='mutation { linkProjectV2ToRepository(input: {projectId: "<PROJECT_ID>", repositoryId: "<REPO_ID>"}) { repository { id } } }'
+```
+
+---
+
+## Branch Protection (à configurer)
+
+| Règle | Valeur |
+|-------|--------|
+| **Branch** | `master` |
+| **Required status checks** | `lint-and-format`, `test-and-coverage`, `build-production` |
+| **Strict** | Oui (branch must be up-to-date before merge) |
+| **Enforce admins** | Non |
+| **Required reviews** | Non (solo project) |
+| **Force push** | Interdit |
+| **Delete branch** | Interdit |
+
+```bash
+gh api repos/yoyonel/suckless-ogl/branches/master/protection -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "lint-and-format",
+      "test-and-coverage",
+      "build-production"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
   - RenderDoc: renderdoc_guide.md
   - Visual Testing: visual_testing_artifacts.md
   - CI/CD Pipeline: cicd_pipeline.md
+  - GitHub Settings: github-settings.md
   - OpenGL Cleanup: opengl_cleanup.md
   - RAII Cleanup: raii_cleanup_guide.md
   - Memory Management Audit: memory_management_audit.md


### PR DESCRIPTION
## Summary

Establish structured GitHub project management for suckless-ogl.

### Changes

- **Refactor** `copilot-instructions.md` (502→204 lines) into modular instruction files:
  - `commit-workflow.instructions.md` — SoC, Conventional Commits, pre-commit workflow
  - `testing-quality.instructions.md` — CI validation, coverage, quality gates
  - `github-project.instructions.md` — PR workflow, labels, milestones, board
- **Add** `docs/github-settings.md` — Full reference: 20 labels, 5 milestones, branch protection, `gh` CLI reproduction commands
- **Add** Roadmap & Project Tracking section to `copilot-instructions.md`
- **Update** `mkdocs.yml` nav with `github-settings.md`

### GitHub Resources Created

| Resource | Count | Details |
|----------|-------|---------|
| Labels | 20 | 8 `subsystem:*`, 3 `infra:*`, 3 `scope:*`, 3 transversal, 3 generic |
| Milestones | 5 | Phase 1–5 (Compute, Quality, CI, Rendering, Docs) |
| Project Board | 1 | [suckless-ogl Roadmap #3](https://github.com/users/yoyonel/projects/3) |
| Issues | 15 | #162–#176 across 5 milestones |

### Docs-only — no application code changes.