### PR TITLE
feat(nbody): N-body gravity sandbox with trail renderer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Cache Clang-Tidy Results
         uses: actions/cache@v4
@@ -38,6 +39,12 @@ jobs:
           key: ${{ runner.os }}-cltcache-${{ hashFiles('src/**/*.c', 'include/**/*.h', '.clang-tidy', 'Makefile') }}
           restore-keys: |
             ${{ runner.os }}-cltcache-
+
+      - name: Check for new NOLINT suppressions
+        if: github.event_name == 'pull_request'
+        run: |
+          git config --global --add safe.directory '*'
+          make check-nolint CONTAINER_RUN="" NOLINT_BASE_REF="origin/${{ github.base_ref }}"
 
       - name: Run Format & Lint
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,10 @@ jobs:
             ${{ runner.os }}-cltcache-
 
       - name: Check for new NOLINT suppressions
-        if: github.event_name == 'pull_request'
         run: |
           git config --global --add safe.directory '*'
-          make check-nolint CONTAINER_RUN="" NOLINT_BASE_REF="origin/${{ github.base_ref }}"
+          BASE="origin/${{ github.base_ref || 'master' }}"
+          make check-nolint CONTAINER_RUN="" NOLINT_BASE_REF="${BASE}"
 
       - name: Run Format & Lint
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,15 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+    -   id: check-nolint
+        name: check-nolint
+        description: Reject new NOLINT suppressions vs origin/master.
+        entry: bash scripts/check_nolint.sh
+        language: system
+        files: \.(c|h)$
+        pass_filenames: false
+        stages: [pre-commit]
+
     -   id: make-format-check
         name: make format-check
         description: Verify formatting without modifying files (dry-run).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ set(SOURCES
     src/main.c
     src/material.c
     src/metric_stack.c
+    src/nbody.c
     src/pbr.c
     src/perf_mode.c
     src/perf_timer.c
@@ -133,6 +134,7 @@ set(SOURCES
     src/stb_image_impl.c
     src/texture.c
     src/tracy_gpu.cpp
+    src/trail_renderer.c
     src/tracy_log.c
     src/tracy_manager.c
     src/ui.c

--- a/Justfile
+++ b/Justfile
@@ -492,6 +492,10 @@ lint-full:
     @{{distrobox}} python3 {{justfile_directory()}}/scripts/lint_incremental.py .lint_full
     @echo "✓ Full linting passed"
 
+# Check for new NOLINT suppressions introduced vs a base ref (default: origin/master)
+check-nolint base_ref="origin/master":
+    @bash scripts/check_nolint.sh {{base_ref}}
+
 # Trace Performance Analysis
 trace-perf:
     @echo "Analyzing GPU performance (Advanced Analysis)..."

--- a/Justfile
+++ b/Justfile
@@ -506,6 +506,7 @@ clean:
 # =============================================================================
 
 tracy_legacy := `if [ "$XDG_SESSION_TYPE" = "wayland" ] || [ -n "$WAYLAND_DISPLAY" ]; then echo OFF; else echo ON; fi`
+tracy_port := env_var_or_default("TRACY_PORT", `ss -tlnH sport = :8086 2>/dev/null | grep -q . && echo 8087 || echo 8086`)
 
 # Build Tracy Server (X11 by default on Linux if LEGACY=ON)
 build-tracy-server:
@@ -514,13 +515,15 @@ build-tracy-server:
     @{{distrobox}} cmake -B deps/tracy/profiler/build -S deps/tracy/profiler -DCMAKE_BUILD_TYPE=Release -DLEGACY={{tracy_legacy}}
     @{{distrobox}} cmake --build deps/tracy/profiler/build --parallel {{nprocs}}
 
-# Run Tracy Server
+# Run Tracy Server (auto-detects free port, override with TRACY_PORT=N)
 tracy-server:
-    @./deps/tracy/profiler/build/tracy-profiler
+    @echo "Tracy server listening on port {{tracy_port}}"
+    @./deps/tracy/profiler/build/tracy-profiler -a 127.0.0.1 -p {{tracy_port}}
 
-# Build and run application with Tracy enabled
+# Build and run application with Tracy enabled (auto-detects free port)
 run-tracy: build-tracy
-    @./build-tracy/app
+    @echo "Tracy client connecting on port {{tracy_port}}"
+    @TRACY_PORT={{tracy_port}} ./build-tracy/app
 
 # Build application with Tracy enabled
 build-tracy:
@@ -549,7 +552,8 @@ test-integration-tracy-release: build-tracy-release
 
 # Run application with Tracy enabled in Release mode
 run-tracy-release: build-tracy-release
-    @./build-tracy-release/app
+    @echo "Tracy client connecting on port {{tracy_port}}"
+    @TRACY_PORT={{tracy_port}} ./build-tracy-release/app
 
 # =============================================================================
 # RenderDoc (Frame Analysis)

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,9 @@ lint-full: $(LINT_FULL_JSON)
 	@$(DISTROBOX) python3 scripts/lint_incremental.py $(LINT_FULL_DIR)
 	@echo "✓ Full linting passed"
 
+check-nolint:
+	@bash scripts/check_nolint.sh $(NOLINT_BASE_REF)
+
 deps-setup:
 	@chmod +x scripts/setup_offline_deps.sh
 	@./scripts/setup_offline_deps.sh

--- a/docs/cicd_pipeline.fr.md
+++ b/docs/cicd_pipeline.fr.md
@@ -13,6 +13,7 @@ Le pipeline est défini dans `.github/workflows/` et s'exécute automatiquement 
 Analyse statique du code source :
 
 - **clang-tidy** : Analyse C/C++
+- **check_nolint.sh** : Garde anti-suppression NOLINT (voir [linting_strategy.fr.md](linting_strategy.fr.md#politique-anti-suppression))
 - **shellcheck** : Vérification des scripts shell
 - **yamllint** : Validation des fichiers YAML
 - **hadolint** : Lint du Dockerfile

--- a/docs/cicd_pipeline.md
+++ b/docs/cicd_pipeline.md
@@ -30,8 +30,9 @@ The workflow is triggered automatically events:
 ### 1. `lint-and-format` (Quality)
 
 - **Goal**: Ensure code style and quality.
-- **Tools**: `clang-format`, `clang-tidy`, `ruff` (Python).
+- **Tools**: `clang-format`, `clang-tidy`, `ruff` (Python), `check_nolint.sh`.
 - **Checks**:
+  - **NOLINT guard**: Rejects any new `NOLINT` suppression vs the base branch (see [linting_strategy.md](linting_strategy.md#no-suppression-policy)).
   - Fails if `make format` results in file changes (enforces code style).
   - Runs `make lint` for static analysis.
 

--- a/docs/justfile.fr.md
+++ b/docs/justfile.fr.md
@@ -95,6 +95,9 @@ Le projet utilise `xdotool` et `Xvfb` pour simuler des interactions utilisateur 
 > [!TIP]
 > Utilisez `just test-integration` pour une vérification fonctionnelle rapide. Cela se termine en quelques secondes, alors que les variantes Valgrind peuvent prendre plusieurs minutes.
 
+> [!NOTE]
+> Le script d'intégration (`scripts/integration_scenarios.sh`) détecte automatiquement la disposition clavier via `setxkbmap` et remape les noms de keysym `xdotool` en conséquence.  Sur **AZERTY (fr)**, GLFW mappe les touches par position physique (US QWERTY), donc `xdotool key a` déclenche en réalité `GLFW_KEY_Q`.  Le script gère cela de manière transparente — aucune configuration manuelle nécessaire.
+
 ### Variantes de construction
 
 - **Release** : `just release` / `just run-release`

--- a/docs/justfile.md
+++ b/docs/justfile.md
@@ -95,6 +95,9 @@ The project uses `xdotool` and `Xvfb` to simulate user interactions and verify U
 > [!TIP]
 > Use `just test-integration` for quick functional verification. It finishes in seconds, whereas Valgrind variants can take several minutes.
 
+> [!NOTE]
+> The integration script (`scripts/integration_scenarios.sh`) auto-detects the keyboard layout via `setxkbmap` and remaps `xdotool` keysym names accordingly.  On **AZERTY (fr)**, GLFW maps keys by physical position (US QWERTY), so `xdotool key a` actually triggers `GLFW_KEY_Q`.  The script transparently handles this — no manual configuration needed.
+
 ### Build Variants
 
 - **Release**: `just release` / `just run-release`

--- a/docs/linting_strategy.fr.md
+++ b/docs/linting_strategy.fr.md
@@ -16,7 +16,7 @@ Nous utilisons `clang-tidy` pour l'analyse statique. La configuration est défin
 Nous privilégions la philosophie « Suckless » :
 
 - Minimiser les dépendances externes.
-- Éviter les commentaires `NOLINT` sauf si absolument nécessaire (ex. : variables globales pour le contexte de test).
+- **Les commentaires `NOLINT` sont interdits** — corriger la cause racine (voir [Politique anti-suppression](#politique-anti-suppression) ci-dessous).
 - Utiliser `static const` ou `enum` plutôt que des nombres magiques.
 
 ## Mise en cache incrémentielle (fichiers sentinelles)
@@ -95,3 +95,37 @@ just lint-shaders-strict
 Exécute la validation avec `--target-env opengl` (règles SPIR-V). Ce mode remonte les problèmes comme les qualificateurs `layout(location=N)` manquants, qui empêchent silencieusement le debugger de shaders RenderDoc de fonctionner.
 
 Depuis mars 2026, **les 33 fichiers shader passent la validation SPIR-V stricte**. Le projet impose des `layout(location=N)` explicites sur tous les varyings et uniforms non-opaques, et `layout(binding=N)` sur tous les samplers/images. Voir [renderdoc_guide.fr.md](renderdoc_guide.fr.md#8-debogage-des-shaders-compatibilite-spir-v) pour le détail complet.
+
+## Politique anti-suppression
+
+**`NOLINT`, `NOLINTNEXTLINE` et `NOLINTBEGIN`/`NOLINTEND` sont interdits.** L'approche correcte est toujours de corriger la cause racine.
+
+Un garde automatisé (`scripts/check_nolint.sh`) applique cette règle à chaque étape du workflow de développement :
+
+| Étape | Déclencheur | Mécanisme | Bloquant |
+|-------|-------------|-----------|----------|
+| **Commit local** | `git commit` sur `*.c` / `*.h` | Hook pre-commit (`check-nolint` dans `.pre-commit-config.yaml`) | Oui (contournable : `--no-verify`) |
+| **Manuel local** | `just check-nolint` ou `make check-nolint` | Invocation directe du script | Oui (exit 1) |
+| **CI — push** | Push sur n'importe quelle branche | Step du job `lint-and-format` | Oui — fait échouer le job |
+| **CI — pull request** | PR ouverte/mise à jour ciblant master | Step du job `lint-and-format` | Oui — fait échouer le job |
+| **CI — planifié** | Cron nocturne (01h00 UTC) | Step du job `lint-and-format` | Oui — fait échouer le job |
+
+### Fonctionnement
+
+Le script compare `git diff <base_ref>...HEAD` sur les fichiers `*.c` et `*.h`, en cherchant les lignes ajoutées (`+`) contenant `NOLINT`. Si des occurrences sont trouvées, le check échoue avec la liste de toutes les violations.
+
+```bash
+# Utilisation locale
+just check-nolint                    # Compare vs origin/master (défaut)
+just check-nolint origin/main        # Ref de base personnalisée
+make check-nolint NOLINT_BASE_REF=origin/main
+```
+
+### Politique d'exception
+
+Si la suppression est la **seule option viable**, elle nécessite :
+
+1. Un commentaire explicite expliquant pourquoi le fix n'est pas possible.
+2. Une évaluation confirmant qu'aucune alternative n'existe.
+3. Un ticket de suivi pour revisiter et retirer la suppression.
+4. **Validation explicite de l'utilisateur** avant le commit (utiliser `--no-verify`).

--- a/docs/linting_strategy.md
+++ b/docs/linting_strategy.md
@@ -16,7 +16,7 @@ We use `clang-tidy` for static analysis. The configuration is defined in `.clang
 We prioritize "Suckless" philosophy:
 
 - Minimize external dependencies.
-- Avoid `NOLINT` comments unless absolutely necessary (e.g., global variables for test context).
+- **`NOLINT` comments are forbidden** — fix the root cause instead (see [No-Suppression Policy](#no-suppression-policy) below).
 - Use `static const` or `enum` instead of magic numbers.
 
 ## Incremental Caching (Sentinel Files)
@@ -95,3 +95,37 @@ just lint-shaders-strict
 Runs validation with `--target-env opengl` (SPIR-V rules). This surfaces issues like missing `layout(location=N)` qualifiers that cause RenderDoc's shader debugger to fail silently.
 
 As of March 2026, **all 33 shader files pass strict SPIR-V validation**. The project enforces explicit `layout(location=N)` on all varyings and non-opaque uniforms, and `layout(binding=N)` on all samplers/images. See [renderdoc_guide.md](renderdoc_guide.md#8-shader-debugging-spir-v-compatibility) for the full rationale.
+
+## No-Suppression Policy
+
+**`NOLINT`, `NOLINTNEXTLINE`, and `NOLINTBEGIN`/`NOLINTEND` are forbidden.** The correct approach is always to fix the root cause.
+
+An automated guard (`scripts/check_nolint.sh`) enforces this at every stage of the development workflow:
+
+| Stage | Trigger | Mechanism | Blocking |
+|-------|---------|-----------|----------|
+| **Local commit** | `git commit` on `*.c` / `*.h` | pre-commit hook (`check-nolint` in `.pre-commit-config.yaml`) | Yes (bypass: `--no-verify`) |
+| **Local manual** | `just check-nolint` or `make check-nolint` | Direct script invocation | Yes (exit 1) |
+| **CI — push** | Push to any branch | `lint-and-format` job step | Yes — fails the job |
+| **CI — pull request** | PR opened/updated targeting master | `lint-and-format` job step | Yes — fails the job |
+| **CI — scheduled** | Nightly cron (01:00 UTC) | `lint-and-format` job step | Yes — fails the job |
+
+### How it Works
+
+The script compares `git diff <base_ref>...HEAD` on `*.c` and `*.h` files, searching for added lines (`+`) containing `NOLINT`. If any are found, the check fails with a listing of all violations.
+
+```bash
+# Local usage
+just check-nolint                    # Compare vs origin/master (default)
+just check-nolint origin/main        # Custom base ref
+make check-nolint NOLINT_BASE_REF=origin/main
+```
+
+### Exception Policy
+
+If suppression is the **only viable path**, it requires:
+
+1. An explicit comment explaining why the fix is not possible.
+2. A clear assessment confirming no alternative exists.
+3. A tracking issue to revisit and remove the suppression.
+4. **Explicit user validation** before committing (use `--no-verify`).

--- a/docs/memory_management_audit.fr.md
+++ b/docs/memory_management_audit.fr.md
@@ -31,6 +31,7 @@ L'audit a porté sur les structures suivantes identifiées comme gérant de la m
 | `PBRMaterial` | `name` (tableau fixe) | Nul | Structure POD (Plain Old Data). Copie sûre. |
 | `MaterialLib` | `materials` (tableau dynamique) | Nul | Géré exclusivement par pointeurs (`MaterialLib*`). Pas de copie par valeur. |
 | `SphereInstance` | Aucun (Vecteurs/Matrices) | Nul | Structure POD. Copie sûre (utilisée massivement dans `sphere_sorting.c`). |
+| `scene_init_instancing` | instance VBO, billboard VBO, `sphere_instances`, `sphere_sorter` | **Corrigé** | Le chemin de ré-init N-body OFF appelle désormais le cleanup avant la ré-init pour éviter une fuite de ~27 Ko par bascule. |
 
 ### Points Particulièrement Examinés
 

--- a/docs/memory_management_audit.md
+++ b/docs/memory_management_audit.md
@@ -31,6 +31,7 @@ The audit covered the following structures identified as managing dynamic memory
 | `PBRMaterial` | `name` (fixed array) | None | POD (Plain Old Data) struct. Safe to copy. |
 | `MaterialLib` | `materials` (dynamic array) | None | Managed exclusively via pointers (`MaterialLib*`). No value copy. |
 | `SphereInstance` | None (Vectors/Matrices) | None | POD struct. Safe to copy (used heavily in `sphere_sorting.c`). |
+| `scene_init_instancing` | instance VBO, billboard VBO, `sphere_instances`, `sphere_sorter` | **Fixed** | N-body OFF re-init path now calls cleanup before re-init to avoid leaking ~27 KB per toggle. |
 
 ### Specifically Examined Points
 

--- a/docs/motion_blur_analysis.fr.md
+++ b/docs/motion_blur_analysis.fr.md
@@ -30,19 +30,36 @@ graph TD
 3. **Pondération avec la Profondeur (Depth Weighting) :** Protège le premier plan en désactivant le mélange de couleurs lorsque l'échantillon prélevé est trop éloigné derrière le pixel central (`depthDiff > 1.0`).
 4. **Bruit de Gradient (Interleaved Gradient Noise) :** Empêche le phénomène de *banding* visuel en transformant les stries liées à un faible nombre d'échantillons en bruit esthétique de style pellicule.
 
-### 📉 Limite de l'implémentation actuelle : Camera-Only
+### ✅ Vélocité Per-Object (Implémentée)
 
-Dans le fichier `pbr_ibl_instanced.vert`, on observe que la configuration actuelle ne calcule le déplacement (Velocity) que par le biais de l'ancienne position de la caméra (`previousViewProj` * la position de la géométrie locale actuelle) :
+Depuis la branche `feat/per-object-motion-blur`, le velocity buffer prend désormais en compte **à la fois le mouvement caméra et le mouvement per-objet**. C'était la limitation la plus critique de l'approche camera-only initiale.
+
+#### Chemin de rendu instancié (`pbr_ibl_instanced.vert`)
+
+Un nouvel attribut vertex `i_prev_center` (location 8) stocke la position du centre de la sphère à la frame précédente. Le vertex shader reconstruit la position monde précédente :
 
 ```glsl
-CurrentClipPos = projection * view * vec4(WorldPos, 1.0);
-PreviousClipPos = previousViewProj * vec4(WorldPos, 1.0);
+vec3 prevWorldPos = i_prev_center + (WorldPos - vec3(i_model[3]));
+PreviousClipPos = previousViewProj * vec4(prevWorldPos, 1.0);
 ```
 
-**Pourquoi c'est tout à fait justifié (pour le moment) :**
-Dans **Suckless OGL**, tous les objets 3D (comme la grille de sphères PBR) sont statiques dans l'espace "World". Seule la caméra se déplace ou effectue des rotations. Par conséquent, il n'y a pas (encore) de concept de vélocité "Objet" (Object Velocity). Le **Camera Motion Blur** est donc 100% suffisant à ce stade du développement.
+Cela capture à la fois le mouvement caméra (via `previousViewProj`) et le mouvement objet (via `i_prev_center != centre actuel`).
 
-**Toutefois**, dès lors que le moteur implémentera des entités dynamiques (ex: des ennemis ou des objets physiques qui tombent), la vélocité propre de l'objet (sa *Previous World Position*) ainsi calculée sera `0` ou du moins faussée devant ne refléter que de la vélocité caméra. Un objet traversant rapidement l'écran devant une caméra fixe ne s'imprimera pas dans le *Velocity Buffer* en l'état actuel et ressortira hyper net par dessus le reste de l'image.
+#### Chemin Billboard/SSBO (`pbr_ibl_billboard.vert` / `.frag`)
+
+La struct SSBO stocke `prev_center_x/y/z` en 3 floats séparés (pas `vec3`, pour respecter l'alignement std430 à l'offset 92). Le fragment shader reconstruit :
+
+```glsl
+vec3 prevHitPos = PrevSphereCenter + (sphereHitPos - SphereCenter);
+vec4 prevClip = previousViewProj * vec4(prevHitPos, 1.0);
+```
+
+#### Flux de données
+
+- `NBodyParticle.prev_position` capture la position avant chaque pas physique
+- `nbody_write_instances()` copie `prev_position` → `SphereInstance.prev_center`
+- Les sphères statiques de la grille ont `prev_center == centre actuel` → vélocité objet nulle
+- `SphereInstance` reste à 128 octets (aligné SIMD, validé par `_Static_assert`)
 
 ---
 
@@ -68,12 +85,8 @@ Afin d'atteindre l'état de l'art, voici les optimisations et changements possib
         3. Créer une passe spécifique (via compute ou quad écran) ne calculant *uniquement* que l'effet de flou dans cette texture allégée en couleurs et vélocités.
         4. Écrire et exécuter l'étape d'*upsample* bilatéral durant la passe `postprocess.frag` ou dans une passe dédiée, afin de recomposer judicieusement l'image finale sur les bords des objets définis par le `depth buffer`.
 
-* **Per-Object et Skinned Velocity (Critique) :**
-  Pour que le motion blur s'applique aux objets en mouvement ou aux personnages, il faut stocker et transmettre la matrice Modèle de la frame précédente pour *chaque* objet.
-  ```glsl
-  vec4 PrevWorldPos = vec3(i_previous_model * vec4(in_position, 1.0));
-  PreviousClipPos = previousViewProj * PrevWorldPos;
-  ```
+* **Per-Object et Skinned Velocity :**
+  ~~Pour que le motion blur s'applique aux objets en mouvement ou aux personnages, il faut stocker et transmettre la matrice Modèle de la frame précédente pour *chaque* objet.~~ ✅ **Implémenté** — la vélocité per-objet est désormais active via `prev_center` dans `SphereInstance`. La prochaine étape est la vélocité skinned per-vertex pour les maillages animés.
 * **Soft Depth-Testing :**
   Remplacer le test booléen et brutal de profondeur par une pondération lissée à l'aide d'un `smoothstep()`. Des limites dures créent un bruit granuleux ou des tremblements de pixels (flickering) sur les arêtes en mouvement.
 
@@ -124,4 +137,4 @@ graph LR
 ```
 
 ### Le Verdict
-Pour permettre à Suckless OGL de concurrencer commercialement ces rendus, l'ajout du *Camera-only* est insuffisant. **L'implémentation du stockage de l'ancienne matrice de modélisation (Previous Model Matrix)** par instance (dans `pbr_ibl_instanced.vert`) est l'étape la plus immédiate et gratifiante à entreprendre.
+Suckless OGL implémente désormais le **motion blur per-objet** via le stockage de `prev_center` dans les données d'instance, couvrant à la fois la vélocité caméra et objet dans le velocity buffer. Les pistes d'amélioration restantes sont : la **vélocité skinned per-vertex** pour les maillages animés, la **reconstruction demi-résolution** pour les performances, et l'**échantillonnage adaptatif** basé sur l'amplitude de vélocité par pixel.

--- a/docs/motion_blur_analysis.md
+++ b/docs/motion_blur_analysis.md
@@ -30,19 +30,36 @@ graph TD
 3. **Depth Weighting:** Protects the foreground by disabling color blending when the sampled pixel is too far behind the center pixel (`depthDiff > 1.0`).
 4. **Interleaved Gradient Noise:** Prevents visual *banding* by transforming stripes from low sample counts into aesthetic film-grain-style noise.
 
-### 📉 Current Implementation Limitation: Camera-Only
+### ✅ Per-Object Velocity (Implemented)
 
-In `pbr_ibl_instanced.vert`, the current configuration calculates velocity (Velocity) only via the previous camera position (`previousViewProj` * the current local geometry position):
+As of the `feat/per-object-motion-blur` branch, the velocity buffer now accounts for **both camera motion and per-object motion**. This was the most critical limitation of the original camera-only approach.
+
+#### Instanced Rendering Path (`pbr_ibl_instanced.vert`)
+
+A new vertex attribute `i_prev_center` (location 8) stores the sphere's previous frame position. The vertex shader reconstructs the previous world position:
 
 ```glsl
-CurrentClipPos = projection * view * vec4(WorldPos, 1.0);
-PreviousClipPos = previousViewProj * vec4(WorldPos, 1.0);
+vec3 prevWorldPos = i_prev_center + (WorldPos - vec3(i_model[3]));
+PreviousClipPos = previousViewProj * vec4(prevWorldPos, 1.0);
 ```
 
-**Why this is fully justified (for now):**
-In **Suckless OGL**, all 3D objects (like the PBR sphere grid) are static in World space. Only the camera moves or rotates. Therefore there is (yet) no concept of "Object" velocity. **Camera Motion Blur** is 100% sufficient at this stage of development.
+This captures both camera movement (via `previousViewProj`) and object movement (via `i_prev_center != current center`).
 
-**However**, once the engine implements dynamic entities (e.g., enemies or falling physics objects), the object's own velocity (its *Previous World Position*) would be `0` or at least incorrect, reflecting only camera velocity. An object crossing the screen quickly in front of a static camera would not register in the *Velocity Buffer* with the current setup and would appear hyper-sharp against the rest of the image.
+#### Billboard/SSBO Path (`pbr_ibl_billboard.vert` / `.frag`)
+
+The SSBO struct stores `prev_center_x/y/z` as 3 separate floats (not `vec3`, to respect std430 alignment at offset 92). The fragment shader reconstructs:
+
+```glsl
+vec3 prevHitPos = PrevSphereCenter + (sphereHitPos - SphereCenter);
+vec4 prevClip = previousViewProj * vec4(prevHitPos, 1.0);
+```
+
+#### Data Flow
+
+- `NBodyParticle.prev_position` snapshots position before each physics step
+- `nbody_write_instances()` copies `prev_position` → `SphereInstance.prev_center`
+- Static grid spheres have `prev_center == current center` → zero object velocity
+- `SphereInstance` remains 128 bytes (SIMD-aligned, validated by `_Static_assert`)
 
 ---
 
@@ -68,12 +85,8 @@ To reach state-of-the-art quality, here are the possible optimizations and chang
         3. Create a dedicated pass (via compute or screen quad) that computes *only* the blur effect in this lightweight texture.
         4. Write and execute the bilateral upsample step during the `postprocess.frag` pass or a dedicated pass to recompose the final image cleanly on object edges defined by the `depth buffer`.
 
-* **Per-Object and Skinned Velocity (Critical):**
-  For motion blur to apply to moving objects or characters, the previous frame's Model matrix must be stored and passed for *each* object.
-  ```glsl
-  vec4 PrevWorldPos = vec3(i_previous_model * vec4(in_position, 1.0));
-  PreviousClipPos = previousViewProj * PrevWorldPos;
-  ```
+* **Per-Object and Skinned Velocity:**
+  ~~For motion blur to apply to moving objects or characters, the previous frame's Model matrix must be stored and passed for *each* object.~~ ✅ **Implemented** — per-object velocity is now active via `prev_center` in `SphereInstance`. The next frontier is per-vertex skinned velocity for animated meshes.
 * **Soft Depth-Testing:**
   Replace the hard boolean depth test with a smooth weight using `smoothstep()`. Hard limits create grainy noise or pixel flickering on moving edges.
 
@@ -124,4 +137,4 @@ graph LR
 ```
 
 ### The Verdict
-For Suckless OGL to commercially compete with these renders, adding *Camera-only* blur is insufficient. **Implementing previous model matrix (Previous Model Matrix) storage** per instance (in `pbr_ibl_instanced.vert`) is the most immediate and rewarding next step.
+Suckless OGL now implements **per-object motion blur** via `prev_center` storage in the instance data, covering both camera and object velocity in the velocity buffer. The remaining improvement paths are: **per-vertex skinned velocity** for animated meshes, **half-resolution reconstruction** for performance, and **adaptive sampling** based on per-pixel velocity magnitude.

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -293,6 +293,42 @@ $$\text{time\_scale} \in \{0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; 4.0,\; 8.0,\; 1
 
 Une notification overlay affiche la vitesse actuelle à chaque changement.
 
+### Inversion Temporelle
+
+La direction du temps peut être **inversée** à l'exécution :
+
+| Touche (US) | Touche (AZERTY) | Action |
+|-------------|-----------------|--------|
+| `Ctrl+Shift+G` | `Ctrl+Shift+G` | Bascule la direction du temps (avant/arrière) |
+
+Ceci exploite une propriété fondamentale de la gravité newtonienne : les
+équations du mouvement sont **invariantes sous $t \to -t$**.  Inverser le
+temps revient à négativer toutes les vitesses — le système retrace sa
+trajectoire en sens inverse.
+
+Comme Velocity Verlet est à la fois **symplectique** et **réversible dans
+le temps** ($\Phi_h^{-1} = \Phi_{-h}$), la simulation inversée suit la
+même orbite avec une erreur d'énergie bornée.  Après $N$ pas en avant et
+$N$ pas en arrière, le système revient à l'état initial (modulo l'arrondi
+flottant : $\sim N \cdot \epsilon_{\text{machine}}$ d'erreur de position).
+
+En marche arrière, le HUD affiche un indicateur ⏪ à côté de la lecture
+d'énergie.  Les contrôles de vitesse (`,` / `.`) ajustent la magnitude
+sans affecter la direction temporelle.
+
+#### Transition Progressive
+
+L'inversion n'est pas instantanée : `time_scale` converge linéairement
+vers sa cible au rythme de **3.0 unités/s** (`NBODY_TIME_SCALE_RATE`).  À
+vitesse $1\times$, la transition complète avant→arrière prend ~0.7 s :
+
+$$+1.0 \xrightarrow{\text{décélération}} 0.0 \xrightarrow{\text{accélération}} -1.0$$
+
+Cela produit un effet naturel « rembobinage VHS » où les corps ralentissent,
+se figent brièvement, puis accélèrent en sens inverse.  Des multiplicateurs
+plus élevés prennent proportionnellement plus de temps (ex. $4\times$ →
+~2.7 s).
+
 ### Contrôle de la Gravité (`gravity`)
 
 La constante gravitationnelle $G$ est ajustable en temps réel avec le

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -245,6 +245,9 @@ invariants physiques sur de longues simulations :
 | `test_nbody_paused_no_change` | Sim en pause parfaitement gelée | Identique bit à bit |
 | `test_nbody_survives_dt_spikes` | Les pics de frame ne déstabilisent pas | Tous les corps $< 50$ unités |
 | `test_nbody_long_run_stability` | Invariants sur 1 200 s | Voir ci-dessous |
+| `test_nbody_kinetic_energy_positive` | $E_k > 0$ après init | Positif |
+| `test_nbody_energy_drift_api` | API drift : $E_0$ stocké, dérive $\approx 0$ à $t=0$ | dérive $< 5\%$ après 10 s |
+| `test_nbody_zero_gravity` | $G = 0$ signifie aucune accélération | Vitesse inchangée après 120 pas |
 
 ### Résultats de Stabilité Long Terme (1 200 s à 120 Hz = 144 000 pas)
 
@@ -290,6 +293,50 @@ $$\text{time\_scale} \in \{0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; 4.0,\; 8.0,\; 1
 
 Une notification overlay affiche la vitesse actuelle à chaque changement.
 
+### Contrôle de la Gravité (`gravity`)
+
+La constante gravitationnelle $G$ est ajustable en temps réel avec le
+modificateur Shift :
+
+| Touche (US) | Touche (AZERTY) | Action |
+|-------------|-----------------|--------|
+| `Shift+.` | `Shift+:` | Doubler G (max 128) |
+| `Shift+,` | `Shift+;` | Diviser G par 2 (min 0.125, puis OFF) |
+
+$G$ suit des puissances de 2 à partir de la valeur courante :
+
+$$G \in \{0,\; 0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; \ldots,\; 128.0\}$$
+
+- **$G = 0$** désactive la gravité : les corps suivent des trajectoires
+  balistiques en ligne droite à leur vitesse courante.
+- Quand $G$ change, l'énergie de référence $E_0$ est **recalculée** pour que
+  l'indicateur de stabilité ne reflète que l'erreur d'intégration numérique,
+  pas le changement intentionnel de paramètre physique.
+
+### Affichage HUD
+
+Quand le mode N-corps est actif et l'overlay texte est activé (`F1`), deux
+lignes sont affichées :
+
+1. **Énergie & Gravité :** `Ek: 77.1 J | G: 2.000` — énergie cinétique
+   $E_k = \sum \tfrac{1}{2} m_i |\mathbf{v}_i|^2$ et valeur courante de $G$.
+2. **Stabilité :** `Stability: Stable (drift: 0.12%)` — indique si
+   l'intégrateur conserve l'énergie.
+
+L'indicateur de stabilité est coloré :
+
+| Couleur | État | Condition |
+|---------|------|-----------|
+| Vert | Stable | dérive $< 5\%$ |
+| Rouge | Divergent | dérive $\geq 5\%$ |
+
+La dérive est calculée par :
+
+$$\text{dérive} = \frac{|E(t) - E_0|}{|E_0|}$$
+
+où $E_0$ est le snapshot d'énergie totale pris à l'initialisation (ou après
+un changement de gravité).
+
 ### Stabilité de la Longueur des Traînées
 
 L'accumulateur d'échantillonnage des traînées est modulé par `time_scale` :
@@ -314,10 +361,11 @@ par frame au lieu de 1, gardant la longueur des traînées constante en unités 
 |---------|------|
 | `include/nbody.h` | API publique, constantes, structures de données |
 | `src/nbody.c` | Implémentation physique (Verlet, adoucissement, preset) |
-| `tests/test_nbody_stability.c` | Suite de tests de stabilité (5 tests) |
+| `tests/test_nbody_stability.c` | Suite de tests de stabilité (8 tests) |
 | `include/trail_renderer.h` | Rendu des traînées (rubans visuels derrière les corps) |
 | `src/trail_renderer.c` | Implémentation des traînées en rubans billboard |
-| `src/app_input.c` | Raccourcis clavier vitesse de simulation (`,` / `.`) |
+| `src/app_input.c` | Raccourcis vitesse de simulation (`,` / `.`) et gravité (variantes Shift) |
+| `src/app_ui.c` | Overlay HUD N-corps (énergie, gravité, stabilité) |
 | `src/app_binding.c` | Enregistrement dans l'overlay d'aide F2 |
 | `shaders/trail.vert` | Vertex shader des traînées |
 | `shaders/trail.frag` | Fragment shader des traînées |

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -355,6 +355,33 @@ par frame au lieu de 1, gardant la longueur des traînées constante en unités 
 
 ---
 
+## Zones de Profilage
+
+Le pipeline N-corps est instrumenté avec des zones de profilage CPU à grain
+fin (visibles dans Tracy ou tout profileur compatible `PROFILE_ZONE`).
+
+### Zones CPU (`PROFILE_ZONE` — Thread Principal)
+
+| Zone | Fichier | Ce qu'elle mesure |
+|------|---------|-------------------|
+| `NBody Physics` | `app.c` | Wrapper top-level (parent de toutes les suivantes) |
+| `NBody Verlet` | `scene.c` | `nbody_step()` — gravité O(N²) + Velocity Verlet |
+| `NBody Trail Sample` | `scene.c` | `trail_renderer_record()` — écriture ring buffers |
+| `NBody Instance Build` | `scene.c` | `nbody_write_instances()` — génération matrices modèle |
+| `NBody VBO Upload` | `scene.c` | `instanced_group_update()` → `glBufferSubData` |
+| `Trail Ribbon Build` | `trail_renderer.c` | `build_ribbon()` × N corps — staging géométrie CPU |
+| `Trail VBO Upload` | `trail_renderer.c` | `glBufferSubData` — upload buffer GPU |
+| `Trail Draw Calls` | `trail_renderer.c` | `glDrawArrays` × N corps |
+
+### Zones GPU (`GPU_STAGE_PROFILER` — Contexte OpenGL)
+
+| Zone | Fichier | Ce qu'elle mesure |
+|------|---------|-------------------|
+| `Instanced Render` | `scene.c` | Draw call des sphères (partagé avec grille matériaux) |
+| `NBody Trails` | `scene.c` | Passe complète de rendu des traînées |
+
+---
+
 ## Carte du Code
 
 | Fichier | Rôle |

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -272,6 +272,42 @@ Toutes les constantes sont définies dans `include/nbody.h` :
 
 ---
 
+## Contrôles en Temps Réel
+
+### Vitesse de Simulation (`time_scale`)
+
+La vitesse de simulation est ajustable au clavier :
+
+| Touche (US) | Touche (AZERTY) | Action |
+|-------------|-----------------|--------|
+| `.` | `:` | Doubler la vitesse (max 64×) |
+| `,` | `;` | Diviser par 2 (min 1/8×) |
+
+Le multiplicateur `time_scale` suit des puissances de 2 pour garantir que
+`1.0×` est toujours atteignable :
+
+$$\text{time\_scale} \in \{0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; 4.0,\; 8.0,\; 16.0,\; 32.0,\; 64.0\}$$
+
+Une notification overlay affiche la vitesse actuelle à chaque changement.
+
+### Stabilité de la Longueur des Traînées
+
+L'accumulateur d'échantillonnage des traînées est modulé par `time_scale` :
+
+```text
+effective_dt = wall_dt × time_scale
+sample_timer += effective_dt
+tant que sample_timer >= TRAIL_SAMPLE_INTERVAL:
+    enregistrer les positions
+    sample_timer -= TRAIL_SAMPLE_INTERVAL
+```
+
+Cela garantit que le ring buffer se remplit et évacue les points au même
+rythme *visuel* quel que soit `time_scale`. À 8×, 8 échantillons sont émis
+par frame au lieu de 1, gardant la longueur des traînées constante en unités monde.
+
+---
+
 ## Carte du Code
 
 | Fichier | Rôle |
@@ -281,5 +317,7 @@ Toutes les constantes sont définies dans `include/nbody.h` :
 | `tests/test_nbody_stability.c` | Suite de tests de stabilité (5 tests) |
 | `include/trail_renderer.h` | Rendu des traînées (rubans visuels derrière les corps) |
 | `src/trail_renderer.c` | Implémentation des traînées en rubans billboard |
+| `src/app_input.c` | Raccourcis clavier vitesse de simulation (`,` / `.`) |
+| `src/app_binding.c` | Enregistrement dans l'overlay d'aide F2 |
 | `shaders/trail.vert` | Vertex shader des traînées |
 | `shaders/trail.frag` | Fragment shader des traînées |

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -418,6 +418,36 @@ fin (visibles dans Tracy ou tout profileur compatible `PROFILE_ZONE`).
 
 ---
 
+## Cycle de Vie des Ressources
+
+Lorsque le mode N-corps est basculé sur **OFF**, le moteur restaure la grille
+de matériaux originale en appelant `scene_init_instancing()` une seconde fois.
+Ce chemin de ré-initialisation doit d'abord libérer chaque ressource allouée
+par l'appel précédent pour éviter les fuites de buffers GPU et de mémoire CPU :
+
+```c
+/* Nettoyage avant ré-init (scene.c — branche N-body OFF) */
+trail_renderer_cleanup(&scene->trail_renderer);
+#ifdef USE_TRANSPARENT_BILLBOARDS
+if (scene->sphere_instances) {
+    platform_aligned_free(scene->sphere_instances);
+    scene->sphere_instances = NULL;
+}
+sphere_sorter_cleanup(&scene->sphere_sorter);
+#endif
+instanced_group_cleanup(&scene->instanced_group);
+billboard_group_cleanup(&scene->billboard_group);
+scene_init_instancing(scene);
+```
+
+Le nettoyage reproduit ce que fait `scene_cleanup()` à la fermeture de
+l'application.  Sans cela, chaque bascule ON → OFF fuyait ~27 Ko (4 blocs :
+instance VBO, billboard VBO, tableau d'instances aligné, trieur de sphères).
+
+Validé avec `just test-integration-valgrind-full` — **0 bytes definitely lost**.
+
+---
+
 ## Carte du Code
 
 | Fichier | Rôle |

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -407,7 +407,7 @@ fin (visibles dans Tracy ou tout profileur compatible `PROFILE_ZONE`).
 | `NBody VBO Upload` | `scene.c` | `instanced_group_update()` → `glBufferSubData` |
 | `Trail Ribbon Build` | `trail_renderer.c` | `build_ribbon()` × N corps — staging géométrie CPU |
 | `Trail VBO Upload` | `trail_renderer.c` | `glBufferSubData` — upload buffer GPU |
-| `Trail Draw Calls` | `trail_renderer.c` | `glDrawArrays` × N corps |
+| `Trail Draw Calls` | `trail_renderer.c` | `glMultiDrawArrays` — N strips batchés en 1 appel |
 
 ### Zones GPU (`GPU_STAGE_PROFILER` — Contexte OpenGL)
 

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -1,0 +1,285 @@
+# Simulation N-Corps — Référence Physique
+
+## Vue d'ensemble
+
+Le module N-corps (`nbody.h` / `nbody.c`) implémente une simulation
+gravitationnelle temps réel de jusqu'à 16 corps en orbite autour d'une étoile
+centrale.  Le moteur physique privilégie la **stabilité long terme**
+(conservation de l'énergie sur des milliers de secondes simulées) en utilisant
+des techniques éprouvées d'astrophysique numérique :
+
+| Composant | Technique |
+|-----------|-----------|
+| Intégrateur | **Velocity Verlet** (symplectique, ordre 2) |
+| Régularisation | **Adoucissement de Plummer** (par paire, adaptatif) |
+| Conditions initiales | Formule de **vitesse orbitale adoucie** |
+| Pas de temps | Fixe $\frac{1}{120}\text{s}$, accumulateur borné |
+
+Validé par un test automatisé de 1 200 s avec **0.002 %** de dérive d'énergie.
+
+---
+
+## Intégrateur Velocity Verlet
+
+[Velocity Verlet](https://en.wikipedia.org/wiki/Verlet_integration#Velocity_Verlet)
+(aussi appelé *Leapfrog kick-drift-kick*) est un intégrateur **symplectique** :
+il préserve la structure géométrique des systèmes hamiltoniens, ce qui garantit
+que l'énergie totale oscille autour de la vraie valeur au lieu de dériver
+monotoniquement.
+
+### Algorithme (par pas fixe $\Delta t$)
+
+1. Calculer les accélérations à partir des positions courantes : $\mathbf{a}_\text{old}$
+2. Mettre à jour les positions :
+$$\mathbf{x} \leftarrow \mathbf{x} + \mathbf{v}\,\Delta t + \tfrac{1}{2}\,\mathbf{a}_\text{old}\,\Delta t^2$$
+3. Calculer les accélérations à partir des nouvelles positions : $\mathbf{a}_\text{new}$
+4. Mettre à jour les vitesses :
+$$\mathbf{v} \leftarrow \mathbf{v} + \tfrac{1}{2}(\mathbf{a}_\text{old} + \mathbf{a}_\text{new})\,\Delta t$$
+
+Implémenté dans `integrate_step()` dans `src/nbody.c`.
+
+### Pourquoi le Symplectique est Important
+
+Les méthodes non-symplectiques (Euler, RK4) accumulent une dérive séculaire
+d'énergie proportionnelle au nombre de pas.  Sur 1 200 s à 120 Hz, cela
+représente 144 000 pas — suffisant pour que même de petites erreurs par pas
+fassent exploser ou effondrer le système.  L'erreur bornée d'un intégrateur
+symplectique maintient les orbites qualitativement correctes indéfiniment.
+
+**Références :**
+
+- [Intégrateur symplectique — Wikipédia](https://fr.wikipedia.org/wiki/Int%C3%A9grateur_symplectique)
+- [Intégration leapfrog — Wikipedia](https://en.wikipedia.org/wiki/Leapfrog_integration)
+- Hairer, Lubich & Wanner, *Geometric Numerical Integration* (Springer, 2006)
+
+---
+
+## Adoucissement de Plummer
+
+Dans un champ gravitationnel pur en $1/r^2$, deux masses ponctuelles passant
+très près subissent des forces arbitrairement grandes, menant à des effets de
+fronde numérique et des échanges chaotiques d'énergie.  Le remède standard en
+astrophysique est l'[adoucissement de Plummer](https://en.wikipedia.org/wiki/Plummer_model) :
+
+$$F = \frac{G\,m_i\,m_j}{(r^2 + \varepsilon^2)^{3/2}}\,\hat{\mathbf{r}}$$
+
+La longueur d'adoucissement $\varepsilon$ régularise la singularité en $r = 0$,
+transformant le potentiel newtonien $1/r$ en le potentiel fini de
+[Plummer](https://en.wikipedia.org/wiki/Plummer_model)
+$\Phi = -G\,M / \sqrt{r^2 + \varepsilon^2}$.
+
+### Adoucissement Adaptatif par Paire
+
+Plutôt qu'un seul $\varepsilon$ global, on adapte l'adoucissement aux rayons
+physiques de chaque paire :
+
+$$\varepsilon^2 = \max\!\bigl(\texttt{NBODY\_SOFTENING\_SQ},\;
+      (\texttt{NBODY\_SOFTENING\_FACTOR} \cdot (r_i + r_j))^2\bigr)$$
+
+Avec les constantes par défaut :
+
+| Constante | Valeur | Rôle |
+|-----------|--------|------|
+| `NBODY_SOFTENING_SQ` | 0.25 | Plancher absolu ($\varepsilon_\min = 0.5$) |
+| `NBODY_SOFTENING_FACTOR` | 2.0 | Multiplicateur par paire sur les rayons combinés |
+
+Ceci garantit que :
+
+- Les gros corps (l'étoile, $r = 1.5$) bénéficient d'un fort adoucissement ($\varepsilon \geq 3.6$).
+- Les petites paires (deux lunes) en reçoivent proportionnellement moins,
+  gardant leur dynamique plus képlérienne.
+- Aucune paire n'atteint jamais la région singulière.
+
+Implémenté dans `pair_softening_sq()`.
+
+**Références :**
+
+- [Adoucissement gravitationnel — Wikipedia](https://en.wikipedia.org/wiki/Softening)
+- Dehnen & Aly, *Improving convergence of N-body methods* (MNRAS 425, 2012)
+- Aarseth, *Gravitational N-Body Simulations* (Cambridge, 2003)
+
+---
+
+## Vitesse Orbitale Adoucie
+
+Une erreur courante est d'initialiser les vitesses d'orbite circulaire avec la
+formule de Kepler $v = \sqrt{G\,M/r}$.  C'est **faux** quand l'adoucissement
+est actif car le potentiel effectif est plus plat que $1/r$.
+
+La condition correcte d'orbite circulaire pour le potentiel de Plummer est :
+
+$$v = r \cdot \sqrt{\frac{G\,M}{(r^2 + \varepsilon^2)^{3/2}}}$$
+
+Elle vient de l'équilibre entre l'accélération centripète $v^2/r$ et
+l'accélération gravitationnelle adoucie $G\,M\,r / (r^2 + \varepsilon^2)^{3/2}$.
+
+Utiliser la formule non-adoucie surestime la vitesse orbitale, injectant
+un excès d'énergie cinétique et causant la spirale vers l'extérieur des corps.
+
+Implémenté dans `softened_orbital_vel()`.
+
+---
+
+## Annulation de la Quantité de Mouvement
+
+Après l'initialisation de tous les corps, la quantité de mouvement totale
+$\mathbf{p} = \sum m_i \mathbf{v}_i$ est mise à zéro en soustrayant la
+vitesse du centre de masse de chaque corps :
+
+$$\mathbf{v}_i \leftarrow \mathbf{v}_i - \frac{\sum m_j\,\mathbf{v}_j}{\sum m_j}$$
+
+Cela maintient le centre de masse immobile et empêche le système entier de
+dériver à travers la scène.  L'opération est faite **une seule fois** à
+l'initialisation, jamais pendant la simulation (ce qui briserait la
+symplecticité).
+
+---
+
+## Pas de Temps Fixe avec Accumulateur
+
+Les pas de temps variables détruisent la propriété symplectique.  La simulation
+utilise un $\Delta t = 1/120\,\text{s}$ fixe avec un motif d'accumulateur
+standard :
+
+```text
+accumulateur += wall_dt × time_scale
+borner accumulateur à NBODY_MAX_ACCUMULATOR (1/30 s)
+tant que accumulateur >= NBODY_FIXED_DT :
+    integrate_step(NBODY_FIXED_DT)
+    accumulateur -= NBODY_FIXED_DT
+```
+
+Le bornage maximum de l'accumulateur empêche un emballement de l'intégration
+après des pics de latence ou lors de la première frame.
+
+---
+
+## Approches Testées et Rejetées
+
+Au cours du développement, plusieurs techniques alternatives ont été testées
+et **rejetées** car elles brisaient l'invariant symplectique ou introduisaient
+une dissipation d'énergie inacceptable.
+
+### 1. Collisions Élastiques
+
+**Idée :** Quand deux corps se chevauchent ($r < r_i + r_j$), refléter leurs
+vitesses avec les formules de collision élastique.
+
+**Problème :** La détection discrète de collision à pas de temps fixe introduit
+des impulsions non-réversibles dans le temps.  Cela brise la symplecticité et
+cause une dérive séculaire d'énergie.  En pratique, les corps gagnaient de
+l'énergie à chaque collision, menant à une explosion exponentielle.
+
+**Verdict :** Supprimé entièrement.  L'adoucissement de Plummer empêche le
+chevauchement sans nécessiter de gestion des collisions.
+
+### 2. Clamp d'Énergie
+
+**Idée :** Après chaque pas, mesurer l'énergie totale ; si elle dépasse un
+seuil, redimensionner toutes les vitesses pour restaurer l'énergie cible.
+
+**Problème :** C'est une étape de projection qui ne dérive pas d'un
+hamiltonien.  Elle détruit la structure symplectique et introduit un
+amortissement ou un pompage artificiel selon le signe de la correction.
+
+**Verdict :** Supprimé.
+
+### 3. Frein d'Échappement
+
+**Idée :** Si un corps dépasse un seuil de distance, appliquer une force de
+traînée pour le ramener.
+
+**Problème :** Force non-conservative → perte séculaire d'énergie → les
+orbites décroissent et le système s'effondre.
+
+**Verdict :** Supprimé.
+
+### 4. Ré-annulation de la Quantité de Mouvement par Pas
+
+**Idée :** Soustraire la vitesse du centre de masse de tous les corps à
+chaque pas.
+
+**Problème :** C'est une projection non-symplectique appliquée à chaque pas.
+Elle interfère avec la structure de l'espace des phases de l'intégrateur et
+cause une dérive descendante de l'énergie.
+
+**Verdict :** La quantité de mouvement est annulée **une seule fois** à
+l'initialisation, jamais pendant la simulation.
+
+### 5. XPBD (Extended Position-Based Dynamics)
+
+**Idée :** Utiliser le solveur de contraintes XPBD (de la physique de jeux
+vidéo) pour imposer une distance minimale entre les corps, remplaçant
+l'adoucissement par une répulsion basée sur des contraintes.
+
+**Problème :** XPBD est **fondamentalement dissipatif par conception** — il
+résout les contraintes en projetant les positions, ce qui ne conserve pas
+l'énergie.  En test, cela a causé **21 % de perte d'énergie** sur 300 s,
+les orbites ont décru rapidement et tous les corps se sont effondrés sur
+l'étoile.
+
+XPBD est excellent pour la physique de jeux (ragdolls, tissus) où la
+dissipation est acceptable voire souhaitable, mais il est **catastrophique**
+pour les simulations gravitationnelles qui nécessitent la conservation de
+l'énergie.
+
+**Verdict :** Rejeté après test.  Verlet pur + fort adoucissement de Plummer
+est l'approche correcte pour la gravité N-corps.
+
+**Références :**
+
+- Müller et al., *Detailed Rigid Body Simulation with Extended Position Based Dynamics* (CGF 2020)
+- [Position Based Dynamics — Wikipedia](https://en.wikipedia.org/wiki/Position-based_dynamics)
+
+---
+
+## Validation par Tests
+
+La suite de tests automatisée (`tests/test_nbody_stability.c`) vérifie les
+invariants physiques sur de longues simulations :
+
+| Test | Ce qu'il vérifie | Seuil |
+|------|-----------------|-------|
+| `test_nbody_single_step_sanity` | Un pas n'explose pas | Positions finies |
+| `test_nbody_energy_conservation` | Énergie bornée après boost initial | $\Delta E / E_0 < 5\%$ |
+| `test_nbody_paused_no_change` | Sim en pause parfaitement gelée | Identique bit à bit |
+| `test_nbody_survives_dt_spikes` | Les pics de frame ne déstabilisent pas | Tous les corps $< 50$ unités |
+| `test_nbody_long_run_stability` | Invariants sur 1 200 s | Voir ci-dessous |
+
+### Résultats de Stabilité Long Terme (1 200 s à 120 Hz = 144 000 pas)
+
+| Métrique | Mesuré | Seuil |
+|----------|--------|-------|
+| Dérive d'énergie $\|\Delta E / E_0\|$ | 0.0017 % | < 5 % |
+| Dérive du centre de masse | 0.001 | < 0.5 |
+| Distance maximale d'un corps | 19.6 | < 50 |
+| Nombre de corps | 7 / 7 | inchangé |
+
+---
+
+## Référence des Constantes
+
+Toutes les constantes sont définies dans `include/nbody.h` :
+
+| Constante | Valeur | Description |
+|-----------|--------|-------------|
+| `NBODY_MAX_BODIES` | 16 | Nombre maximum de corps |
+| `NBODY_DEFAULT_G` | 1.0 | Constante gravitationnelle |
+| `NBODY_SOFTENING_SQ` | 0.25 | $\varepsilon^2$ minimum |
+| `NBODY_SOFTENING_FACTOR` | 2.0 | Multiplicateur d'adoucissement par paire |
+| `NBODY_FIXED_DT` | 1/120 s | Pas de temps fixe d'intégration |
+| `NBODY_MAX_ACCUMULATOR` | 1/30 s | Temps physique accumulé maximum |
+
+---
+
+## Carte du Code
+
+| Fichier | Rôle |
+|---------|------|
+| `include/nbody.h` | API publique, constantes, structures de données |
+| `src/nbody.c` | Implémentation physique (Verlet, adoucissement, preset) |
+| `tests/test_nbody_stability.c` | Suite de tests de stabilité (5 tests) |
+| `include/trail_renderer.h` | Rendu des traînées (rubans visuels derrière les corps) |
+| `src/trail_renderer.c` | Implémentation des traînées en rubans billboard |
+| `shaders/trail.vert` | Vertex shader des traînées |
+| `shaders/trail.frag` | Fragment shader des traînées |

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -395,7 +395,7 @@ The N-body pipeline is instrumented with fine-grained CPU profiling zones
 | `NBody VBO Upload` | `scene.c` | `instanced_group_update()` → `glBufferSubData` |
 | `Trail Ribbon Build` | `trail_renderer.c` | `build_ribbon()` × N bodies — CPU geometry staging |
 | `Trail VBO Upload` | `trail_renderer.c` | `glBufferSubData` — GPU buffer upload |
-| `Trail Draw Calls` | `trail_renderer.c` | `glDrawArrays` × N bodies |
+| `Trail Draw Calls` | `trail_renderer.c` | `glMultiDrawArrays` — batched N strips in 1 call |
 
 ### GPU Zones (`GPU_STAGE_PROFILER` — OpenGL Context)
 

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -1,0 +1,276 @@
+# N-Body Gravity Simulation — Physics Reference
+
+## Overview
+
+The N-body module (`nbody.h` / `nbody.c`) implements a real-time gravitational
+simulation of up to 16 bodies orbiting a central star.  The physics engine
+prioritises **long-term stability** (energy conservation over thousands of
+simulated seconds) using well-established techniques from computational
+astrophysics:
+
+| Component | Technique |
+|-----------|-----------|
+| Integrator | **Velocity Verlet** (symplectic, 2nd-order) |
+| Regularisation | **Plummer softening** (per-pair, adaptive) |
+| Initial conditions | **Softened orbital velocity** formula |
+| Timestep | Fixed $\frac{1}{120}\text{s}$, accumulator-clamped |
+
+Validated by a 1 200 s automated test with **0.002 %** energy drift.
+
+---
+
+## Velocity Verlet Integrator
+
+[Velocity Verlet](https://en.wikipedia.org/wiki/Verlet_integration#Velocity_Verlet)
+(also called *Leapfrog kick-drift-kick*) is a **symplectic** integrator: it
+preserves the geometric structure of Hamiltonian systems, which guarantees that
+total energy oscillates around the true value instead of drifting monotonically.
+
+### Algorithm (per fixed step $\Delta t$)
+
+1. Compute accelerations from current positions: $\mathbf{a}_\text{old}$
+2. Update positions:
+$$\mathbf{x} \leftarrow \mathbf{x} + \mathbf{v}\,\Delta t + \tfrac{1}{2}\,\mathbf{a}_\text{old}\,\Delta t^2$$
+3. Compute accelerations from new positions: $\mathbf{a}_\text{new}$
+4. Update velocities:
+$$\mathbf{v} \leftarrow \mathbf{v} + \tfrac{1}{2}(\mathbf{a}_\text{old} + \mathbf{a}_\text{new})\,\Delta t$$
+
+This is implemented in `integrate_step()` in `src/nbody.c`.
+
+### Why Symplectic Matters
+
+Non-symplectic methods (Euler, RK4) accumulate a secular energy drift
+proportional to the number of steps.  Over 1 200 s at 120 Hz that is 144 000
+steps — enough for even small per-step errors to blow the system apart or
+collapse it.  A symplectic integrator's bounded energy error keeps the orbits
+qualitatively correct indefinitely.
+
+**References:**
+
+- [Symplectic integrator — Wikipedia](https://en.wikipedia.org/wiki/Symplectic_integrator)
+- [Leapfrog integration — Wikipedia](https://en.wikipedia.org/wiki/Leapfrog_integration)
+- Hairer, Lubich & Wanner, *Geometric Numerical Integration* (Springer, 2006)
+
+---
+
+## Plummer Softening
+
+In a pure $1/r^2$ gravitational field, two point masses passing very close
+experience arbitrarily large forces, leading to numerical slingshot effects and
+chaotic energy exchange.  The standard astrophysical cure is
+[Plummer softening](https://en.wikipedia.org/wiki/Plummer_model):
+
+$$F = \frac{G\,m_i\,m_j}{(r^2 + \varepsilon^2)^{3/2}}\,\hat{\mathbf{r}}$$
+
+The softening length $\varepsilon$ regularises the singularity at $r = 0$,
+turning the Newtonian $1/r$ potential into the finite
+[Plummer potential](https://en.wikipedia.org/wiki/Plummer_model)
+$\Phi = -G\,M / \sqrt{r^2 + \varepsilon^2}$.
+
+### Per-Pair Adaptive Softening
+
+Rather than a single global $\varepsilon$, we scale the softening to each
+body pair's physical radii:
+
+$$\varepsilon^2 = \max\!\bigl(\texttt{NBODY\_SOFTENING\_SQ},\;
+      (\texttt{NBODY\_SOFTENING\_FACTOR} \cdot (r_i + r_j))^2\bigr)$$
+
+With the default constants:
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `NBODY_SOFTENING_SQ` | 0.25 | Absolute floor ($\varepsilon_\min = 0.5$) |
+| `NBODY_SOFTENING_FACTOR` | 2.0 | Per-pair multiplier on combined radii |
+
+This ensures that:
+
+- Large bodies (the star, $r = 1.5$) get strong softening ($\varepsilon \geq 3.6$).
+- Small pairs (two moons) get proportionally less, keeping their dynamics
+  more Keplerian.
+- No pair ever reaches the singular region.
+
+Implemented in `pair_softening_sq()`.
+
+**References:**
+
+- [Gravitational softening — Wikipedia](https://en.wikipedia.org/wiki/Softening)
+- Dehnen & Aly, *Improving convergence of N-body methods* (MNRAS 425, 2012)
+- Aarseth, *Gravitational N-Body Simulations* (Cambridge, 2003)
+
+---
+
+## Softened Orbital Velocity
+
+A common mistake is to initialise circular-orbit speeds using the Kepler
+formula $v = \sqrt{G\,M/r}$.  This is **wrong** when softening is active
+because the effective potential is shallower than $1/r$.
+
+The correct circular-orbit condition for the Plummer potential is:
+
+$$v = r \cdot \sqrt{\frac{G\,M}{(r^2 + \varepsilon^2)^{3/2}}}$$
+
+This comes from balancing the centripetal acceleration $v^2/r$ with the
+softened gravitational acceleration $G\,M\,r / (r^2 + \varepsilon^2)^{3/2}$.
+
+Using the unsoftened formula over-estimates the orbital speed, injecting
+excess kinetic energy and causing bodies to spiral outward.
+
+Implemented in `softened_orbital_vel()`.
+
+---
+
+## Momentum Zeroing
+
+After initialising all bodies, the total momentum $\mathbf{p} = \sum m_i \mathbf{v}_i$
+is set to zero by subtracting the centre-of-mass velocity from every body:
+
+$$\mathbf{v}_i \leftarrow \mathbf{v}_i - \frac{\sum m_j\,\mathbf{v}_j}{\sum m_j}$$
+
+This keeps the centre of mass stationary and prevents the whole system from
+drifting across the scene.  It is done **once** at init, not per step (which
+would break symplecticity).
+
+---
+
+## Fixed Timestep with Accumulator
+
+Variable timesteps destroy the symplectic property.  The simulation uses a
+fixed $\Delta t = 1/120\,\text{s}$ with a standard accumulator pattern:
+
+```text
+accumulator += wall_dt × time_scale
+clamp accumulator to NBODY_MAX_ACCUMULATOR (1/30 s)
+while accumulator >= NBODY_FIXED_DT:
+    integrate_step(NBODY_FIXED_DT)
+    accumulator -= NBODY_FIXED_DT
+```
+
+The max-accumulator clamp prevents a spiral of death after lag spikes or on
+the first frame.
+
+---
+
+## Approaches Tried and Rejected
+
+During development, several alternative techniques were tested and
+**rejected** because they broke the symplectic invariant or introduced
+unacceptable energy dissipation.
+
+### 1. Elastic Collisions
+
+**Idea:** When two bodies overlap ($r < r_i + r_j$), reflect their velocities
+using elastic collision formulae.
+
+**Problem:** Discrete collision detection at fixed timestep introduces
+non-time-reversible impulses.  This breaks symplecticity and causes secular
+energy drift.  In practice, bodies gained energy at every collision,
+leading to exponential blow-up.
+
+**Verdict:** Removed entirely.  Plummer softening prevents overlap without
+the need for collision handling.
+
+### 2. Energy Clamp
+
+**Idea:** After each step, measure total energy; if it exceeds a threshold,
+rescale all velocities to restore the target energy.
+
+**Problem:** This is a projection step that is not derived from a Hamiltonian.
+It destroys the symplectic structure and introduces artificial damping
+or pumping depending on the sign of the correction.
+
+**Verdict:** Removed.
+
+### 3. Escape Brake
+
+**Idea:** If a body moves beyond a radius threshold, apply a drag force to
+bring it back.
+
+**Problem:** Non-conservative force → secular energy loss → orbits decay
+and system collapses.
+
+**Verdict:** Removed.
+
+### 4. Per-Step Momentum Re-Zeroing
+
+**Idea:** Subtract the centre-of-mass velocity from all bodies every step.
+
+**Problem:** This is a non-symplectic projection applied at every step.  It
+interferes with the integrator's phase-space structure and causes energy
+to drift downward.
+
+**Verdict:** Momentum is zeroed **once** at init, never during simulation.
+
+### 5. XPBD (Extended Position-Based Dynamics)
+
+**Idea:** Use XPBD constraint solver (from game physics) to enforce minimum
+distance between bodies, replacing softening with constraint-based repulsion.
+
+**Problem:** XPBD is **fundamentally dissipative by design** — it solves
+constraints by projecting positions, which does not conserve energy.
+In testing, this caused **21 % energy loss** over 300 s, orbits decayed
+rapidly, and all bodies collapsed onto the star.
+
+XPBD is excellent for game-physics scenarios (ragdolls, cloth) where
+dissipation is acceptable and even desirable, but it is **catastrophic**
+for gravity simulations that require energy conservation.
+
+**Verdict:** Rejected after testing.  Pure Verlet + strong Plummer softening
+is the correct approach for N-body gravity.
+
+**References:**
+
+- Müller et al., *Detailed Rigid Body Simulation with Extended Position Based Dynamics* (CGF 2020)
+- [Position Based Dynamics — Wikipedia](https://en.wikipedia.org/wiki/Position-based_dynamics)
+
+---
+
+## Test Validation
+
+The automated test suite (`tests/test_nbody_stability.c`) verifies physics
+invariants over long simulation runs:
+
+| Test | What it checks | Threshold |
+|------|---------------|-----------|
+| `test_nbody_single_step_sanity` | One step does not explode | Positions finite |
+| `test_nbody_energy_conservation` | Energy bounded after init boost | $\Delta E / E_0 < 5\%$ |
+| `test_nbody_paused_no_change` | Paused sim is perfectly frozen | Bit-exact |
+| `test_nbody_survives_dt_spikes` | Spike frames do not destabilise | All bodies $< 50$ units |
+| `test_nbody_long_run_stability` | 1 200 s simulation invariants | See below |
+
+### Long-Run Stability Results (1 200 s at 120 Hz = 144 000 steps)
+
+| Metric | Measured | Threshold |
+|--------|----------|-----------|
+| Energy drift $\|\Delta E / E_0\|$ | 0.0017 % | < 5 % |
+| Centre-of-mass drift | 0.001 | < 0.5 |
+| Maximum body distance | 19.6 | < 50 |
+| Body count | 7 / 7 | unchanged |
+
+---
+
+## Constants Reference
+
+All constants are defined in `include/nbody.h`:
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `NBODY_MAX_BODIES` | 16 | Maximum body count |
+| `NBODY_DEFAULT_G` | 1.0 | Gravitational constant |
+| `NBODY_SOFTENING_SQ` | 0.25 | Minimum $\varepsilon^2$ |
+| `NBODY_SOFTENING_FACTOR` | 2.0 | Per-pair softening multiplier |
+| `NBODY_FIXED_DT` | 1/120 s | Fixed integration timestep |
+| `NBODY_MAX_ACCUMULATOR` | 1/30 s | Max accumulated physics time |
+
+---
+
+## Code Map
+
+| File | Role |
+|------|------|
+| `include/nbody.h` | Public API, constants, data structures |
+| `src/nbody.c` | Physics implementation (Verlet, softening, preset) |
+| `tests/test_nbody_stability.c` | Stability test suite (5 tests) |
+| `include/trail_renderer.h` | Trail rendering (visual ribbons behind bodies) |
+| `src/trail_renderer.c` | Billboard ribbon trail implementation |
+| `shaders/trail.vert` | Trail vertex shader |
+| `shaders/trail.frag` | Trail fragment shader |

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -236,6 +236,9 @@ invariants over long simulation runs:
 | `test_nbody_paused_no_change` | Paused sim is perfectly frozen | Bit-exact |
 | `test_nbody_survives_dt_spikes` | Spike frames do not destabilise | All bodies $< 50$ units |
 | `test_nbody_long_run_stability` | 1 200 s simulation invariants | See below |
+| `test_nbody_kinetic_energy_positive` | $E_k > 0$ after init | Positive |
+| `test_nbody_energy_drift_api` | Drift API: $E_0$ stored, drift $\approx 0$ at $t=0$ | drift $< 5\%$ after 10 s |
+| `test_nbody_zero_gravity` | $G = 0$ means no acceleration | Velocity unchanged after 120 steps |
 
 ### Long-Run Stability Results (1 200 s at 120 Hz = 144 000 steps)
 
@@ -281,6 +284,49 @@ $$\text{time\_scale} \in \{0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; 4.0,\; 8.0,\; 1
 
 An overlay notification displays the current speed on each change.
 
+### Gravity Control (`gravity`)
+
+The gravitational constant $G$ can be adjusted at runtime with Shift modifier:
+
+| Key (US layout) | Key (AZERTY) | Action |
+|-----------------|--------------|--------|
+| `Shift+.` | `Shift+:` | Double G (max 128) |
+| `Shift+,` | `Shift+;` | Halve G (min 0.125, then OFF) |
+
+$G$ follows powers of 2 from the current value:
+
+$$G \in \{0,\; 0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; \ldots,\; 128.0\}$$
+
+- **$G = 0$** disables gravity entirely: bodies follow straight-line ballistic
+  trajectories at their current velocity.
+- When $G$ changes, the reference energy $E_0$ is **recalculated** so the
+  stability indicator reflects only numerical integration error, not the
+  intentional physics parameter change.
+
+### HUD Overlay
+
+When the N-body mode is active and text overlay is enabled (`F1`), two lines
+are displayed:
+
+1. **Energy & Gravity:** `Ek: 77.1 J | G: 2.000` — kinetic energy
+   $E_k = \sum \tfrac{1}{2} m_i |\mathbf{v}_i|^2$ and current $G$ value.
+2. **Stability:** `Stability: Stable (drift: 0.12%)` — shows whether the
+   integrator is conserving energy.
+
+The stability indicator is colour-coded:
+
+| Colour | State | Condition |
+|--------|-------|-----------|
+| Green | Stable | drift $< 5\%$ |
+| Red | Divergent | drift $\geq 5\%$ |
+
+Drift is computed as:
+
+$$\text{drift} = \frac{|E(t) - E_0|}{|E_0|}$$
+
+where $E_0$ is the total energy snapshot taken at initialisation (or after
+a gravity change).
+
 ### Trail Length Stability
 
 The trail sampling accumulator scales by `time_scale`:
@@ -305,10 +351,11 @@ per frame instead of 1, keeping trail length constant in world units.
 |------|------|
 | `include/nbody.h` | Public API, constants, data structures |
 | `src/nbody.c` | Physics implementation (Verlet, softening, preset) |
-| `tests/test_nbody_stability.c` | Stability test suite (5 tests) |
+| `tests/test_nbody_stability.c` | Stability test suite (8 tests) |
 | `include/trail_renderer.h` | Trail rendering (visual ribbons behind bodies) |
 | `src/trail_renderer.c` | Billboard ribbon trail implementation |
-| `src/app_input.c` | Simulation speed keybindings (`,` / `.`) |
+| `src/app_input.c` | Simulation speed (`,` / `.`) and gravity (Shift variants) keybindings |
+| `src/app_ui.c` | N-body HUD overlay (energy, gravity, stability) |
 | `src/app_binding.c` | F2 help overlay registration |
 | `shaders/trail.vert` | Trail vertex shader |
 | `shaders/trail.frag` | Trail fragment shader |

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -263,6 +263,42 @@ All constants are defined in `include/nbody.h`:
 
 ---
 
+## Runtime Controls
+
+### Simulation Speed (`time_scale`)
+
+The simulation speed can be adjusted at runtime via keyboard:
+
+| Key (US layout) | Key (AZERTY) | Action |
+|-----------------|--------------|--------|
+| `.` | `:` | Double speed (max 64×) |
+| `,` | `;` | Halve speed (min 1/8×) |
+
+The `time_scale` multiplier follows powers of 2 to ensure that `1.0×` is
+always reachable:
+
+$$\text{time\_scale} \in \{0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; 4.0,\; 8.0,\; 16.0,\; 32.0,\; 64.0\}$$
+
+An overlay notification displays the current speed on each change.
+
+### Trail Length Stability
+
+The trail sampling accumulator scales by `time_scale`:
+
+```text
+effective_dt = wall_dt × time_scale
+sample_timer += effective_dt
+while sample_timer >= TRAIL_SAMPLE_INTERVAL:
+    record positions
+    sample_timer -= TRAIL_SAMPLE_INTERVAL
+```
+
+This ensures the trail ring buffer fills and evicts points at the same
+*visual* pace regardless of `time_scale`. At 8× speed, 8 samples are emitted
+per frame instead of 1, keeping trail length constant in world units.
+
+---
+
 ## Code Map
 
 | File | Role |
@@ -272,5 +308,7 @@ All constants are defined in `include/nbody.h`:
 | `tests/test_nbody_stability.c` | Stability test suite (5 tests) |
 | `include/trail_renderer.h` | Trail rendering (visual ribbons behind bodies) |
 | `src/trail_renderer.c` | Billboard ribbon trail implementation |
+| `src/app_input.c` | Simulation speed keybindings (`,` / `.`) |
+| `src/app_binding.c` | F2 help overlay registration |
 | `shaders/trail.vert` | Trail vertex shader |
 | `shaders/trail.frag` | Trail fragment shader |

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -284,6 +284,40 @@ $$\text{time\_scale} \in \{0.125,\; 0.25,\; 0.5,\; 1.0,\; 2.0,\; 4.0,\; 8.0,\; 1
 
 An overlay notification displays the current speed on each change.
 
+### Time Reversal
+
+The time direction can be **reversed** at runtime:
+
+| Key (US layout) | Key (AZERTY) | Action |
+|-----------------|--------------|--------|
+| `Ctrl+Shift+G` | `Ctrl+Shift+G` | Toggle time direction (forward/reverse) |
+
+This exploits a fundamental property of Newtonian gravity: the equations of
+motion are **invariant under $t \to -t$**.  Reversing time is equivalent to
+negating all velocities — the system retraces its trajectory backwards.
+
+Because Velocity Verlet is both **symplectic** and **time-reversible**
+($\Phi_h^{-1} = \Phi_{-h}$), the reversed simulation follows the same
+orbit with bounded energy error.  After $N$ forward steps and $N$ backward
+steps, the system returns to the initial state (modulo floating-point
+rounding: $\sim N \cdot \epsilon_{\text{machine}}$ position error).
+
+When reversed, the HUD shows a ⏪ indicator next to the energy readout.
+Speed controls (`,` / `.`) adjust the magnitude without affecting the
+time direction.
+
+#### Progressive Transition
+
+The reversal is not instantaneous: `time_scale` ramps linearly toward
+its target at a rate of **3.0 units/s** (`NBODY_TIME_SCALE_RATE`).  At
+$1\times$ speed the full forward→reverse transition takes ~0.7 s:
+
+$$+1.0 \xrightarrow{\text{decelerate}} 0.0 \xrightarrow{\text{accelerate}} -1.0$$
+
+This produces a natural “VHS rewind” feel where bodies slow down, pause
+briefly, then accelerate in reverse.  Higher speed multipliers take
+proportionally longer to reverse (e.g. $4\times$ → ~2.7 s).
+
 ### Gravity Control (`gravity`)
 
 The gravitational constant $G$ can be adjusted at runtime with Shift modifier:

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -406,6 +406,36 @@ The N-body pipeline is instrumented with fine-grained CPU profiling zones
 
 ---
 
+## Resource Lifecycle
+
+When N-body mode is toggled **OFF**, the engine restores the original material
+grid by calling `scene_init_instancing()` a second time.  This re-init path must
+first release every resource allocated by the previous init call to avoid GPU
+buffer and CPU memory leaks:
+
+```c
+/* Cleanup before re-init (scene.c — N-body OFF branch) */
+trail_renderer_cleanup(&scene->trail_renderer);
+#ifdef USE_TRANSPARENT_BILLBOARDS
+if (scene->sphere_instances) {
+    platform_aligned_free(scene->sphere_instances);
+    scene->sphere_instances = NULL;
+}
+sphere_sorter_cleanup(&scene->sphere_sorter);
+#endif
+instanced_group_cleanup(&scene->instanced_group);
+billboard_group_cleanup(&scene->billboard_group);
+scene_init_instancing(scene);
+```
+
+The cleanup mirrors what `scene_cleanup()` does at application exit.  Without it,
+each ON → OFF toggle leaked ~27 KB (4 blocks: instance VBO, billboard VBO,
+aligned instance array, sphere sorter).
+
+Validated with `just test-integration-valgrind-full` — **0 bytes definitely lost**.
+
+---
+
 ## Code Map
 
 | File | Role |

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -345,6 +345,33 @@ per frame instead of 1, keeping trail length constant in world units.
 
 ---
 
+## Profiling Zones
+
+The N-body pipeline is instrumented with fine-grained CPU profiling zones
+(visible in Tracy or any `PROFILE_ZONE`-compatible profiler).
+
+### CPU Zones (`PROFILE_ZONE` — Main Thread)
+
+| Zone | Location | What it measures |
+|------|----------|------------------|
+| `NBody Physics` | `app.c` | Top-level wrapper (parent of all below) |
+| `NBody Verlet` | `scene.c` | `nbody_step()` — O(N²) gravity + Velocity Verlet |
+| `NBody Trail Sample` | `scene.c` | `trail_renderer_record()` — ring buffer writes |
+| `NBody Instance Build` | `scene.c` | `nbody_write_instances()` — model matrix generation |
+| `NBody VBO Upload` | `scene.c` | `instanced_group_update()` → `glBufferSubData` |
+| `Trail Ribbon Build` | `trail_renderer.c` | `build_ribbon()` × N bodies — CPU geometry staging |
+| `Trail VBO Upload` | `trail_renderer.c` | `glBufferSubData` — GPU buffer upload |
+| `Trail Draw Calls` | `trail_renderer.c` | `glDrawArrays` × N bodies |
+
+### GPU Zones (`GPU_STAGE_PROFILER` — OpenGL Context)
+
+| Zone | Location | What it measures |
+|------|----------|------------------|
+| `Instanced Render` | `scene.c` | Sphere draw call (shared with material grid) |
+| `NBody Trails` | `scene.c` | Full trail rendering pass |
+
+---
+
 ## Code Map
 
 | File | Role |

--- a/docs/profiling_tracy.fr.md
+++ b/docs/profiling_tracy.fr.md
@@ -107,7 +107,7 @@ apparaissent dans Tracy :
 | `NBody VBO Upload` | NBody Physics | Stall `glBufferSubData` |
 | `Trail Ribbon Build` | NBody Trails | Staging géométrie CPU |
 | `Trail VBO Upload` | NBody Trails | Upload buffer |
-| `Trail Draw Calls` | NBody Trails | `glDrawArrays` par corps |
+| `Trail Draw Calls` | NBody Trails | `glMultiDrawArrays` — N strips batchés |
 
 ### Zones GPU (Contexte OpenGL)
 

--- a/docs/profiling_tracy.fr.md
+++ b/docs/profiling_tracy.fr.md
@@ -71,6 +71,51 @@ cmake -B build -DENABLE_TRACY=ON
 cmake -B build -DCMAKE_BUILD_TYPE=Release  # Tracy automatiquement désactivé
 ```
 
+## Configuration du Port
+
+Par défaut, Tracy utilise le port **8086** pour les données et le broadcast.
+Si ce port est déjà utilisé sur votre système, le `Justfile` détecte
+automatiquement un port libre :
+
+```bash
+# Automatique — utilise 8087 si 8086 est occupé
+just tracy-server    # Terminal 1
+just run-tracy       # Terminal 2
+
+# Forçage manuel
+TRACY_PORT=9090 just tracy-server
+TRACY_PORT=9090 just run-tracy
+```
+
+La variable `tracy_port` du Justfile sonde le port 8086 avec `ss` et
+bascule sur 8087 s'il est occupé. Le serveur utilise `-a 127.0.0.1 -p <port>`
+pour une connexion directe (pas de broadcast UDP).
+
+## Zones de Profilage N-Corps
+
+Lorsque la simulation N-corps est active (`Shift+G`), les zones suivantes
+apparaissent dans Tracy :
+
+### Zones CPU (Thread Principal)
+
+| Zone | Parent | Ce qu'elle mesure |
+|------|--------|-------------------|
+| `NBody Physics` | Frame | Wrapper top-level N-corps |
+| `NBody Verlet` | NBody Physics | Gravité O(N²) + intégration Verlet |
+| `NBody Trail Sample` | NBody Physics | Enregistrement ring buffer traînées |
+| `NBody Instance Build` | NBody Physics | Génération matrices modèle |
+| `NBody VBO Upload` | NBody Physics | Stall `glBufferSubData` |
+| `Trail Ribbon Build` | NBody Trails | Staging géométrie CPU |
+| `Trail VBO Upload` | NBody Trails | Upload buffer |
+| `Trail Draw Calls` | NBody Trails | `glDrawArrays` par corps |
+
+### Zones GPU (Contexte OpenGL)
+
+| Zone | Ce qu'elle mesure |
+|------|-------------------|
+| `Instanced Render` | Draw call instancié des sphères |
+| `NBody Trails` | Passe de rendu des traînées |
+
 ## Voir aussi
 
 - [gpu_profiling.md](./gpu_profiling.md) — Système de profilage GPU intégré

--- a/docs/profiling_tracy.md
+++ b/docs/profiling_tracy.md
@@ -117,7 +117,7 @@ appear in Tracy:
 | `NBody VBO Upload` | NBody Physics | `glBufferSubData` stall |
 | `Trail Ribbon Build` | NBody Trails | CPU geometry staging |
 | `Trail VBO Upload` | NBody Trails | Buffer upload |
-| `Trail Draw Calls` | NBody Trails | `glDrawArrays` per body |
+| `Trail Draw Calls` | NBody Trails | `glMultiDrawArrays` — batched N strips |
 
 ### GPU Zones (OpenGL Context)
 

--- a/docs/profiling_tracy.md
+++ b/docs/profiling_tracy.md
@@ -81,7 +81,52 @@ When using the `HYBRID_MEASURE_LOG` macro, you will see specific zones in the ti
 - **Memory Button:** Audit every allocation and find exactly who leaked memory.
 - **Messages:** View your application logs (`LOG_INFO`, etc.) perfectly synced with the timeline.
 
-## 5. Enabling Sampling (Linux)
+## 5. Port Configuration
+
+By default, Tracy uses port **8086** for both data and broadcast.
+If that port is already in use on your system, the `Justfile` auto-detects
+a free port:
+
+```bash
+# Automatic — uses 8087 if 8086 is busy
+just tracy-server    # Terminal 1
+just run-tracy       # Terminal 2
+
+# Manual override
+TRACY_PORT=9090 just tracy-server
+TRACY_PORT=9090 just run-tracy
+```
+
+The `tracy_port` variable in the Justfile probes port 8086 with `ss` and
+falls back to 8087 if occupied. The server uses `-a 127.0.0.1 -p <port>`
+for direct connection (no UDP broadcast).
+
+## 6. N-Body Profiling Zones
+
+When the N-body simulation is active (`Shift+G`), the following zones
+appear in Tracy:
+
+### CPU Zones (Main Thread)
+
+| Zone | Parent | What it measures |
+|------|--------|------------------|
+| `NBody Physics` | Frame | Top-level N-body wrapper |
+| `NBody Verlet` | NBody Physics | O(N²) gravity + Verlet integration |
+| `NBody Trail Sample` | NBody Physics | Ring buffer trail recording |
+| `NBody Instance Build` | NBody Physics | Model matrix generation |
+| `NBody VBO Upload` | NBody Physics | `glBufferSubData` stall |
+| `Trail Ribbon Build` | NBody Trails | CPU geometry staging |
+| `Trail VBO Upload` | NBody Trails | Buffer upload |
+| `Trail Draw Calls` | NBody Trails | `glDrawArrays` per body |
+
+### GPU Zones (OpenGL Context)
+
+| Zone | What it measures |
+|------|------------------|
+| `Instanced Render` | Sphere instanced draw call |
+| `NBody Trails` | Trail rendering pass |
+
+## 7. Enabling Sampling (Linux)
 
 If the **Sampling** tab in Statistics is empty, it means the kernel blocked access to performance counters.
 
@@ -94,7 +139,7 @@ sudo sysctl -w kernel.perf_event_paranoid=-1
 > [!WARNING]
 > This setting allows all users to monitor system performance.
 
-## 6. Analyzing Sampling Data
+## 8. Analyzing Sampling Data
 
 The **Sampling** tab shows where the CPU spends its time based on periodic stack traces (samples), **even for functions that are not manually instrumented**. This is crucial for finding hidden performance bottlenecks.
 

--- a/docs/renderdoc_guide.fr.md
+++ b/docs/renderdoc_guide.fr.md
@@ -209,7 +209,75 @@ Correspondance de référence pour les shaders PBR principaux (billboard et inst
 | 3 | `ProbeBuffer` | SSBO |
 | 8–14 | `u_SHTexture0`–`6` | sampler3D |
 
-## Ressources textures et tampons
+## 9. Pixel History & « Pixel shader debug failed »
+
+### 9.1 Comprendre l'erreur
+
+Quand on fait un clic droit sur un pixel puis **Pixel History**, RenderDoc liste tous les draw calls qui ont touché ce pixel. Chaque ligne montre l'**Event ID (EID)**, un aperçu avant/après, et un bouton **Debug**.
+
+Cliquer sur **Debug** rejoue l'invocation du fragment shader pour ce draw call, permettant de parcourir le code GLSL ligne par ligne. Cependant, RenderDoc affiche parfois :
+
+> **Pixel shader debug failed** — most likely this is caused by no write to the pixel at the current event.
+
+Cela signifie : *« J'ai essayé de rejouer le fragment shader pour ce draw call au pixel sélectionné, mais ce draw call n'a pas produit de fragment visible à ces coordonnées. »*
+
+### 9.2 Causes fréquentes
+
+| Cause | Explication |
+|-------|-------------|
+| **Mauvais EID sélectionné** | Vous avez sélectionné un draw call dans l'Event Browser qui ne touche pas ce pixel. Plusieurs draws ont lieu dans la même passe — seuls certains écrivent sur un pixel donné. |
+| **`discard` dans le fragment shader** | Le shader rejette les fragments en dessous d'un seuil (ex. `if (alpha < 0.005) { discard; }`). Le fragment a été exécuté mais n'a produit aucune sortie. RenderDoc ne peut pas debugger un fragment rejeté. |
+| **Rejet depth/stencil** | Le fragment a été éliminé par le test de profondeur ou de stencil avant l'exécution du fragment shader, ou le résultat a été rejeté par un test de profondeur ultérieur. |
+| **Blending additif avec contribution nulle** | Avec le blending `GL_SRC_ALPHA`, un fragment avec `alpha ≈ 0` ne contribue rien de visible, et RenderDoc peut ne pas l'enregistrer comme une « écriture ». |
+
+### 9.3 La solution : debugger depuis le Pixel History (pas l'Event Browser)
+
+Le point clé : **toujours partir du panneau Pixel History**, pas de l'Event Browser.
+
+**Étape par étape :**
+
+1. **Clic droit** sur le pixel à inspecter dans le Texture Viewer.
+2. Ouvrir l'onglet **Pixel History** (en bas à droite, à côté de « Pixel Context »).
+3. Dans la liste du Pixel History, trouver la ligne où **Tex After** affiche la couleur qui vous intéresse. La ligne montre :
+    - L'EID (ex. `EID 72`)
+    - `1 Fragments touc...` — confirme que le fragment shader a été exécuté et a écrit sur ce pixel
+    - Les valeurs de couleur avant/après
+4. **Déplier** cette ligne (cliquer la flèche `>`) pour voir le fragment individuel.
+5. Cliquer sur le bouton **Debug** sur la **ligne du fragment** (pas la ligne de l'event).
+
+Cela fonctionne parce que RenderDoc sait que *ce fragment spécifique* a passé tous les tests (depth, stencil, discard) et a effectivement écrit dans le framebuffer.
+
+!!! tip "Raccourci double-clic"
+    Vous pouvez **double-cliquer** sur une ligne EID dans le Pixel History pour sauter directement à cet event dans l'Event Browser. C'est utile pour inspecter l'état du pipeline (textures liées, uniforms, mode de blending) du draw call qui a écrit le pixel.
+
+### 9.4 Spécificités du shader de trails
+
+Le fragment shader des trails (`shaders/trail.frag`) utilise un `discard` précoce pour les fragments quasi-transparents :
+
+```glsl
+if (alpha < 0.005) {
+    discard;
+}
+```
+
+Concrètement :
+- **La plupart des fragments aux bords du ruban échoueront au debug** — ils sont rejetés par le seuil d'alpha.
+- **Les fragments au centre du ruban se debuggent normalement** — ils ont un alpha élevé et passent le seuil.
+- Pour debugger un fragment de bord, commenter temporairement le bloc `discard`, recompiler et recapturer. Le remettre ensuite.
+
+### 9.5 Draws batchés (glMultiDrawArrays) dans le Pixel History
+
+Avec `glMultiDrawArrays(GL_TRIANGLE_STRIP, starts, counts, N)`, RenderDoc décompose l'appel unique en N sous-draws dans l'Event Browser :
+
+```text
+67  glMultiDrawArrays(14)       ← event parent
+ 68  glMultiDrawArrays[0](494)  ← sous-draw 0 (corps 0, 494 vertices)
+ 69  glMultiDrawArrays[1](494)  ← sous-draw 1 (corps 1)
+ ...
+ 81  glMultiDrawArrays[13](494) ← sous-draw 13 (corps 13)
+```
+
+Dans le Pixel History, l'EID pointe vers le **sous-draw spécifique** qui a écrit le pixel (ex. `EID 72 — glMultiDrawArrays[5](494)`). On conserve la même granularité par corps qu'avec des appels `glDrawArrays` individuels, mais avec moins de surcharge CPU à l'exécution.
 
 L'inspecteur de ressources permet de visualiser :
 - Les textures à chaque étape (avant/après bloom, avant/après tonemapping)

--- a/docs/renderdoc_guide.md
+++ b/docs/renderdoc_guide.md
@@ -188,3 +188,73 @@ Reference mapping for the main PBR shaders (billboard and instanced share the sa
 | 2 | `brdfLUT` | sampler2D |
 | 3 | `ProbeBuffer` | SSBO |
 | 8–14 | `u_SHTexture0`–`6` | sampler3D |
+
+## 9. Pixel History & "Pixel Shader Debug Failed"
+
+### 9.1 Understanding the Error
+
+When right-clicking a pixel and selecting **Pixel History**, RenderDoc lists every draw call that touched that pixel. Each row shows the **Event ID (EID)**, a before/after preview, and a **Debug** button.
+
+Clicking **Debug** on a row replays that single fragment shader invocation so you can step through its GLSL source line by line. However, RenderDoc sometimes shows:
+
+> **Pixel shader debug failed** — most likely this is caused by no write to the pixel at the current event.
+
+This means: *"I tried to replay the fragment shader for this draw call at the pixel you selected, but that draw call did not actually produce a visible fragment at those coordinates."*
+
+### 9.2 Common Causes
+
+| Cause | Explanation |
+|-------|-------------|
+| **Wrong EID selected** | You selected a draw call in the Event Browser that doesn't touch the pixel. Multiple draws happen in the same pass — only some write to any given pixel. |
+| **`discard` in the fragment shader** | The shader discards fragments below a threshold (e.g., `if (alpha < 0.005) { discard; }`). The fragment was executed but produced no output. RenderDoc cannot debug a discarded fragment. |
+| **Depth/stencil rejection** | The fragment was killed by depth or stencil testing before the fragment shader ran, or the fragment shader ran but the result was discarded by a later depth test. |
+| **Additive blending with zero contribution** | With `GL_SRC_ALPHA` blending, a fragment with `alpha ≈ 0` contributes nothing visible, and RenderDoc may not record it as a "write". |
+
+### 9.3 The Fix: Debug from Pixel History (Not Event Browser)
+
+The key insight: **always start from the Pixel History panel**, not the Event Browser.
+
+**Step-by-step:**
+
+1. **Right-click** the pixel you want to inspect in the Texture Viewer.
+2. Open the **Pixel History** tab (bottom-right, next to "Pixel Context").
+3. In the Pixel History list, find the row where **Tex After** shows the color you're interested in. The row will show:
+    - The EID (e.g., `EID 72`)
+    - `1 Fragments touc...` — confirms the fragment shader executed and wrote to this pixel
+    - Before/after color values
+4. **Expand** that row (click the `>` arrow) to see the individual fragment.
+5. Click the **Debug** button on the **fragment row** (not the event row).
+
+This works because RenderDoc knows that *this specific fragment* passed all tests (depth, stencil, discard) and actually wrote to the framebuffer.
+
+!!! tip "Double-click shortcut"
+    You can **double-click** an EID row in Pixel History to jump directly to that event in the Event Browser. This is useful to inspect the pipeline state (bound textures, uniforms, blend mode) of the draw call that wrote the pixel.
+
+### 9.4 Trail Shader Specifics
+
+The trail fragment shader (`shaders/trail.frag`) uses an early `discard` for near-transparent fragments:
+
+```glsl
+if (alpha < 0.005) {
+    discard;
+}
+```
+
+This means:
+- **Most trail fragments at the ribbon edges will fail debug** — they are discarded by the alpha threshold.
+- **Center-of-ribbon fragments will debug fine** — they have high alpha and pass the threshold.
+- If you want to debug an edge fragment, temporarily comment out the `discard` block, rebuild, and recapture. Restore it afterward.
+
+### 9.5 Batched Draws (glMultiDrawArrays) in Pixel History
+
+When using `glMultiDrawArrays(GL_TRIANGLE_STRIP, starts, counts, N)`, RenderDoc expands the single API call into N sub-draws in the Event Browser:
+
+```text
+67  glMultiDrawArrays(14)       ← parent event
+ 68  glMultiDrawArrays[0](494)  ← sub-draw 0 (body 0, 494 vertices)
+ 69  glMultiDrawArrays[1](494)  ← sub-draw 1 (body 1)
+ ...
+ 81  glMultiDrawArrays[13](494) ← sub-draw 13 (body 13)
+```
+
+In Pixel History, the EID points to the **specific sub-draw** that wrote the pixel (e.g., `EID 72 — glMultiDrawArrays[5](494)`). This gives the same per-body granularity as individual `glDrawArrays` calls, but with lower CPU overhead at runtime.

--- a/include/app_ui.h
+++ b/include/app_ui.h
@@ -69,6 +69,10 @@ static const vec3 CYBER_TITLE_COLOR = {0.0F, 0.90F, 0.95F};
 static const vec3 ENV_TEXT_COLOR = {0.7F, 0.7F, 0.7F};
 static const vec3 GRAPH_TEXT_COLOR = {0.8F, 0.8F, 0.8F};
 static const vec3 DEBUG_ORANGE_COLOR = {1.0F, 0.5F, 0.0F};
+static const vec3 NBODY_INFO_COLOR = {0.4F, 0.8F, 1.0F};
+static const vec3 NBODY_STABLE_COLOR = {0.2F, 1.0F, 0.4F};
+static const vec3 NBODY_DIVERGE_COLOR = {1.0F, 0.3F, 0.2F};
+static const float NBODY_STABILITY_THRESHOLD = 0.05F;
 static const vec3 HISTO_BAR_COLOR_GREEN = {0.0F, 0.7F, 0.0F};
 static const vec3 HISTO_BAR_COLOR_BLUE = {0.0F, 0.5F, 0.8F};
 static const vec3 HISTO_BAR_COLOR_RED = {0.8F, 0.5F, 0.0F};
@@ -94,6 +98,7 @@ enum {
 	RANGE_TEXT_BUFFER_SIZE = 64,
 	ENV_TEXT_BUFFER_SIZE = 256,
 	EXPOSURE_TEXT_BUFFER_SIZE = 64,
+	NBODY_TEXT_BUFFER_SIZE = 128,
 	MODIFIER_BUFFER_SIZE = 16,
 	KEYBOARD_BUFFER_SIZE = 256
 };

--- a/include/app_ui.h
+++ b/include/app_ui.h
@@ -203,6 +203,8 @@ static const KeyPos KEY_LAYOUT_QWERTY[] = {
     {GLFW_KEY_B, ROW_ZXCV, 6.3F, 1.0F, "B"},
     {GLFW_KEY_N, ROW_ZXCV, 7.3F, 1.0F, "N"},
     {GLFW_KEY_M, ROW_ZXCV, 8.3F, 1.0F, "M"},
+    {GLFW_KEY_COMMA, ROW_ZXCV, 9.3F, 1.0F, ","},
+    {GLFW_KEY_PERIOD, ROW_ZXCV, 10.3F, 1.0F, "."},
 
     /* Row 5: Space/System */
     {GLFW_KEY_LEFT_CONTROL, ROW_BOTTOM, 0.0F, 1.5F, "Ctrl"},

--- a/include/gl_common.h
+++ b/include/gl_common.h
@@ -116,9 +116,10 @@ enum { MAX_VERTEX_ATTRIBS_BASELINE = 16 };
 /** @brief Starting index for instanced vertex attributes. */
 enum { INSTANCE_ATTR_START = 2 };
 
-/** @brief Starting index for synchronization vertex attributes (motion blur).
- */
-enum { SYNC_ATTR_START = 8 };
+/** @brief Starting index for synchronization vertex attributes.
+ *  Attributes 0-8 are used: 0=pos, 1=norm, 2-5=model, 6=albedo,
+ *  7=pbr, 8=prev_center (motion blur). Cleanup starts at 9. */
+enum { SYNC_ATTR_START = 9 };
 
 /** @brief Number of vertices in a standard screen-filling quad (2 triangles).
  */

--- a/include/gpu_profiler.h
+++ b/include/gpu_profiler.h
@@ -30,6 +30,7 @@ static const int GPU_PROFILER_POSTPROCESS_COLOR = 0xB48EAD;
 static const int GPU_PROFILER_UI_COLOR = 0x4C566A;
 static const int GPU_PROFILER_GI_SYNC_COLOR = 0x8FBCBB;
 static const int GPU_PROFILER_GI_DEBUG_COLOR = 0xB48EAD;
+static const int GPU_PROFILER_NBODY_COLOR = 0xD8DEE9;
 
 /* --- Capture Settings --- */
 static const float GPU_PROFILER_WINDOW_DURATION_S = 0.5F;

--- a/include/instanced_rendering.h
+++ b/include/instanced_rendering.h
@@ -21,12 +21,14 @@
  * and compatibility with SIMD-based sorting or physics.
  */
 typedef struct {
-	mat4 model;      /**< 4x4 Transformation matrix. */
-	vec3 albedo;     /**< Base color (linear RGB). */
-	float metallic;  /**< PBR metallic factor (0.0 - 1.0). */
-	float roughness; /**< PBR roughness factor (0.0 - 1.0). */
-	float ao;        /**< Ambient occlusion factor. */
-	float padding;   /**< Alignment padding. */
+	mat4 model;       /**< 4x4 Transformation matrix. */
+	vec3 albedo;      /**< Base color (linear RGB). */
+	float metallic;   /**< PBR metallic factor (0.0 - 1.0). */
+	float roughness;  /**< PBR roughness factor (0.0 - 1.0). */
+	float ao;         /**< Ambient occlusion factor. */
+	float padding;    /**< Alignment padding. */
+	vec3 prev_center; /**< Previous frame center (for per-object motion
+	                     blur). */
 } __attribute__((aligned(SIMD_ALIGNMENT))) SphereInstance;
 
 /**

--- a/include/instanced_rendering.h
+++ b/include/instanced_rendering.h
@@ -60,6 +60,15 @@ void instanced_group_bind_mesh(InstancedGroup* group, GLuint vbo, GLuint nbo,
                                GLuint ebo);
 
 /**
+ * @brief Updates the instance VBO with new data (e.g., N-body positions).
+ * @param group Pointer to the group.
+ * @param data New instance data array.
+ * @param count Number of instances (must not exceed original allocation).
+ */
+void instanced_group_update(InstancedGroup* group, const SphereInstance* data,
+                            int count);
+
+/**
  * @brief Executes an indexed instanced draw call.
  * @param group Pointer to the group.
  * @param index_count Number of indices in the base mesh.

--- a/include/nbody.h
+++ b/include/nbody.h
@@ -18,7 +18,7 @@
 #include <stdbool.h>
 
 /** Maximum number of bodies in the simulation. */
-enum { NBODY_MAX_BODIES = 16 };
+enum { NBODY_MAX_BODIES = 32 };
 
 /** Default gravitational constant (tuned for visual scale ~20 units). */
 static const float NBODY_DEFAULT_G = 1.0F;

--- a/include/nbody.h
+++ b/include/nbody.h
@@ -60,14 +60,18 @@ typedef struct {
  * @struct NBodySim
  * @brief State container for the N-body simulation.
  */
+/** Rate at which time_scale transitions toward its target (units/s). */
+static const float NBODY_TIME_SCALE_RATE = 3.0F;
+
 typedef struct {
 	NBodyParticle bodies[NBODY_MAX_BODIES]; /**< Array of bodies. */
 	int body_count;                         /**< Number of active bodies. */
-	float gravity;        /**< Gravitational constant G. */
-	float accumulator;    /**< Physics timestep accumulator. */
-	float time_scale;     /**< Speed multiplier (1.0 = real-time). */
-	float initial_energy; /**< Total energy at init (E₀ reference). */
-	bool paused;          /**< If true, simulation does not advance. */
+	float gravity;           /**< Gravitational constant G. */
+	float accumulator;       /**< Physics timestep accumulator. */
+	float time_scale;        /**< Speed multiplier (1.0 = real-time). */
+	float target_time_scale; /**< Smooth-transition target. */
+	float initial_energy;    /**< Total energy at init (E₀ reference). */
+	bool paused;             /**< If true, simulation does not advance. */
 } NBodySim;
 
 /**
@@ -117,5 +121,15 @@ float nbody_kinetic_energy(const NBodySim* sim);
  * Returns 0 when initial_energy is zero (no reference).
  */
 float nbody_energy_drift(const NBodySim* sim);
+
+/**
+ * @brief Smoothly transitions time_scale toward target_time_scale.
+ *
+ * Called once per frame.  Ramps at NBODY_TIME_SCALE_RATE units/s,
+ * producing a decelerate → pause → accelerate-in-reverse effect.
+ * @param sim Pointer to the simulation state.
+ * @param delta_time Wall-clock frame delta (seconds).
+ */
+void nbody_update_time_scale(NBodySim* sim, float delta_time);
 
 #endif /* NBODY_H */

--- a/include/nbody.h
+++ b/include/nbody.h
@@ -1,0 +1,108 @@
+/**
+ * @file nbody.h
+ * @brief N-body gravitational simulation (Velocity Verlet + Plummer softening).
+ *
+ * Manages a set of gravitational bodies with position, velocity, and mass.
+ * Uses a symplectic Velocity Verlet integrator with per-pair Plummer
+ * softening to guarantee long-term energy conservation without ad-hoc
+ * damping.  Produces SphereInstance data for the instanced renderer.
+ *
+ * @see docs/nbody_physics.md for the full physics reference.
+ */
+
+#ifndef NBODY_H
+#define NBODY_H
+
+#include "instanced_rendering.h"
+#include <cglm/types.h>
+#include <stdbool.h>
+
+/** Maximum number of bodies in the simulation. */
+enum { NBODY_MAX_BODIES = 16 };
+
+/** Default gravitational constant (tuned for visual scale ~20 units). */
+static const float NBODY_DEFAULT_G = 1.0F;
+
+/** Minimum softening factor squared — prevents singularity at r→0.
+ *  Actual softening per pair is max(this, (F*(r_i + r_j))²) so that bodies
+ *  repel naturally before visually overlapping (Plummer softening). */
+static const float NBODY_SOFTENING_SQ = 0.25F;
+
+/** Per-pair softening multiplier.
+ *  eps = F * (r_i + r_j).  Higher values weaken close encounters
+ *  and reduce chaotic 3-body slingshot effects at the cost of
+ *  making gravity less Keplerian at short range. */
+static const float NBODY_SOFTENING_FACTOR = 2.0F;
+
+/** Fixed physics timestep for stable integration (seconds). */
+static const float NBODY_FIXED_DT = 1.0F / 120.0F;
+
+/** Maximum accumulated physics time per call to nbody_step.
+ *  Prevents runaway integration after lag spikes or first frame. */
+static const float NBODY_MAX_ACCUMULATOR = 1.0F / 30.0F;
+
+/**
+ * @struct NBodyParticle
+ * @brief A single gravitational body.
+ */
+typedef struct {
+	vec3 position;   /**< World position. */
+	float mass;      /**< Gravitational mass. */
+	vec3 velocity;   /**< Current velocity. */
+	float radius;    /**< Visual sphere radius (for rendering scale). */
+	vec3 albedo;     /**< PBR base color for this body. */
+	float metallic;  /**< PBR metallic factor. */
+	float roughness; /**< PBR roughness factor. */
+	float _pad[3];   /**< Alignment padding. */
+} NBodyParticle;
+
+/**
+ * @struct NBodySim
+ * @brief State container for the N-body simulation.
+ */
+typedef struct {
+	NBodyParticle bodies[NBODY_MAX_BODIES]; /**< Array of bodies. */
+	int body_count;                         /**< Number of active bodies. */
+	float gravity;     /**< Gravitational constant G. */
+	float accumulator; /**< Physics timestep accumulator. */
+	float time_scale;  /**< Speed multiplier (1.0 = real-time). */
+	bool paused;       /**< If true, simulation does not advance. */
+} NBodySim;
+
+/**
+ * @brief Initializes the simulation with a preset solar system configuration.
+ * @param sim Pointer to the simulation state.
+ */
+void nbody_init_preset(NBodySim* sim);
+
+/**
+ * @brief Advances the simulation by the given wall-clock delta time.
+ *
+ * Uses a fixed-timestep accumulator with Velocity Verlet integration.
+ * @param sim Pointer to the simulation state.
+ * @param delta_time Wall-clock time elapsed since last call (seconds).
+ */
+void nbody_step(NBodySim* sim, float delta_time);
+
+/**
+ * @brief Writes current body positions and materials into a SphereInstance
+ *        array suitable for the instanced rendering pipeline.
+ * @param sim Pointer to the simulation state.
+ * @param out Output array (must have capacity >= sim->body_count).
+ */
+void nbody_write_instances(const NBodySim* sim, SphereInstance* out);
+
+/**
+ * @brief Returns the number of active bodies.
+ */
+int nbody_get_count(const NBodySim* sim);
+
+/**
+ * @brief Computes the total energy (kinetic + gravitational potential).
+ *
+ * Useful for stability diagnostics.  With a symplectic integrator,
+ * this quantity oscillates with bounded amplitude around E₀.
+ */
+float nbody_total_energy(const NBodySim* sim);
+
+#endif /* NBODY_H */

--- a/include/nbody.h
+++ b/include/nbody.h
@@ -46,14 +46,14 @@ static const float NBODY_MAX_ACCUMULATOR = 1.0F / 30.0F;
  * @brief A single gravitational body.
  */
 typedef struct {
-	vec3 position;   /**< World position. */
-	float mass;      /**< Gravitational mass. */
-	vec3 velocity;   /**< Current velocity. */
-	float radius;    /**< Visual sphere radius (for rendering scale). */
-	vec3 albedo;     /**< PBR base color for this body. */
-	float metallic;  /**< PBR metallic factor. */
-	float roughness; /**< PBR roughness factor. */
-	float _pad[3];   /**< Alignment padding. */
+	vec3 position;      /**< World position. */
+	float mass;         /**< Gravitational mass. */
+	vec3 velocity;      /**< Current velocity. */
+	float radius;       /**< Visual sphere radius (for rendering scale). */
+	vec3 albedo;        /**< PBR base color for this body. */
+	float metallic;     /**< PBR metallic factor. */
+	float roughness;    /**< PBR roughness factor. */
+	vec3 prev_position; /**< Position from previous frame (motion blur). */
 } NBodyParticle;
 
 /**

--- a/include/nbody.h
+++ b/include/nbody.h
@@ -63,10 +63,11 @@ typedef struct {
 typedef struct {
 	NBodyParticle bodies[NBODY_MAX_BODIES]; /**< Array of bodies. */
 	int body_count;                         /**< Number of active bodies. */
-	float gravity;     /**< Gravitational constant G. */
-	float accumulator; /**< Physics timestep accumulator. */
-	float time_scale;  /**< Speed multiplier (1.0 = real-time). */
-	bool paused;       /**< If true, simulation does not advance. */
+	float gravity;        /**< Gravitational constant G. */
+	float accumulator;    /**< Physics timestep accumulator. */
+	float time_scale;     /**< Speed multiplier (1.0 = real-time). */
+	float initial_energy; /**< Total energy at init (E₀ reference). */
+	bool paused;          /**< If true, simulation does not advance. */
 } NBodySim;
 
 /**
@@ -104,5 +105,17 @@ int nbody_get_count(const NBodySim* sim);
  * this quantity oscillates with bounded amplitude around E₀.
  */
 float nbody_total_energy(const NBodySim* sim);
+
+/**
+ * @brief Computes kinetic energy only: Σ ½ m v².
+ */
+float nbody_kinetic_energy(const NBodySim* sim);
+
+/**
+ * @brief Returns the relative energy drift |E(t) - E₀| / |E₀|.
+ *
+ * Returns 0 when initial_energy is zero (no reference).
+ */
+float nbody_energy_drift(const NBodySim* sim);
 
 #endif /* NBODY_H */

--- a/include/render_utils.h
+++ b/include/render_utils.h
@@ -220,10 +220,13 @@ GLuint render_utils_create_texture_2d(int width, int height,
  * @param offset_albedo Byte offset of the albedo field.
  * @param offset_metallic Byte offset of the metallic field (start of PBR
  * block).
+ * @param offset_prev_center Byte offset of the prev_center field (motion
+ * blur).
  */
 void render_utils_setup_sphere_instance_attributes(GLsizei stride,
                                                    size_t offset_albedo,
-                                                   size_t offset_metallic);
+                                                   size_t offset_metallic,
+                                                   size_t offset_prev_center);
 
 // -----------------------------------------------------------------------------
 // State Management

--- a/include/scene.h
+++ b/include/scene.h
@@ -10,9 +10,11 @@
 #include "instanced_rendering.h"
 #include "light_probes.h"
 #include "material.h"
+#include "nbody.h"
 #include "shader.h"
 #include "skybox.h"
 #include "sphere_sorting.h"
+#include "trail_renderer.h"
 #include <cglm/cglm.h>
 
 #ifdef USE_SSBO_RENDERING
@@ -216,6 +218,11 @@ typedef struct Scene {
 	int specular_aa_enabled;  /**< Screen-Space Specular Anti-Aliasing. */
 	AAMode aa_mode;           /**< AA Mode: Screen-space or Curvature. */
 
+	/* --- N-Body Simulation --- */
+	NBodySim nbody_sim;           /**< N-body gravitational simulation. */
+	TrailRenderer trail_renderer; /**< Orbital trail renderer. */
+	int nbody_mode;               /**< Toggle: 0=grid, 1=N-body. */
+
 	/* --- Uniform Caches --- */
 	BillboardUniforms billboard_uniforms; /**< Cached locations. */
 	InstancedUniforms instanced_uniforms; /**< Cached locations. */
@@ -262,5 +269,19 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
  * @param scene Pointer to the scene.
  */
 void scene_update_gpu_buffers(Scene* scene);
+
+/**
+ * @brief Toggles N-body simulation mode on/off.
+ * @param scene Pointer to the scene.
+ */
+void scene_toggle_nbody(Scene* scene);
+
+/**
+ * @brief Advances the N-body simulation by one frame.
+ * @param scene Pointer to the scene.
+ * @param delta_time Wall-clock time elapsed.
+ * @param cam_pos Camera world position (for trail billboard).
+ */
+void scene_nbody_update(Scene* scene, float delta_time);
 
 #endif /* SCENE_H */

--- a/include/trail_renderer.h
+++ b/include/trail_renderer.h
@@ -1,0 +1,128 @@
+/**
+ * @file trail_renderer.h
+ * @brief GPU-accelerated ribbon trail renderer for N-body simulation.
+ *
+ * Records positions over time for each body and renders camera-facing
+ * ribbon geometry with:
+ * - Width tapering (thick at head, zero at tail)
+ * - Soft anti-aliased edges via fragment shader smoothstep
+ * - HDR emissive colors for bloom integration
+ * - Additive blending for glow accumulation
+ */
+
+#ifndef TRAIL_RENDERER_H
+#define TRAIL_RENDERER_H
+
+#include "gl_common.h"
+#include "nbody.h"
+#include "shader.h"
+#include <cglm/types.h>
+#include <stdbool.h>
+
+/** Maximum trail sample points per body. At 60 samples/sec ≈ 4.3 seconds. */
+enum { TRAIL_MAX_POINTS = 256 };
+
+/** HDR intensity multiplier — ensures bloom threshold is exceeded. */
+static const float TRAIL_HDR_INTENSITY = 3.0F;
+
+/** Maximum ribbon half-width in world units. */
+static const float TRAIL_MAX_WIDTH = 0.18F;
+
+/** Minimum time between trail samples (seconds). */
+static const float TRAIL_SAMPLE_INTERVAL = 1.0F / 60.0F;
+
+/**
+ * @struct TrailVertex
+ * @brief Per-vertex data for the ribbon triangle strip.
+ *
+ * 32 bytes per vertex, cache-line friendly.
+ */
+typedef struct {
+	float position[3]; /**< World position. */
+	float u;           /**< Along trail: 0=head, 1=tail. */
+	float color[3];    /**< HDR emissive color (pre-multiplied). */
+	float v;           /**< Across ribbon: 0=left edge, 1=right edge. */
+} TrailVertex;
+
+/**
+ * @struct TrailRing
+ * @brief Ring buffer of recorded positions for one body.
+ */
+typedef struct {
+	vec3 points[TRAIL_MAX_POINTS]; /**< Circular buffer of positions. */
+	int head;                      /**< Write index (newest). */
+	int count;                     /**< Number of valid samples. */
+} TrailRing;
+
+/**
+ * @struct TrailRenderer
+ * @brief Manages trail state and GPU resources for all bodies.
+ */
+typedef struct {
+	TrailRing rings[NBODY_MAX_BODIES]; /**< Per-body position history. */
+	int body_count;                    /**< Number of tracked bodies. */
+	float sample_timer;                /**< Accumulator for sample rate. */
+
+	/* GPU Resources */
+	GLuint vao;       /**< VAO for ribbon geometry. */
+	GLuint vbo;       /**< Dynamic VBO for ribbon vertices. */
+	Shader* shader;   /**< Trail rendering shader program. */
+	int vertex_count; /**< Vertices written this frame. */
+
+	/* Per-body trail colors (HDR emissive). */
+	vec3 colors[NBODY_MAX_BODIES];
+} TrailRenderer;
+
+/**
+ * @brief Initializes trail renderer resources.
+ * @param tr Pointer to the trail renderer.
+ * @param body_count Number of bodies to track.
+ * @return true on success, false on failure.
+ */
+bool trail_renderer_init(TrailRenderer* tr, int body_count);
+
+/**
+ * @brief Sets the trail color for a specific body.
+ * @param tr Pointer to the trail renderer.
+ * @param body_index Body index.
+ * @param color HDR emissive color (values > 1.0 are valid for bloom).
+ */
+void trail_renderer_set_color(TrailRenderer* tr, int body_index,
+                              const vec3 color);
+
+/**
+ * @brief Records current positions from the simulation.
+ *
+ * Should be called every frame. Internally rate-limits sampling.
+ * @param tr Pointer to the trail renderer.
+ * @param sim Pointer to the N-body simulation.
+ * @param delta_time Frame delta time.
+ */
+void trail_renderer_record(TrailRenderer* tr, const NBodySim* sim,
+                           float delta_time);
+
+/**
+ * @brief Builds ribbon geometry and renders all trails.
+ *
+ * Must be called while the HDR framebuffer is active (before post-process).
+ * Sets up additive blending and depth-read-no-write internally.
+ * @param tr Pointer to the trail renderer.
+ * @param view View matrix.
+ * @param proj Projection matrix.
+ * @param cam_pos Camera world position.
+ */
+void trail_renderer_draw(TrailRenderer* tr, mat4 view, mat4 proj, vec3 cam_pos);
+
+/**
+ * @brief Clears all recorded trail data (e.g., on simulation reset).
+ * @param tr Pointer to the trail renderer.
+ */
+void trail_renderer_clear(TrailRenderer* tr);
+
+/**
+ * @brief Releases all GPU resources.
+ * @param tr Pointer to the trail renderer.
+ */
+void trail_renderer_cleanup(TrailRenderer* tr);
+
+#endif /* TRAIL_RENDERER_H */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
   - Platform Abstraction (PAL): portability_pal.md
 - Rendering:
   - Global Illumination: global_illumination.md
+  - N-Body Physics: nbody_physics.md
   - PBR Sphere Rendering: sphere_rendering.md
   - Skybox: skybox_rendering.md
   - Progressive IBL: progressive_ibl.md

--- a/scripts/check_nolint.sh
+++ b/scripts/check_nolint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# check_nolint.sh — Detect new NOLINT suppressions introduced vs a base ref.
+#
+# Usage: scripts/check_nolint.sh [BASE_REF]
+#   BASE_REF defaults to origin/master.
+#
+# Exits 0 if no new NOLINT found, 1 otherwise.
+# Designed for CI (lint-and-format job) and local pre-push validation.
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/master}"
+
+# On CI (pull_request), GitHub Actions merges the PR branch into the target.
+# The merge base is available via `git merge-base`.
+# For local use, origin/master works directly.
+if ! git rev-parse --verify "${BASE_REF}" >/dev/null 2>&1; then
+    echo "⚠️  Base ref '${BASE_REF}' not available (shallow clone?). Skipping NOLINT check."
+    exit 0
+fi
+
+# Extract only added lines (+) from the diff of C/H files.
+# Write diff to temp file first to avoid pipefail issues with multi-grep pipes.
+DIFF_TMP=$(mktemp)
+NOLINT_TMP=$(mktemp)
+trap 'rm -f "${DIFF_TMP}" "${NOLINT_TMP}"' EXIT
+
+git -c color.diff=false diff "${BASE_REF}"...HEAD -- '*.c' '*.h' > "${DIFF_TMP}"
+
+# Match added lines containing NOLINT (exclude diff header "+++" lines).
+grep -E '^\+[^+].*NOLINT' "${DIFF_TMP}" > "${NOLINT_TMP}" || true
+
+if [ ! -s "${NOLINT_TMP}" ]; then
+    echo "✓ No new NOLINT suppressions introduced."
+    exit 0
+fi
+
+COUNT=$(wc -l < "${NOLINT_TMP}")
+
+echo "❌ Found ${COUNT} new NOLINT suppression(s) vs ${BASE_REF}:"
+echo ""
+cat "${NOLINT_TMP}"
+echo ""
+echo "Policy: fix the root cause instead of suppressing warnings."
+echo "See .github/instructions/testing-quality.instructions.md"
+exit 1

--- a/scripts/integration_scenarios.sh
+++ b/scripts/integration_scenarios.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
 
+# Detect keyboard layout for xdotool keysym mapping.
+# GLFW maps keys by physical position (US QWERTY), not by keysym.
+# xdotool resolves keysym names to keycodes, so on non-US layouts
+# we must use the layout-specific keysym for the correct physical key.
+_layout=$(setxkbmap -query 2>/dev/null | awk '/layout/{print $2}')
+case "$_layout" in
+    fr)
+        # AZERTY: physical key positions differ from US QWERTY.
+        # Variable names = GLFW_KEY constant the app expects.
+        # Values = xdotool keysym that hits the correct physical key.
+        KEY_A="q"              # AC01 (phys A) has keysym 'q'
+        KEY_Q="a"              # AD01 (phys Q) has keysym 'a'
+        KEY_W="z"              # AD02 (phys W) has keysym 'z'
+        KEY_M="comma"          # AB07 (phys M) has keysym 'comma'
+        KEY_COMMA="semicolon"  # AB08 (phys ,) has keysym 'semicolon'
+        KEY_PERIOD="colon"     # AB09 (phys .) has keysym 'colon'
+        ;;
+    *)
+        KEY_A="a"
+        KEY_Q="q"
+        KEY_W="w"
+        KEY_M="m"
+        KEY_COMMA="comma"
+        KEY_PERIOD="period"
+        ;;
+esac
+
 run_scenario_full() {
     echo "Starting Integration Test Scenario (FULL)..."
 
@@ -49,7 +76,7 @@ run_scenario_full() {
 
     # 2. Styles
     echo "=> Testing Styles (1-6)"
-    for i in {1..6}; do xdotool key --delay 500 $i; done
+    for i in {1..6}; do xdotool key --delay 500 "$i"; done
     xdotool key --delay 500 2 # Style: Subtle
 
     # 8.b GI Diffuse 1-Bounce
@@ -70,19 +97,19 @@ run_scenario_full() {
     xdotool key --delay 500 b # Bloom
     xdotool key --delay 500 h # DoF
     xdotool key --delay 500 j # Auto Exposure
-    xdotool key --delay 500 m # Motion Blur
+    xdotool key --delay 500 "$KEY_M" # Motion Blur
     xdotool key --delay 500 x # FXAA
 
-    xdotool key --delay 500 w # Wireframe ON
-    xdotool key --delay 500 w # Wireframe OFF
+    xdotool key --delay 500 "$KEY_W" # Wireframe ON
+    xdotool key --delay 500 "$KEY_W" # Wireframe OFF
 
     echo "=> Toggling Sphere Sorting (O)"
     for i in {1..6}; do xdotool key --delay 500 o; done
 
     # 4. Camera Movement
     echo "=> Moving Camera"
-    for key in z d s a q e; do
-        xdotool keydown $key; sleep 0.5; xdotool keyup $key
+    for key in "$KEY_W" d s "$KEY_A" "$KEY_Q" e; do
+        xdotool keydown "$key"; sleep 0.5; xdotool keyup "$key"
     done
 
     # 5. PBR Debug Modes
@@ -133,17 +160,17 @@ run_scenario_full() {
     sleep 1
 
     echo "=> Sim Speed Up (period) / Down (comma)"
-    xdotool key --delay 300 period
-    xdotool key --delay 300 period
+    xdotool key --delay 300 "$KEY_PERIOD"
+    xdotool key --delay 300 "$KEY_PERIOD"
     sleep 0.5
-    xdotool key --delay 300 comma
+    xdotool key --delay 300 "$KEY_COMMA"
     sleep 0.5
 
     echo "=> Gravity Control (Shift+period / Shift+comma)"
-    xdotool key --delay 300 shift+period
-    xdotool key --delay 300 shift+period
+    xdotool key --delay 300 "shift+$KEY_PERIOD"
+    xdotool key --delay 300 "shift+$KEY_PERIOD"
     sleep 0.5
-    xdotool key --delay 300 shift+comma
+    xdotool key --delay 300 "shift+$KEY_COMMA"
     sleep 0.5
 
     echo "=> Time Reversal (Ctrl+Shift+G)"
@@ -176,7 +203,7 @@ run_scenario_minimal() {
 
     # 2. Styles
     echo "=> Testing Styles (1-6)"
-    for i in {1..6}; do xdotool key --delay 500 $i; done
+    for i in {1..6}; do xdotool key --delay 500 "$i"; done
     xdotool key --delay 500 2 # Style: Subtle
 
     # 3. Post-Process Effects
@@ -196,8 +223,8 @@ run_scenario_minimal() {
 
     # 4. Camera Movement
     echo "=> Moving Camera"
-    for key in z d s a; do
-        xdotool keydown $key; sleep 0.5; xdotool keyup $key
+    for key in "$KEY_W" d s "$KEY_A"; do
+        xdotool keydown "$key"; sleep 0.5; xdotool keyup "$key"
     done
 
     # 5. PBR Debug Modes
@@ -235,7 +262,7 @@ run_scenario_minimal() {
     sleep 1
 
     echo "=> Sim Speed Up (period)"
-    xdotool key --delay 300 period
+    xdotool key --delay 300 "$KEY_PERIOD"
     sleep 0.5
 
     echo "=> Time Reversal (Ctrl+Shift+G)"

--- a/scripts/integration_scenarios.sh
+++ b/scripts/integration_scenarios.sh
@@ -127,6 +127,36 @@ run_scenario_full() {
     echo "=> Resetting to Default (0)"
     xdotool key --delay 500 0
 
+    # 10. N-Body Gravity Sandbox (Shift+G)
+    echo "=> Activating N-Body Mode (Shift+G)"
+    xdotool key --delay 500 shift+g
+    sleep 1
+
+    echo "=> Sim Speed Up (period) / Down (comma)"
+    xdotool key --delay 300 period
+    xdotool key --delay 300 period
+    sleep 0.5
+    xdotool key --delay 300 comma
+    sleep 0.5
+
+    echo "=> Gravity Control (Shift+period / Shift+comma)"
+    xdotool key --delay 300 shift+period
+    xdotool key --delay 300 shift+period
+    sleep 0.5
+    xdotool key --delay 300 shift+comma
+    sleep 0.5
+
+    echo "=> Time Reversal (Ctrl+Shift+G)"
+    xdotool key --delay 300 ctrl+shift+g
+    sleep 1.5
+    echo "=> Time Forward (Ctrl+Shift+G)"
+    xdotool key --delay 300 ctrl+shift+g
+    sleep 1.5
+
+    echo "=> Deactivating N-Body Mode (Shift+G)"
+    xdotool key --delay 500 shift+g
+    sleep 0.5
+
     echo "=> Test Complete."
     xdotool key Escape
 }
@@ -198,6 +228,23 @@ run_scenario_minimal() {
     echo "=> Resetting to Default (0)"
     xdotool key --delay 500 0
     sleep 1
+
+    # 8. N-Body Gravity Sandbox (Shift+G)
+    echo "=> Activating N-Body Mode (Shift+G)"
+    xdotool key --delay 500 shift+g
+    sleep 1
+
+    echo "=> Sim Speed Up (period)"
+    xdotool key --delay 300 period
+    sleep 0.5
+
+    echo "=> Time Reversal (Ctrl+Shift+G)"
+    xdotool key --delay 300 ctrl+shift+g
+    sleep 1.5
+
+    echo "=> Deactivating N-Body Mode (Shift+G)"
+    xdotool key --delay 500 shift+g
+    sleep 0.5
 
     echo "=> Test Complete."
     xdotool key Escape

--- a/shaders/billboard_instance_ssbo.glsl
+++ b/shaders/billboard_instance_ssbo.glsl
@@ -10,7 +10,10 @@ struct SphereInstance {
 	float roughness;
 	float ao;
 	float padding;
-	float _pad[9];
+	float prev_center_x;
+	float prev_center_y;
+	float prev_center_z;
+	float _pad[6];
 };
 
 layout(std430, binding = 2) readonly buffer BillboardInstanceSSBO

--- a/shaders/pbr_ibl_billboard.frag
+++ b/shaders/pbr_ibl_billboard.frag
@@ -14,6 +14,8 @@ flat layout(location = 7) in float AO;
 
 layout(location = 8) in vec4
     CurrentClipPos;  // Interpolated clip pos of the quad (juste pour l'AA)
+flat layout(location = 9) in vec3
+    PrevSphereCenter;  // Previous frame center (per-object motion blur)
 
 @header "billboard_ubo.glsl"
 
@@ -132,19 +134,19 @@ void main()
 #endif
 
 	// ------------------------------------------------------------------------
-	// VELOCITY CALCULATION (OPTIMIZATION "HACK")
+	// VELOCITY CALCULATION (Per-Object + Camera Motion)
 	// ------------------------------------------------------------------------
-	// Ici, on imite le comportement du vertex shader mesh, mais pixel par
-	// pixel.
+	// Combines camera movement (previousViewProj) AND object movement
+	// (PrevSphereCenter) for accurate per-pixel motion vectors.
 
 	// A. Position NDC Actuelle (Basée sur le point raytracé exact)
 	vec2 currentPosNDC = clipPosActual.xy / clipPosActual.w;
 
 	// B. Position NDC Précédente
-	// HACK : On suppose que la sphère est statique dans le monde (WorldPos
-	// frame N == WorldPos frame N-1). On projette sphereHitPos avec la
-	// matrice caméra précédente.
-	vec4 previousClip = previousViewProj * vec4(sphereHitPos, 1.0);
+	// Reconstruct previous hit position: offset the hit relative to the
+	// sphere center, then apply the same offset to the previous center.
+	vec3 prevHitPos = PrevSphereCenter + (sphereHitPos - SphereCenter);
+	vec4 previousClip = previousViewProj * vec4(prevHitPos, 1.0);
 	vec2 previousPosNDC = previousClip.xy / previousClip.w;
 
 	// C. Calcul du Delta

--- a/shaders/pbr_ibl_billboard.vert
+++ b/shaders/pbr_ibl_billboard.vert
@@ -19,8 +19,8 @@ flat layout(location = 7) out float AO;
 
 layout(location = 8) out vec4
     CurrentClipPos;  // Used for AA size calculation in Frag
-// out vec4 PreviousClipPos;  <-- SUPPRIMÉ : Le calcul vertex est faux pour un
-// billboard
+flat layout(location = 9) out vec3
+    PrevSphereCenter;  // Previous frame center (per-object motion blur)
 
 /* clang-format off */
 @header "billboard_instance_ssbo.glsl"
@@ -58,6 +58,10 @@ layout(location = 8) out vec4
 	// Normale "face caméra" pour le quad (la vraie normale sera calculée
 	// par raytracing)
 	Normal = -vec3(view[0][2], view[1][2], view[2][2]);
+
+	// Previous frame center for per-object motion blur velocity
+	PrevSphereCenter =
+	    vec3(inst.prev_center_x, inst.prev_center_y, inst.prev_center_z);
 
 	CurrentClipPos = clipPos;
 	gl_Position = CurrentClipPos;

--- a/shaders/pbr_ibl_instanced.vert
+++ b/shaders/pbr_ibl_instanced.vert
@@ -8,6 +8,8 @@ layout(location = 2) in mat4 i_model;   // Emplacement 2, 3, 4, 5
 layout(location = 6) in vec3 i_albedo;  // Emplacement 6
 layout(location = 7)
     in vec3 i_pbr;  // Emplacement 7 (x: metallic, y: roughness, z: ao)
+layout(location = 8) in vec3
+    i_prev_center;  // Previous frame center (motion blur)
 
 layout(location = 0) out vec3 WorldPos;
 layout(location = 1) out vec3 Normal;
@@ -39,7 +41,12 @@ void main()
 	AO = i_pbr.z;
 
 	CurrentClipPos = projection * view * vec4(WorldPos, 1.0);
-	PreviousClipPos = previousViewProj * vec4(WorldPos, 1.0);
+
+	/* Per-object motion blur: reconstruct previous world position by
+	 * applying the same local vertex offset to the previous center.
+	 * For static objects, i_prev_center == current center → camera-only. */
+	vec3 prevWorldPos = i_prev_center + (WorldPos - vec3(i_model[3]));
+	PreviousClipPos = previousViewProj * vec4(prevWorldPos, 1.0);
 
 	gl_Position = CurrentClipPos;
 }

--- a/shaders/trail.frag
+++ b/shaders/trail.frag
@@ -1,0 +1,50 @@
+#version 430 core
+
+/*
+ * trail.frag — HDR ribbon trail fragment shader.
+ *
+ * Visual quality features:
+ * 1. Soft anti-aliased edges via smoothstep across ribbon width (vV).
+ * 2. Smooth age-based opacity fade along the trail (vU).
+ * 3. HDR emissive output — bloom post-process picks up values > threshold.
+ * 4. Core glow: brighter center, dimmer edges for a natural light-trail look.
+ */
+
+in float vU;    /* Along trail: 0=head, 1=tail */
+in float vV;    /* Across ribbon: 0=left edge, 1=right edge */
+in vec3 vColor; /* HDR emissive color (pre-attenuated by age on CPU) */
+
+layout(location = 0) out vec4 FragColor;
+
+void main()
+{
+	/* --- Soft edge anti-aliasing ---
+	 * Map vV from [0,1] to a centered coordinate [-1,1],
+	 * then apply a smooth falloff at the edges.
+	 * This creates a soft, rounded ribbon profile. */
+	float center = abs(vV * 2.0 - 1.0); /* 0 at center, 1 at edges */
+	float edge_softness = 1.0 - smoothstep(0.6, 1.0, center);
+
+	/* --- Core glow ---
+	 * Brighter at the center of the ribbon, dimmer at edges.
+	 * Creates a natural volumetric light appearance. */
+	float core = exp(-center * center * 2.0);
+	float glow = mix(0.4, 1.0, core);
+
+	/* --- Age-based fade ---
+	 * Quadratic fade: newer parts fully opaque, tail fades smoothly.
+	 * The CPU already attenuates color intensity; this adds alpha. */
+	float age_alpha = (1.0 - vU) * (1.0 - vU);
+
+	/* --- Final composite ---
+	 * Color is HDR (already > 1.0 from CPU), bloom catches the excess.
+	 * Alpha controls additive blend contribution. */
+	float alpha = edge_softness * glow * age_alpha;
+
+	/* Discard near-invisible fragments to avoid depth/blend artifacts */
+	if (alpha < 0.005) {
+		discard;
+	}
+
+	FragColor = vec4(vColor * glow, alpha);
+}

--- a/shaders/trail.vert
+++ b/shaders/trail.vert
@@ -1,0 +1,31 @@
+#version 430 core
+
+/*
+ * trail.vert — Camera-facing ribbon trail vertex shader.
+ *
+ * Input: CPU-generated triangle strip with position, UV, and HDR color.
+ * The geometry is already camera-billboarded on the CPU side.
+ */
+
+/* Attribute 0: position.xyz + u (along trail, 0=head 1=tail) */
+layout(location = 0) in vec4 a_position_u;
+
+/* Attribute 1: color.rgb + v (across ribbon, 0=left 1=right) */
+layout(location = 1) in vec4 a_color_v;
+
+uniform mat4 u_view;
+uniform mat4 u_proj;
+
+out float vU;    /* Along trail: 0=head, 1=tail */
+out float vV;    /* Across ribbon: 0.0 or 1.0 */
+out vec3 vColor; /* HDR emissive color */
+
+void main()
+{
+	vec3 worldPos = a_position_u.xyz;
+	vU = a_position_u.w;
+	vColor = a_color_v.rgb;
+	vV = a_color_v.w;
+
+	gl_Position = u_proj * u_view * vec4(worldPos, 1.0);
+}

--- a/src/app.c
+++ b/src/app.c
@@ -312,7 +312,7 @@ void app_run(App* app)
 		}
 
 		{
-			PROFILE_ZONE(nbody_ctx, "NBody Update");
+			PROFILE_ZONE(nbody_ctx, "NBody Physics");
 			scene_nbody_update(&app->scene, (float)app->delta_time);
 			PROFILE_ZONE_END(nbody_ctx);
 		}

--- a/src/app.c
+++ b/src/app.c
@@ -312,6 +312,12 @@ void app_run(App* app)
 		}
 
 		{
+			PROFILE_ZONE(nbody_ctx, "NBody Update");
+			scene_nbody_update(&app->scene, (float)app->delta_time);
+			PROFILE_ZONE_END(nbody_ctx);
+		}
+
+		{
 			PROFILE_ZONE(update_ctx, "App Update");
 			app_update(app);
 			PROFILE_ZONE_END(update_ctx);

--- a/src/app_binding.c
+++ b/src/app_binding.c
@@ -122,6 +122,12 @@ void app_binding_registry_init(AppBindingRegistry* registry)
 	add_binding(GLFW_KEY_G, GLFW_MOD_SHIFT, "N-Body Gravity",
 	            "Toggles N-body gravitational sandbox mode.",
 	            BINDING_CAT_VISUALS, BINDING_TYPE_TOGGLE);
+	add_binding(GLFW_KEY_PERIOD, 0, "Sim Speed Up",
+	            "Doubles the N-body simulation speed (max 64x).",
+	            BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);
+	add_binding(GLFW_KEY_COMMA, 0, "Sim Speed Down",
+	            "Halves the N-body simulation speed (min 1/8x).",
+	            BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);
 	add_binding(GLFW_KEY_H, 0, "Toggle DOF", "Toggles Depth of Field blur.",
 	            BINDING_CAT_POSTFX, BINDING_TYPE_TOGGLE);
 	add_binding(GLFW_KEY_H, GLFW_MOD_SHIFT, "Toggle DOF Debug",

--- a/src/app_binding.c
+++ b/src/app_binding.c
@@ -119,6 +119,9 @@ void app_binding_registry_init(AppBindingRegistry* registry)
 	add_binding(GLFW_KEY_G, 0, "Toggle Grain",
 	            "Toggles film grain noise effect.", BINDING_CAT_POSTFX,
 	            BINDING_TYPE_TOGGLE);
+	add_binding(GLFW_KEY_G, GLFW_MOD_SHIFT, "N-Body Gravity",
+	            "Toggles N-body gravitational sandbox mode.",
+	            BINDING_CAT_VISUALS, BINDING_TYPE_TOGGLE);
 	add_binding(GLFW_KEY_H, 0, "Toggle DOF", "Toggles Depth of Field blur.",
 	            BINDING_CAT_POSTFX, BINDING_TYPE_TOGGLE);
 	add_binding(GLFW_KEY_H, GLFW_MOD_SHIFT, "Toggle DOF Debug",

--- a/src/app_binding.c
+++ b/src/app_binding.c
@@ -128,6 +128,12 @@ void app_binding_registry_init(AppBindingRegistry* registry)
 	add_binding(GLFW_KEY_COMMA, 0, "Sim Speed Down",
 	            "Halves the N-body simulation speed (min 1/8x).",
 	            BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);
+	add_binding(GLFW_KEY_PERIOD, GLFW_MOD_SHIFT, "Gravity Up",
+	            "Doubles the gravitational constant G (max 128).",
+	            BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);
+	add_binding(GLFW_KEY_COMMA, GLFW_MOD_SHIFT, "Gravity Down",
+	            "Halves G (min 0.125, then OFF).", BINDING_CAT_VISUALS,
+	            BINDING_TYPE_CYCLE);
 	add_binding(GLFW_KEY_H, 0, "Toggle DOF", "Toggles Depth of Field blur.",
 	            BINDING_CAT_POSTFX, BINDING_TYPE_TOGGLE);
 	add_binding(GLFW_KEY_H, GLFW_MOD_SHIFT, "Toggle DOF Debug",

--- a/src/app_binding.c
+++ b/src/app_binding.c
@@ -122,6 +122,11 @@ void app_binding_registry_init(AppBindingRegistry* registry)
 	add_binding(GLFW_KEY_G, GLFW_MOD_SHIFT, "N-Body Gravity",
 	            "Toggles N-body gravitational sandbox mode.",
 	            BINDING_CAT_VISUALS, BINDING_TYPE_TOGGLE);
+	add_binding(
+	    GLFW_KEY_G,
+	    (int)((unsigned)GLFW_MOD_SHIFT | (unsigned)GLFW_MOD_CONTROL),
+	    "Time Reversal", "Reverses time direction in N-body simulation.",
+	    BINDING_CAT_VISUALS, BINDING_TYPE_TOGGLE);
 	add_binding(GLFW_KEY_PERIOD, 0, "Sim Speed Up",
 	            "Doubles the N-body simulation speed (max 64x).",
 	            BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -32,6 +32,12 @@ static const float SIM_SPEED_MAX = 64.0F;
 static const float SIM_SPEED_MIN = 0.125F;
 static const float SIM_SPEED_INV_FACTOR = 0.5F;
 
+/* N-Body gravity constants (power-of-2 steps, with G=0 special case). */
+static const float GRAVITY_FACTOR = 2.0F;
+static const float GRAVITY_MAX = 128.0F;
+static const float GRAVITY_MIN_POSITIVE = 0.125F;
+static const float GRAVITY_INV_FACTOR = 0.5F;
+
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
 	App* app = (App*)glfwGetWindowUserPointer(window);
@@ -471,6 +477,43 @@ static void handle_sim_speed_input(App* app, bool speed_up)
 	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
 }
 
+static void handle_gravity_input(App* app, bool increase)
+{
+	NBodySim* sim = &app->scene.nbody_sim;
+	if (increase) {
+		if (sim->gravity == 0.0F) {
+			sim->gravity = GRAVITY_MIN_POSITIVE;
+		} else {
+			sim->gravity *= GRAVITY_FACTOR;
+			if (sim->gravity > GRAVITY_MAX) {
+				sim->gravity = GRAVITY_MAX;
+			}
+		}
+	} else {
+		sim->gravity *= GRAVITY_INV_FACTOR;
+		if (sim->gravity < GRAVITY_MIN_POSITIVE) {
+			sim->gravity = 0.0F;
+		}
+	}
+	char buf[NOTIF_BUF_SIZE];
+	if (sim->gravity == 0.0F) {
+		(void)safe_snprintf(buf, sizeof(buf), "Gravity: OFF");
+	} else {
+		(void)safe_snprintf(buf, sizeof(buf), "Gravity: G=%.3f",
+		                    (double)sim->gravity);
+	}
+	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+}
+
+static void handle_sim_or_gravity_input(App* app, int mods, bool increase)
+{
+	if (check_flag(mods, GLFW_MOD_SHIFT)) {
+		handle_gravity_input(app, increase);
+	} else {
+		handle_sim_speed_input(app, increase);
+	}
+}
+
 static void handle_o_key_input(App* app)
 {
 	app->scene.sorting_mode =
@@ -587,10 +630,10 @@ void handle_app_input(App* app, int key, int mods)
 			}
 			break;
 		case GLFW_KEY_PERIOD:
-			handle_sim_speed_input(app, true);
+			handle_sim_or_gravity_input(app, mods, true);
 			break;
 		case GLFW_KEY_COMMA:
-			handle_sim_speed_input(app, false);
+			handle_sim_or_gravity_input(app, mods, false);
 			break;
 		default:
 			break;

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -26,6 +26,12 @@ enum { PBR_DEBUG_MODE_COUNT = 10 };
 /* Notification constants */
 enum { NOTIF_BUF_SIZE = 128 };
 
+/* N-Body simulation speed constants (powers of 2 for exact round-trip). */
+static const float SIM_SPEED_FACTOR = 2.0F;
+static const float SIM_SPEED_MAX = 64.0F;
+static const float SIM_SPEED_MIN = 0.125F;
+static const float SIM_SPEED_INV_FACTOR = 0.5F;
+
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
 	App* app = (App*)glfwGetWindowUserPointer(window);
@@ -445,6 +451,26 @@ static bool handle_g_key_input(App* app, int mods)
 	return true;
 }
 
+static void handle_sim_speed_input(App* app, bool speed_up)
+{
+	NBodySim* sim = &app->scene.nbody_sim;
+	if (speed_up) {
+		sim->time_scale *= SIM_SPEED_FACTOR;
+		if (sim->time_scale > SIM_SPEED_MAX) {
+			sim->time_scale = SIM_SPEED_MAX;
+		}
+	} else {
+		sim->time_scale *= SIM_SPEED_INV_FACTOR;
+		if (sim->time_scale < SIM_SPEED_MIN) {
+			sim->time_scale = SIM_SPEED_MIN;
+		}
+	}
+	char buf[NOTIF_BUF_SIZE];
+	(void)safe_snprintf(buf, sizeof(buf), "Sim Speed: %.1fx",
+	                    (double)sim->time_scale);
+	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+}
+
 static void handle_o_key_input(App* app)
 {
 	app->scene.sorting_mode =
@@ -559,6 +585,12 @@ void handle_app_input(App* app, int key, int mods)
 			if (handle_g_key_input(app, mods)) {
 				return;
 			}
+			break;
+		case GLFW_KEY_PERIOD:
+			handle_sim_speed_input(app, true);
+			break;
+		case GLFW_KEY_COMMA:
+			handle_sim_speed_input(app, false);
 			break;
 		default:
 			break;

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -17,6 +17,7 @@
 #include "utils.h"
 #include "window.h"
 #include <GLFW/glfw3.h>
+#include <math.h>
 #include <stb_image_write.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -445,6 +446,22 @@ static void handle_system_key_input(App* app, int key, int mods)
 
 static bool handle_g_key_input(App* app, int mods)
 {
+	/* Ctrl+Shift+G: toggle time reversal */
+	const int ctrl_shift =
+	    (int)((unsigned)GLFW_MOD_SHIFT | (unsigned)GLFW_MOD_CONTROL);
+	if (((unsigned)mods & (unsigned)ctrl_shift) == (unsigned)ctrl_shift) {
+		NBodySim* sim = &app->scene.nbody_sim;
+		sim->target_time_scale = -sim->target_time_scale;
+		const char* dir =
+		    (sim->target_time_scale < 0.0F) ? "REVERSE" : "FORWARD";
+		LOG_INFO("suckless-ogl.app", "Time direction: %s (%.1fx)", dir,
+		         (double)sim->target_time_scale);
+		char buf[NOTIF_BUF_SIZE];
+		(void)safe_snprintf(buf, sizeof(buf), "Time: %s (%.1fx)", dir,
+		                    (double)fabsf(sim->target_time_scale));
+		action_notifier_push(&app->notifier, buf, NOTIF_DUR_LONG);
+		return true;
+	}
 	if (!check_flag(mods, GLFW_MOD_SHIFT)) {
 		return false;
 	}
@@ -461,20 +478,23 @@ static bool handle_g_key_input(App* app, int mods)
 static void handle_sim_speed_input(App* app, bool speed_up)
 {
 	NBodySim* sim = &app->scene.nbody_sim;
+	float mag = fabsf(sim->target_time_scale);
+	float sign = (sim->target_time_scale < 0.0F) ? -1.0F : 1.0F;
 	if (speed_up) {
-		sim->time_scale *= SIM_SPEED_FACTOR;
-		if (sim->time_scale > SIM_SPEED_MAX) {
-			sim->time_scale = SIM_SPEED_MAX;
+		mag *= SIM_SPEED_FACTOR;
+		if (mag > SIM_SPEED_MAX) {
+			mag = SIM_SPEED_MAX;
 		}
 	} else {
-		sim->time_scale *= SIM_SPEED_INV_FACTOR;
-		if (sim->time_scale < SIM_SPEED_MIN) {
-			sim->time_scale = SIM_SPEED_MIN;
+		mag *= SIM_SPEED_INV_FACTOR;
+		if (mag < SIM_SPEED_MIN) {
+			mag = SIM_SPEED_MIN;
 		}
 	}
+	sim->target_time_scale = sign * mag;
+	sim->time_scale = sim->target_time_scale;
 	char buf[NOTIF_BUF_SIZE];
-	(void)safe_snprintf(buf, sizeof(buf), "Sim Speed: %.1fx",
-	                    (double)sim->time_scale);
+	(void)safe_snprintf(buf, sizeof(buf), "Sim Speed: %.1fx", (double)mag);
 	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
 }
 

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -9,6 +9,7 @@
 #include "env_manager.h"
 #include "glad/glad.h"
 #include "log.h"
+#include "nbody.h"
 #include "perf_mode.h"
 #include "postprocess_input.h"
 #include "profiler.h"
@@ -495,6 +496,10 @@ static void handle_gravity_input(App* app, bool increase)
 			sim->gravity = 0.0F;
 		}
 	}
+	/* Recalculate reference energy so drift only measures numerical error,
+	 * not the intentional physics parameter change. */
+	sim->initial_energy = nbody_total_energy(sim);
+
 	char buf[NOTIF_BUF_SIZE];
 	if (sim->gravity == 0.0F) {
 		(void)safe_snprintf(buf, sizeof(buf), "Gravity: OFF");

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -430,6 +430,49 @@ static void handle_system_key_input(App* app, int key, int mods)
 	}
 }
 
+static bool handle_g_key_input(App* app, int mods)
+{
+	if (!check_flag(mods, GLFW_MOD_SHIFT)) {
+		return false;
+	}
+	scene_toggle_nbody(&app->scene);
+	LOG_INFO("suckless-ogl.app", "N-Body mode: %s",
+	         app->scene.nbody_mode ? "ON" : "OFF");
+	action_notifier_push(&app->notifier,
+	                     app->scene.nbody_mode ? "N-Body Gravity: ON"
+	                                           : "N-Body Gravity: OFF",
+	                     NOTIF_DUR_LONG);
+	return true;
+}
+
+static void handle_o_key_input(App* app)
+{
+	app->scene.sorting_mode =
+	    (app->scene.sorting_mode + 1) % SORTING_MODE_COUNT;
+	const char* mode_name = "Unknown";
+	const char* notif_name = "Sort: Unknown";
+
+	switch (app->scene.sorting_mode) {
+		case SORTING_MODE_CPU_QSORT:
+			mode_name = "CPU (qsort)";
+			notif_name = "Sort: CPU (qsort)";
+			break;
+		case SORTING_MODE_CPU_RADIX:
+			mode_name = "CPU (Radix)";
+			notif_name = "Sort: CPU (Radix)";
+			break;
+		case SORTING_MODE_GPU_BITONIC:
+			mode_name = "GPU (Bitonic)";
+			notif_name = "Sort: GPU (Bitonic)";
+			break;
+		default:
+			break;
+	}
+
+	LOG_INFO("suckless-ogl.app", "Sphere Sorting: %s", mode_name);
+	action_notifier_push(&app->notifier, notif_name, NOTIF_DUR_NORMAL);
+}
+
 void handle_app_input(App* app, int key, int mods)
 {
 	if (key >= GLFW_KEY_F1 && key <= GLFW_KEY_F12) {
@@ -466,32 +509,7 @@ void handle_app_input(App* app, int key, int mods)
 			                     NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_O:
-			app->scene.sorting_mode =
-			    (app->scene.sorting_mode + 1) % SORTING_MODE_COUNT;
-			const char* mode_name = "Unknown";
-			const char* notif_name = "Sort: Unknown";
-
-			switch (app->scene.sorting_mode) {
-				case SORTING_MODE_CPU_QSORT:
-					mode_name = "CPU (qsort)";
-					notif_name = "Sort: CPU (qsort)";
-					break;
-				case SORTING_MODE_CPU_RADIX:
-					mode_name = "CPU (Radix)";
-					notif_name = "Sort: CPU (Radix)";
-					break;
-				case SORTING_MODE_GPU_BITONIC:
-					mode_name = "GPU (Bitonic)";
-					notif_name = "Sort: GPU (Bitonic)";
-					break;
-				default:
-					break;
-			}
-
-			LOG_INFO("suckless-ogl.app", "Sphere Sorting: %s",
-			         mode_name);
-			action_notifier_push(&app->notifier, notif_name,
-			                     NOTIF_DUR_NORMAL);
+			handle_o_key_input(app);
 			break;
 		case GLFW_KEY_T:
 			app->env_mgr.env_transition_mode =
@@ -536,6 +554,11 @@ void handle_app_input(App* app, int key, int mods)
 			                         ? "Skybox: ON"
 			                         : "Skybox: OFF",
 			                     NOTIF_DUR_NORMAL);
+			break;
+		case GLFW_KEY_G:
+			if (handle_g_key_input(app, mods)) {
+				return;
+			}
 			break;
 		default:
 			break;

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -1174,10 +1174,12 @@ static void draw_nbody_overlay(const App* app, UILayout* layout)
 	const NBodySim* sim = &app->scene.nbody_sim;
 	char text[NBODY_TEXT_BUFFER_SIZE];
 
-	/* Kinetic energy */
+	/* Kinetic energy + time direction */
 	float kinetic = nbody_kinetic_energy(sim);
-	(void)safe_snprintf(text, sizeof(text), "Ek: %.1f J | G: %.3f",
-	                    (double)kinetic, (double)sim->gravity);
+	const char* time_dir =
+	    (sim->target_time_scale < 0.0F) ? " \xe2\x8f\xaa" : "";
+	(void)safe_snprintf(text, sizeof(text), "Ek: %.1f J | G: %.3f%s",
+	                    (double)kinetic, (double)sim->gravity, time_dir);
 	ui_layout_text(layout, text, (float*)NBODY_INFO_COLOR);
 
 	/* Stability indicator */

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -6,6 +6,7 @@
 #include "app_binding.h"
 #include "app_settings.h"
 #include "glad/glad.h"
+#include "nbody.h"
 #include "postprocess.h"
 #include "texture.h"
 #include "ui.h"
@@ -20,6 +21,7 @@
 
 /* --- Forward Declarations (Internal) --- */
 static void draw_exposure_overlay(const App* app, UILayout* layout);
+static void draw_nbody_overlay(const App* app, UILayout* layout);
 static void draw_loading_indicator(const App* app);
 static void draw_help_overlay_keys(const App* app, float start_x, float start_y,
                                    float total_h,
@@ -1163,6 +1165,33 @@ static void draw_exposure_overlay(const App* app, UILayout* layout)
 	ui_layout_text(layout, exposure_text, ENV_TEXT_COLOR);
 }
 
+static void draw_nbody_overlay(const App* app, UILayout* layout)
+{
+	if (app->overlay.text_overlay_mode < 1 || !app->scene.nbody_mode) {
+		return;
+	}
+
+	const NBodySim* sim = &app->scene.nbody_sim;
+	char text[NBODY_TEXT_BUFFER_SIZE];
+
+	/* Kinetic energy */
+	float kinetic = nbody_kinetic_energy(sim);
+	(void)safe_snprintf(text, sizeof(text), "Ek: %.1f J | G: %.3f",
+	                    (double)kinetic, (double)sim->gravity);
+	ui_layout_text(layout, text, (float*)NBODY_INFO_COLOR);
+
+	/* Stability indicator */
+	float drift = nbody_energy_drift(sim);
+	const char* status =
+	    (drift < NBODY_STABILITY_THRESHOLD) ? "Stable" : "Divergent";
+	const float* color = (drift < NBODY_STABILITY_THRESHOLD)
+	                         ? (const float*)NBODY_STABLE_COLOR
+	                         : (const float*)NBODY_DIVERGE_COLOR;
+	(void)safe_snprintf(text, sizeof(text), "Stability: %s (drift: %.2f%%)",
+	                    status, (double)(drift * 100.0F));
+	ui_layout_text(layout, text, (float*)color);
+}
+
 static void draw_loading_indicator(const App* app)
 {
 	if (app->scene.ibl_coord.state == IBL_STATE_IDLE &&
@@ -1212,6 +1241,7 @@ void app_render_ui(const App* app)
 	draw_main_info_overlay(app, &layout);
 	draw_cinematic_overlay(app, &layout);
 	draw_exposure_overlay(app, &layout);
+	draw_nbody_overlay(app, &layout);
 	draw_bloom_debug_status(app, &layout);
 	draw_loading_indicator(app);
 

--- a/src/billboard_rendering.c
+++ b/src/billboard_rendering.c
@@ -93,7 +93,8 @@ static void setup_billboard_instance_attributes(void)
 {
 	render_utils_setup_sphere_instance_attributes(
 	    (GLsizei)sizeof(SphereInstance), offsetof(SphereInstance, albedo),
-	    offsetof(SphereInstance, metallic));
+	    offsetof(SphereInstance, metallic),
+	    offsetof(SphereInstance, prev_center));
 }
 
 static void create_billboard_vao(GLuint* vao, GLuint geometry_vbo,

--- a/src/gamepad_input.c
+++ b/src/gamepad_input.c
@@ -2,6 +2,9 @@
 
 #include "camera.h"
 #include "log.h"
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
 #include <GLFW/glfw3.h>
 #include <math.h>
 

--- a/src/instanced_rendering.c
+++ b/src/instanced_rendering.c
@@ -64,6 +64,15 @@ void instanced_group_bind_mesh(InstancedGroup* group, GLuint vbo, GLuint nbo,
 	glBindVertexArray(0);
 }
 
+void instanced_group_update(InstancedGroup* group, const SphereInstance* data,
+                            int count)
+{
+	group->instance_count = count;
+	glBindBuffer(GL_ARRAY_BUFFER, group->instance_vbo);
+	glBufferSubData(GL_ARRAY_BUFFER, 0,
+	                (GLsizeiptr)(count * sizeof(SphereInstance)), data);
+}
+
 void instanced_group_draw(InstancedGroup* group, size_t index_count)
 {
 	glBindVertexArray(group->vao);

--- a/src/instanced_rendering.c
+++ b/src/instanced_rendering.c
@@ -22,7 +22,8 @@ static void setup_instance_attributes(void)
 {
 	render_utils_setup_sphere_instance_attributes(
 	    (GLsizei)sizeof(SphereInstance), offsetof(SphereInstance, albedo),
-	    offsetof(SphereInstance, metallic));
+	    offsetof(SphereInstance, metallic),
+	    offsetof(SphereInstance, prev_center));
 }
 
 void instanced_group_bind_mesh(InstancedGroup* group, GLuint vbo, GLuint nbo,

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -60,6 +60,7 @@ void nbody_init_preset(NBodySim* sim)
 	(void)safe_memset(sim, sizeof(*sim), 0, sizeof(*sim));
 	sim->gravity = NBODY_DEFAULT_G;
 	sim->time_scale = 1.0F;
+	sim->target_time_scale = 1.0F;
 	sim->paused = false;
 
 	/* Body 0: Central star — gold/bronze, heavy, stationary */
@@ -303,14 +304,21 @@ void nbody_step(NBodySim* sim, float delta_time)
 		              sim->bodies[i].prev_position);
 	}
 
-	sim->accumulator += delta_time * sim->time_scale;
+	float scaled_dt = delta_time * sim->time_scale;
+	sim->accumulator += scaled_dt;
+
+	/* Clamp magnitude to prevent spiral of death */
 	if (sim->accumulator > NBODY_MAX_ACCUMULATOR) {
 		sim->accumulator = NBODY_MAX_ACCUMULATOR;
+	} else if (sim->accumulator < -NBODY_MAX_ACCUMULATOR) {
+		sim->accumulator = -NBODY_MAX_ACCUMULATOR;
 	}
 
-	while (sim->accumulator >= NBODY_FIXED_DT) {
-		integrate_step(sim, NBODY_FIXED_DT);
-		sim->accumulator -= NBODY_FIXED_DT;
+	/* Integrate: step sign follows accumulator sign (time reversal) */
+	float step = copysignf(NBODY_FIXED_DT, sim->accumulator);
+	while (fabsf(sim->accumulator) >= NBODY_FIXED_DT) {
+		integrate_step(sim, step);
+		sim->accumulator -= step;
 	}
 }
 
@@ -360,4 +368,18 @@ float nbody_energy_drift(const NBodySim* sim)
 	float diff = current - ref_energy;
 	return (diff < 0.0F ? -diff : diff) /
 	       (ref_energy < 0.0F ? -ref_energy : ref_energy);
+}
+
+void nbody_update_time_scale(NBodySim* sim, float delta_time)
+{
+	float diff = sim->target_time_scale - sim->time_scale;
+	if (diff == 0.0F) {
+		return;
+	}
+	float step = NBODY_TIME_SCALE_RATE * delta_time;
+	if (fabsf(diff) <= step) {
+		sim->time_scale = sim->target_time_scale;
+	} else {
+		sim->time_scale += copysignf(step, diff);
+	}
 }

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -154,6 +154,12 @@ void nbody_init_preset(NBodySim* sim)
 
 	/* Snapshot total energy for diagnostics (tests). */
 	(void)nbody_total_energy(sim);
+
+	/* Initialize prev_position = position for first frame (no motion). */
+	for (int i = 0; i < sim->body_count; i++) {
+		glm_vec3_copy(sim->bodies[i].position,
+		              sim->bodies[i].prev_position);
+	}
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
@@ -289,6 +295,14 @@ void nbody_step(NBodySim* sim, float delta_time)
 		return;
 	}
 
+	/* Snapshot current positions for per-object motion blur.
+	 * prev_position will be used by nbody_write_instances() to
+	 * fill SphereInstance::prev_center for the velocity buffer. */
+	for (int i = 0; i < sim->body_count; i++) {
+		glm_vec3_copy(sim->bodies[i].position,
+		              sim->bodies[i].prev_position);
+	}
+
 	sim->accumulator += delta_time * sim->time_scale;
 	if (sim->accumulator > NBODY_MAX_ACCUMULATOR) {
 		sim->accumulator = NBODY_MAX_ACCUMULATOR;
@@ -312,6 +326,7 @@ void nbody_write_instances(const NBodySim* sim, SphereInstance* out)
 		out[i].metallic = body->metallic;
 		out[i].roughness = body->roughness;
 		out[i].ao = 1.0F;
+		glm_vec3_copy((float*)body->prev_position, out[i].prev_center);
 	}
 }
 

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -54,6 +54,16 @@ static float softened_orbital_vel(float grav, float central_mass, float orbit_r,
 /* Preset                                                                    */
 /* ========================================================================= */
 
+/* Central star properties for the default preset. */
+static const float CENTRAL_STAR_MASS = 100.0F;
+static const float CENTRAL_STAR_RADIUS = 1.5F;
+static const vec3 CENTRAL_STAR_ALBEDO = {1.0F, 0.76F, 0.34F};
+static const float CENTRAL_STAR_METALLIC = 1.0F;
+static const float CENTRAL_STAR_ROUGHNESS = 0.2F;
+
+/* Physics half-factor for kinetic energy (½mv²) and Verlet integration. */
+static const float HALF = 0.5F;
+
 /* Descriptor for an orbiting body in the preset. */
 struct OrbiterDef {
 	vec3 pos;      /**< Initial position. */
@@ -89,7 +99,6 @@ static const struct OrbiterDef ORBITERS[] = {
 
 static const int ORBITER_COUNT = (int)(sizeof(ORBITERS) / sizeof(ORBITERS[0]));
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 void nbody_init_preset(NBodySim* sim)
 {
 	(void)safe_memset(sim, sizeof(*sim), 0, sizeof(*sim));
@@ -99,17 +108,17 @@ void nbody_init_preset(NBodySim* sim)
 	sim->paused = false;
 
 	/* Body 0: Central star — gold/bronze, heavy, stationary */
-	const float star_r = 1.5F;
-	add_body(sim, (vec3){0.0F, 0.0F, 0.0F}, (vec3){0.0F, 0.0F, 0.0F},
-	         100.0F, star_r, (vec3){1.0F, 0.76F, 0.34F}, 1.0F, 0.2F);
+	add_body(sim, (vec3){0}, (vec3){0}, CENTRAL_STAR_MASS,
+	         CENTRAL_STAR_RADIUS, CENTRAL_STAR_ALBEDO,
+	         CENTRAL_STAR_METALLIC, CENTRAL_STAR_ROUGHNESS);
 
 	/* Add all orbiters from the table. */
 	for (int idx = 0; idx < ORBITER_COUNT; idx++) {
 		const struct OrbiterDef* orb = &ORBITERS[idx];
-		float spd =
-		    softened_orbital_vel(sim->gravity, 100.0F, orb->orbit_r,
-		                         star_r, orb->body_r) *
-		    orb->ecc;
+		float spd = softened_orbital_vel(
+		                sim->gravity, CENTRAL_STAR_MASS, orb->orbit_r,
+		                CENTRAL_STAR_RADIUS, orb->body_r) *
+		            orb->ecc;
 		vec3 vel = {orb->vel_dir[0] * spd, orb->vel_dir[1] * spd,
 		            orb->vel_dir[2] * spd};
 		add_body(sim, orb->pos, vel, orb->mass, orb->body_r,
@@ -143,14 +152,10 @@ void nbody_init_preset(NBodySim* sim)
 		              sim->bodies[i].prev_position);
 	}
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
 /* ========================================================================= */
 /* Energy diagnostics                                                        */
 /* ========================================================================= */
-
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-// NOLINTBEGIN(readability-identifier-length)
 
 /* E = Σ ½ m v² − Σ_{i<j} G m_i m_j / sqrt(r² + ε²)
  * Conserved (bounded oscillation) by the symplectic integrator. */
@@ -159,20 +164,20 @@ float nbody_total_energy(const NBodySim* sim)
 {
 	float kinetic = 0.0F;
 	for (int i = 0; i < sim->body_count; i++) {
-		vec3 v;
-		glm_vec3_copy((float*)sim->bodies[i].velocity, v);
-		kinetic += 0.5F * sim->bodies[i].mass * glm_vec3_dot(v, v);
+		vec3 vel;
+		glm_vec3_copy((float*)sim->bodies[i].velocity, vel);
+		kinetic += HALF * sim->bodies[i].mass * glm_vec3_dot(vel, vel);
 	}
 
 	float potential = 0.0F;
 	for (int i = 0; i < sim->body_count; i++) {
 		for (int j = i + 1; j < sim->body_count; j++) {
 			vec3 diff;
-			vec3 pi;
-			vec3 pj;
-			glm_vec3_copy((float*)sim->bodies[i].position, pi);
-			glm_vec3_copy((float*)sim->bodies[j].position, pj);
-			glm_vec3_sub(pj, pi, diff);
+			vec3 pos_i;
+			vec3 pos_j;
+			glm_vec3_copy((float*)sim->bodies[i].position, pos_i);
+			glm_vec3_copy((float*)sim->bodies[j].position, pos_j);
+			glm_vec3_sub(pos_j, pos_i, diff);
 			float eps2 = pair_softening_sq(sim->bodies[i].radius,
 			                               sim->bodies[j].radius);
 			float dist = sqrtf(glm_vec3_dot(diff, diff) + eps2);
@@ -184,14 +189,9 @@ float nbody_total_energy(const NBodySim* sim)
 	return kinetic + potential;
 }
 
-// NOLINTEND(readability-identifier-length)
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-
 /* ========================================================================= */
 /* Gravity & Integration                                                     */
 /* ========================================================================= */
-
-// NOLINTBEGIN(readability-identifier-length)
 
 /* O(N²) pairwise gravity with per-pair Plummer softening.
  * ε² = max(NBODY_SOFTENING_SQ, (F·(r_i+r_j))²)  */
@@ -205,11 +205,11 @@ static void compute_accelerations(const NBodySim* sim, vec3* accel)
 	for (int i = 0; i < sim->body_count; i++) {
 		for (int j = i + 1; j < sim->body_count; j++) {
 			vec3 diff;
-			vec3 pi;
-			vec3 pj;
-			glm_vec3_copy((float*)sim->bodies[i].position, pi);
-			glm_vec3_copy((float*)sim->bodies[j].position, pj);
-			glm_vec3_sub(pj, pi, diff);
+			vec3 pos_i;
+			vec3 pos_j;
+			glm_vec3_copy((float*)sim->bodies[i].position, pos_i);
+			glm_vec3_copy((float*)sim->bodies[j].position, pos_j);
+			glm_vec3_sub(pos_j, pos_i, diff);
 
 			float eps2 = pair_softening_sq(sim->bodies[i].radius,
 			                               sim->bodies[j].radius);
@@ -218,54 +218,49 @@ static void compute_accelerations(const NBodySim* sim, vec3* accel)
 			float inv_dist3 = inv_dist * inv_dist * inv_dist;
 			float grav = sim->gravity * inv_dist3;
 
-			vec3 f;
-			glm_vec3_scale(diff, grav * sim->bodies[j].mass, f);
-			glm_vec3_add(accel[i], f, accel[i]);
+			vec3 force;
+			glm_vec3_scale(diff, grav * sim->bodies[j].mass, force);
+			glm_vec3_add(accel[i], force, accel[i]);
 
-			glm_vec3_scale(diff, grav * sim->bodies[i].mass, f);
-			glm_vec3_sub(accel[j], f, accel[j]);
+			glm_vec3_scale(diff, grav * sim->bodies[i].mass, force);
+			glm_vec3_sub(accel[j], force, accel[j]);
 		}
 	}
 }
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-
 /* Velocity Verlet (symplectic, 2nd order).
  * Energy oscillates with bounded amplitude thanks to Plummer softening. */
 
-static void integrate_step(NBodySim* sim,
-                           float dt)  // NOLINT(readability-identifier-length)
+static void integrate_step(NBodySim* sim, float delta_time)
 {
 	vec3 accel_old[NBODY_MAX_BODIES];
 	vec3 accel_new[NBODY_MAX_BODIES];
 
 	compute_accelerations(sim, accel_old);
 
-	/* x += v·dt + 0.5·a·dt² */
+	/* x += v·dt + ½·a·dt² */
 	for (int i = 0; i < sim->body_count; i++) {
 		vec3 tmp;
-		glm_vec3_scale(sim->bodies[i].velocity, dt, tmp);
+		glm_vec3_scale(sim->bodies[i].velocity, delta_time, tmp);
 		glm_vec3_add(sim->bodies[i].position, tmp,
 		             sim->bodies[i].position);
-		glm_vec3_scale(accel_old[i], 0.5F * dt * dt, tmp);
+		glm_vec3_scale(accel_old[i], HALF * delta_time * delta_time,
+		               tmp);
 		glm_vec3_add(sim->bodies[i].position, tmp,
 		             sim->bodies[i].position);
 	}
 
 	compute_accelerations(sim, accel_new);
 
-	/* v += 0.5·(a_old + a_new)·dt */
+	/* v += ½·(a_old + a_new)·dt */
 	for (int i = 0; i < sim->body_count; i++) {
 		vec3 avg;
 		glm_vec3_add(accel_old[i], accel_new[i], avg);
-		glm_vec3_scale(avg, 0.5F * dt, avg);
+		glm_vec3_scale(avg, HALF * delta_time, avg);
 		glm_vec3_add(sim->bodies[i].velocity, avg,
 		             sim->bodies[i].velocity);
 	}
 }
-
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-// NOLINTEND(readability-identifier-length)
 
 /* ========================================================================= */
 /* Public API                                                                */
@@ -324,20 +319,16 @@ int nbody_get_count(const NBodySim* sim)
 	return sim->body_count;
 }
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-
 float nbody_kinetic_energy(const NBodySim* sim)
 {
 	float kinetic = 0.0F;
 	for (int i = 0; i < sim->body_count; i++) {
 		vec3 vel;
 		glm_vec3_copy((float*)sim->bodies[i].velocity, vel);
-		kinetic += 0.5F * sim->bodies[i].mass * glm_vec3_dot(vel, vel);
+		kinetic += HALF * sim->bodies[i].mass * glm_vec3_dot(vel, vel);
 	}
 	return kinetic;
 }
-
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
 float nbody_energy_drift(const NBodySim* sim)
 {

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -1,0 +1,321 @@
+#include "nbody.h"
+
+#include "utils.h"
+#include <cglm/affine.h>
+#include <cglm/mat4.h>
+#include <cglm/vec3.h>
+#include <math.h>
+
+/* ========================================================================= */
+/* Helpers                                                                   */
+/* ========================================================================= */
+
+static void add_body(NBodySim* sim, const vec3 pos, const vec3 vel, float mass,
+                     float radius, const vec3 albedo, float metallic,
+                     float roughness)
+{
+	if (sim->body_count >= NBODY_MAX_BODIES) {
+		return;
+	}
+	NBodyParticle* body = &sim->bodies[sim->body_count];
+	glm_vec3_copy((float*)pos, body->position);
+	glm_vec3_copy((float*)vel, body->velocity);
+	body->mass = mass;
+	body->radius = radius;
+	glm_vec3_copy((float*)albedo, body->albedo);
+	body->metallic = metallic;
+	body->roughness = roughness;
+	sim->body_count++;
+}
+
+/* Per-pair Plummer softening: ε² = max(NBODY_SOFTENING_SQ, (F·(r_i+r_j))²).
+ * Used by forces, energy, and initial velocities for consistency. */
+static float pair_softening_sq(float radius_i, float radius_j)
+{
+	float sum_r = radius_i + radius_j;
+	float eps = NBODY_SOFTENING_FACTOR * sum_r;
+	float eps_sq = eps * eps;
+	return eps_sq > NBODY_SOFTENING_SQ ? eps_sq : NBODY_SOFTENING_SQ;
+}
+
+/* Circular-orbit speed in a Plummer-softened potential:
+ * v = r · sqrt(G·M / (r² + ε²)^{3/2})  */
+static float softened_orbital_vel(float grav, float central_mass, float orbit_r,
+                                  float star_r, float body_r)
+{
+	float eps_sq = pair_softening_sq(star_r, body_r);
+	float r_sq = orbit_r * orbit_r;
+	float d_sq = r_sq + eps_sq;
+	float d_32 = d_sq * sqrtf(d_sq);
+	return orbit_r * sqrtf(grav * central_mass / d_32);
+}
+
+/* ========================================================================= */
+/* Preset                                                                    */
+/* ========================================================================= */
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+void nbody_init_preset(NBodySim* sim)
+{
+	(void)safe_memset(sim, sizeof(*sim), 0, sizeof(*sim));
+	sim->gravity = NBODY_DEFAULT_G;
+	sim->time_scale = 1.0F;
+	sim->paused = false;
+
+	/* Body 0: Central star — gold/bronze, heavy, stationary */
+	const float star_r = 1.5F;
+	add_body(sim, (vec3){0.0F, 0.0F, 0.0F}, (vec3){0.0F, 0.0F, 0.0F},
+	         100.0F, star_r, (vec3){1.0F, 0.76F, 0.34F}, 1.0F, 0.2F);
+
+	/* Body 1: Tiny fast orbiter — gold, tight circular orbit in XY plane */
+	{
+		const float rad = 3.0F;
+		const float body_r = 0.3F;
+		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
+		                                       rad, star_r, body_r);
+		add_body(sim, (vec3){rad, 0.0F, 0.0F}, (vec3){0.0F, vel, 0.0F},
+		         0.3F, body_r, (vec3){1.0F, 0.84F, 0.0F}, 1.0F, 0.1F);
+	}
+
+	/* Body 2: Chrome moon — circular orbit, slightly inclined */
+	{
+		const float rad = 5.0F;
+		const float body_r = 0.5F;
+		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
+		                                       rad, star_r, body_r);
+		add_body(sim, (vec3){0.0F, rad, 0.5F}, (vec3){-vel, 0.0F, 0.0F},
+		         1.5F, body_r, (vec3){0.77F, 0.78F, 0.78F}, 1.0F,
+		         0.05F);
+	}
+
+	/* Body 3: Silver moon — different orbital plane (XZ) */
+	{
+		const float rad = 7.0F;
+		const float body_r = 0.6F;
+		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
+		                                       rad, star_r, body_r);
+		add_body(sim, (vec3){0.0F, -1.0F, rad}, (vec3){vel, 0.0F, 0.0F},
+		         2.0F, body_r, (vec3){0.85F, 0.85F, 0.90F}, 1.0F,
+		         0.15F);
+	}
+
+	/* Body 4: Copper planet — wide circular orbit */
+	{
+		const float rad = 10.0F;
+		const float body_r = 0.8F;
+		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
+		                                       rad, star_r, body_r);
+		add_body(sim, (vec3){-rad, 0.0F, 1.5F},
+		         (vec3){0.0F, -vel, 0.0F}, 4.0F, body_r,
+		         (vec3){0.72F, 0.45F, 0.20F}, 1.0F, 0.3F);
+	}
+
+	/* Body 5: Cyan glass comet — mildly elliptical orbit */
+	{
+		const float rad = 8.0F;
+		const float body_r = 0.4F;
+		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
+		                                       rad, star_r, body_r) *
+		                  0.85F;
+		add_body(sim, (vec3){rad, 2.0F, 2.0F},
+		         (vec3){0.0F, vel, -vel * 0.3F}, 0.5F, body_r,
+		         (vec3){0.15F, 0.85F, 0.95F}, 0.1F, 0.05F);
+	}
+
+	/* Body 6: Magenta glass comet — mildly elliptical, different plane */
+	{
+		const float rad = 11.0F;
+		const float body_r = 0.35F;
+		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
+		                                       rad, star_r, body_r) *
+		                  0.85F;
+		add_body(sim, (vec3){-3.0F, rad, -2.0F},
+		         (vec3){vel * 0.5F, 0.0F, vel * 0.6F}, 0.5F, body_r,
+		         (vec3){0.90F, 0.20F, 0.75F}, 0.1F, 0.05F);
+	}
+
+	/* Zero the total momentum so the center of mass stays fixed.
+	 * v_cm = Σ(m_i * v_i) / Σ(m_i), then subtract from each body. */
+	vec3 total_momentum = {0.0F, 0.0F, 0.0F};
+	float total_mass = 0.0F;
+	for (int i = 0; i < sim->body_count; i++) {
+		vec3 mom;
+		glm_vec3_scale(sim->bodies[i].velocity, sim->bodies[i].mass,
+		               mom);
+		glm_vec3_add(total_momentum, mom, total_momentum);
+		total_mass += sim->bodies[i].mass;
+	}
+	vec3 vel_cm;
+	glm_vec3_scale(total_momentum, 1.0F / total_mass, vel_cm);
+	for (int i = 0; i < sim->body_count; i++) {
+		glm_vec3_sub(sim->bodies[i].velocity, vel_cm,
+		             sim->bodies[i].velocity);
+	}
+
+	/* Snapshot total energy for diagnostics (tests). */
+	(void)nbody_total_energy(sim);
+}
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+/* ========================================================================= */
+/* Energy diagnostics                                                        */
+/* ========================================================================= */
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+// NOLINTBEGIN(readability-identifier-length)
+
+/* E = Σ ½ m v² − Σ_{i<j} G m_i m_j / sqrt(r² + ε²)
+ * Conserved (bounded oscillation) by the symplectic integrator. */
+
+float nbody_total_energy(const NBodySim* sim)
+{
+	float kinetic = 0.0F;
+	for (int i = 0; i < sim->body_count; i++) {
+		vec3 v;
+		glm_vec3_copy((float*)sim->bodies[i].velocity, v);
+		kinetic += 0.5F * sim->bodies[i].mass * glm_vec3_dot(v, v);
+	}
+
+	float potential = 0.0F;
+	for (int i = 0; i < sim->body_count; i++) {
+		for (int j = i + 1; j < sim->body_count; j++) {
+			vec3 diff;
+			vec3 pi;
+			vec3 pj;
+			glm_vec3_copy((float*)sim->bodies[i].position, pi);
+			glm_vec3_copy((float*)sim->bodies[j].position, pj);
+			glm_vec3_sub(pj, pi, diff);
+			float eps2 = pair_softening_sq(sim->bodies[i].radius,
+			                               sim->bodies[j].radius);
+			float dist = sqrtf(glm_vec3_dot(diff, diff) + eps2);
+			potential -= sim->gravity * sim->bodies[i].mass *
+			             sim->bodies[j].mass / dist;
+		}
+	}
+
+	return kinetic + potential;
+}
+
+// NOLINTEND(readability-identifier-length)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+/* ========================================================================= */
+/* Gravity & Integration                                                     */
+/* ========================================================================= */
+
+// NOLINTBEGIN(readability-identifier-length)
+
+/* O(N²) pairwise gravity with per-pair Plummer softening.
+ * ε² = max(NBODY_SOFTENING_SQ, (F·(r_i+r_j))²)  */
+
+static void compute_accelerations(const NBodySim* sim, vec3* accel)
+{
+	for (int i = 0; i < sim->body_count; i++) {
+		glm_vec3_zero(accel[i]);
+	}
+
+	for (int i = 0; i < sim->body_count; i++) {
+		for (int j = i + 1; j < sim->body_count; j++) {
+			vec3 diff;
+			vec3 pi;
+			vec3 pj;
+			glm_vec3_copy((float*)sim->bodies[i].position, pi);
+			glm_vec3_copy((float*)sim->bodies[j].position, pj);
+			glm_vec3_sub(pj, pi, diff);
+
+			float eps2 = pair_softening_sq(sim->bodies[i].radius,
+			                               sim->bodies[j].radius);
+			float dist_sq = glm_vec3_dot(diff, diff) + eps2;
+			float inv_dist = 1.0F / sqrtf(dist_sq);
+			float inv_dist3 = inv_dist * inv_dist * inv_dist;
+			float grav = sim->gravity * inv_dist3;
+
+			vec3 f;
+			glm_vec3_scale(diff, grav * sim->bodies[j].mass, f);
+			glm_vec3_add(accel[i], f, accel[i]);
+
+			glm_vec3_scale(diff, grav * sim->bodies[i].mass, f);
+			glm_vec3_sub(accel[j], f, accel[j]);
+		}
+	}
+}
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+/* Velocity Verlet (symplectic, 2nd order).
+ * Energy oscillates with bounded amplitude thanks to Plummer softening. */
+
+static void integrate_step(NBodySim* sim,
+                           float dt)  // NOLINT(readability-identifier-length)
+{
+	vec3 accel_old[NBODY_MAX_BODIES];
+	vec3 accel_new[NBODY_MAX_BODIES];
+
+	compute_accelerations(sim, accel_old);
+
+	/* x += v·dt + 0.5·a·dt² */
+	for (int i = 0; i < sim->body_count; i++) {
+		vec3 tmp;
+		glm_vec3_scale(sim->bodies[i].velocity, dt, tmp);
+		glm_vec3_add(sim->bodies[i].position, tmp,
+		             sim->bodies[i].position);
+		glm_vec3_scale(accel_old[i], 0.5F * dt * dt, tmp);
+		glm_vec3_add(sim->bodies[i].position, tmp,
+		             sim->bodies[i].position);
+	}
+
+	compute_accelerations(sim, accel_new);
+
+	/* v += 0.5·(a_old + a_new)·dt */
+	for (int i = 0; i < sim->body_count; i++) {
+		vec3 avg;
+		glm_vec3_add(accel_old[i], accel_new[i], avg);
+		glm_vec3_scale(avg, 0.5F * dt, avg);
+		glm_vec3_add(sim->bodies[i].velocity, avg,
+		             sim->bodies[i].velocity);
+	}
+}
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+// NOLINTEND(readability-identifier-length)
+
+/* ========================================================================= */
+/* Public API                                                                */
+/* ========================================================================= */
+
+void nbody_step(NBodySim* sim, float delta_time)
+{
+	if (sim->paused) {
+		return;
+	}
+
+	sim->accumulator += delta_time * sim->time_scale;
+	if (sim->accumulator > NBODY_MAX_ACCUMULATOR) {
+		sim->accumulator = NBODY_MAX_ACCUMULATOR;
+	}
+
+	while (sim->accumulator >= NBODY_FIXED_DT) {
+		integrate_step(sim, NBODY_FIXED_DT);
+		sim->accumulator -= NBODY_FIXED_DT;
+	}
+}
+
+void nbody_write_instances(const NBodySim* sim, SphereInstance* out)
+{
+	for (int i = 0; i < sim->body_count; i++) {
+		const NBodyParticle* body = &sim->bodies[i];
+		glm_mat4_identity(out[i].model);
+		glm_translate(out[i].model, (float*)body->position);
+		vec3 scale = {body->radius, body->radius, body->radius};
+		glm_scale(out[i].model, scale);
+		glm_vec3_copy((float*)body->albedo, out[i].albedo);
+		out[i].metallic = body->metallic;
+		out[i].roughness = body->roughness;
+		out[i].ao = 1.0F;
+	}
+}
+
+int nbody_get_count(const NBodySim* sim)
+{
+	return sim->body_count;
+}

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -152,8 +152,8 @@ void nbody_init_preset(NBodySim* sim)
 		             sim->bodies[i].velocity);
 	}
 
-	/* Snapshot total energy for diagnostics (tests). */
-	(void)nbody_total_energy(sim);
+	/* Snapshot total energy as reference for stability diagnostics. */
+	sim->initial_energy = nbody_total_energy(sim);
 
 	/* Initialize prev_position = position for first frame (no motion). */
 	for (int i = 0; i < sim->body_count; i++) {
@@ -333,4 +333,31 @@ void nbody_write_instances(const NBodySim* sim, SphereInstance* out)
 int nbody_get_count(const NBodySim* sim)
 {
 	return sim->body_count;
+}
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+float nbody_kinetic_energy(const NBodySim* sim)
+{
+	float kinetic = 0.0F;
+	for (int i = 0; i < sim->body_count; i++) {
+		vec3 vel;
+		glm_vec3_copy((float*)sim->bodies[i].velocity, vel);
+		kinetic += 0.5F * sim->bodies[i].mass * glm_vec3_dot(vel, vel);
+	}
+	return kinetic;
+}
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+float nbody_energy_drift(const NBodySim* sim)
+{
+	float ref_energy = sim->initial_energy;
+	if (ref_energy == 0.0F) {
+		return 0.0F;
+	}
+	float current = nbody_total_energy(sim);
+	float diff = current - ref_energy;
+	return (diff < 0.0F ? -diff : diff) /
+	       (ref_energy < 0.0F ? -ref_energy : ref_energy);
 }

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -54,6 +54,41 @@ static float softened_orbital_vel(float grav, float central_mass, float orbit_r,
 /* Preset                                                                    */
 /* ========================================================================= */
 
+/* Descriptor for an orbiting body in the preset. */
+struct OrbiterDef {
+	vec3 pos;      /**< Initial position. */
+	vec3 vel_dir;  /**< Velocity direction (each component × orbital speed).
+	                */
+	float orbit_r; /**< Orbital radius (for speed computation). */
+	float body_r;  /**< Body radius. */
+	float mass;
+	vec3 albedo;
+	float metallic;
+	float roughness;
+	float ecc; /**< Eccentricity factor on orbital speed (1 = circular). */
+};
+
+/* clang-format off */
+static const struct OrbiterDef ORBITERS[] = {
+	/*          position              vel_dir        orb_r  r     mass  albedo              met   rough ecc  */
+	/* 1  Gold orbiter      */ {{ 3, 0, 0},      { 0, 1, 0},     3,   0.30F, 0.3F, {1.0F,0.84F,0.0F},  1.0F, 0.10F, 1.00F},
+	/* 2  Chrome moon       */ {{ 0, 5, 0.5F},   {-1, 0, 0},     5,   0.50F, 1.5F, {0.77F,0.78F,0.78F},1.0F, 0.05F, 1.00F},
+	/* 3  Silver moon       */ {{ 0,-1, 7},      { 1, 0, 0},     7,   0.60F, 2.0F, {0.85F,0.85F,0.90F},1.0F, 0.15F, 1.00F},
+	/* 4  Copper planet     */ {{-10, 0, 1.5F},  { 0,-1, 0},    10,   0.80F, 4.0F, {0.72F,0.45F,0.20F},1.0F, 0.30F, 1.00F},
+	/* 5  Cyan comet        */ {{ 8, 2, 2},      { 0, 1,-0.3F},  8,   0.40F, 0.5F, {0.15F,0.85F,0.95F},0.1F, 0.05F, 0.85F},
+	/* 6  Magenta comet     */ {{-3,11,-2},      { 0.5F, 0, 0.6F},11,  0.35F, 0.5F, {0.90F,0.20F,0.75F},0.1F, 0.05F, 0.85F},
+	/* 7  Emerald orbiter   */ {{ 4, 0.5F, 0},   { 0, 0, 1},     4,   0.35F, 0.6F, {0.15F,0.85F,0.30F},0.8F, 0.15F, 1.00F},
+	/* 8  Rose quartz       */ {{ 0,-10, 2},     { 1, 0, 0},    10,   0.55F, 1.8F, {0.90F,0.55F,0.65F},0.3F, 0.25F, 0.95F},
+	/* 9  Deep blue         */ {{ 0, 0,-3.5F},   { 0, 1, 0},     3.5F,0.30F, 0.4F, {0.10F,0.25F,0.95F},0.9F, 0.10F, 1.00F},
+	/* 10 Amber planet      */ {{ 9,-2, 0},      { 0, 1, 0},     9,   0.65F, 3.0F, {1.0F,0.60F,0.10F}, 0.7F, 0.30F, 1.00F},
+	/* 11 Violet comet      */ {{11, 2,-3},      {-0.4F, 0, 0.7F},11,  0.30F, 0.4F, {0.55F,0.15F,0.95F},0.2F, 0.08F, 0.92F},
+	/* 12 Turquoise moon    */ {{-6, 0,-1},      { 0, 1, 0},     6,   0.45F, 1.2F, {0.20F,0.80F,0.75F},0.6F, 0.12F, 1.00F},
+	/* 13 Crimson dwarf     */ {{-12,-2, 1},     { 0.3F, 0.7F, 0},12,  0.50F, 2.5F, {0.90F,0.12F,0.15F},0.85F,0.35F, 0.95F},
+};
+/* clang-format on */
+
+static const int ORBITER_COUNT = (int)(sizeof(ORBITERS) / sizeof(ORBITERS[0]));
+
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 void nbody_init_preset(NBodySim* sim)
 {
@@ -68,71 +103,17 @@ void nbody_init_preset(NBodySim* sim)
 	add_body(sim, (vec3){0.0F, 0.0F, 0.0F}, (vec3){0.0F, 0.0F, 0.0F},
 	         100.0F, star_r, (vec3){1.0F, 0.76F, 0.34F}, 1.0F, 0.2F);
 
-	/* Body 1: Tiny fast orbiter — gold, tight circular orbit in XY plane */
-	{
-		const float rad = 3.0F;
-		const float body_r = 0.3F;
-		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
-		                                       rad, star_r, body_r);
-		add_body(sim, (vec3){rad, 0.0F, 0.0F}, (vec3){0.0F, vel, 0.0F},
-		         0.3F, body_r, (vec3){1.0F, 0.84F, 0.0F}, 1.0F, 0.1F);
-	}
-
-	/* Body 2: Chrome moon — circular orbit, slightly inclined */
-	{
-		const float rad = 5.0F;
-		const float body_r = 0.5F;
-		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
-		                                       rad, star_r, body_r);
-		add_body(sim, (vec3){0.0F, rad, 0.5F}, (vec3){-vel, 0.0F, 0.0F},
-		         1.5F, body_r, (vec3){0.77F, 0.78F, 0.78F}, 1.0F,
-		         0.05F);
-	}
-
-	/* Body 3: Silver moon — different orbital plane (XZ) */
-	{
-		const float rad = 7.0F;
-		const float body_r = 0.6F;
-		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
-		                                       rad, star_r, body_r);
-		add_body(sim, (vec3){0.0F, -1.0F, rad}, (vec3){vel, 0.0F, 0.0F},
-		         2.0F, body_r, (vec3){0.85F, 0.85F, 0.90F}, 1.0F,
-		         0.15F);
-	}
-
-	/* Body 4: Copper planet — wide circular orbit */
-	{
-		const float rad = 10.0F;
-		const float body_r = 0.8F;
-		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
-		                                       rad, star_r, body_r);
-		add_body(sim, (vec3){-rad, 0.0F, 1.5F},
-		         (vec3){0.0F, -vel, 0.0F}, 4.0F, body_r,
-		         (vec3){0.72F, 0.45F, 0.20F}, 1.0F, 0.3F);
-	}
-
-	/* Body 5: Cyan glass comet — mildly elliptical orbit */
-	{
-		const float rad = 8.0F;
-		const float body_r = 0.4F;
-		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
-		                                       rad, star_r, body_r) *
-		                  0.85F;
-		add_body(sim, (vec3){rad, 2.0F, 2.0F},
-		         (vec3){0.0F, vel, -vel * 0.3F}, 0.5F, body_r,
-		         (vec3){0.15F, 0.85F, 0.95F}, 0.1F, 0.05F);
-	}
-
-	/* Body 6: Magenta glass comet — mildly elliptical, different plane */
-	{
-		const float rad = 11.0F;
-		const float body_r = 0.35F;
-		const float vel = softened_orbital_vel(sim->gravity, 100.0F,
-		                                       rad, star_r, body_r) *
-		                  0.85F;
-		add_body(sim, (vec3){-3.0F, rad, -2.0F},
-		         (vec3){vel * 0.5F, 0.0F, vel * 0.6F}, 0.5F, body_r,
-		         (vec3){0.90F, 0.20F, 0.75F}, 0.1F, 0.05F);
+	/* Add all orbiters from the table. */
+	for (int idx = 0; idx < ORBITER_COUNT; idx++) {
+		const struct OrbiterDef* orb = &ORBITERS[idx];
+		float spd =
+		    softened_orbital_vel(sim->gravity, 100.0F, orb->orbit_r,
+		                         star_r, orb->body_r) *
+		    orb->ecc;
+		vec3 vel = {orb->vel_dir[0] * spd, orb->vel_dir[1] * spd,
+		            orb->vel_dir[2] * spd};
+		add_body(sim, orb->pos, vel, orb->mass, orb->body_r,
+		         orb->albedo, orb->metallic, orb->roughness);
 	}
 
 	/* Zero the total momentum so the center of mass stays fixed.

--- a/src/render_utils.c
+++ b/src/render_utils.c
@@ -274,7 +274,8 @@ GLuint render_utils_create_texture_2d(int width, int height,
 
 void render_utils_setup_sphere_instance_attributes(GLsizei stride,
                                                    size_t offset_albedo,
-                                                   size_t offset_metallic)
+                                                   size_t offset_metallic,
+                                                   size_t offset_prev_center)
 {
 	GLuint index_vattrib = 2; /* Start at 2 (0=Pos, 1=Norm usually) */
 
@@ -301,6 +302,13 @@ void render_utils_setup_sphere_instance_attributes(GLsizei stride,
 	glEnableVertexAttribArray(index_vattrib);
 	glVertexAttribPointer(index_vattrib, 3, GL_FLOAT, GL_FALSE, stride,
 	                      utils_buffer_offset(offset_metallic));
+	glVertexAttribDivisor(index_vattrib, 1);
+	index_vattrib++;
+
+	/* prev_center (8) — previous frame center for per-object motion blur */
+	glEnableVertexAttribArray(index_vattrib);
+	glVertexAttribPointer(index_vattrib, 3, GL_FLOAT, GL_FALSE, stride,
+	                      utils_buffer_offset(offset_prev_center));
 	glVertexAttribDivisor(index_vattrib, 1);
 }
 

--- a/src/scene.c
+++ b/src/scene.c
@@ -123,6 +123,9 @@ static void scene_init_instancing(Scene* scene)
 		data[i].metallic = mat->metallic;
 		data[i].roughness = mat->roughness;
 		data[i].ao = 1.0F;
+		/* Static grid: prev_center = current center (no object motion)
+		 */
+		glm_vec3_copy(position, data[i].prev_center);
 	}
 
 	instanced_group_init(&scene->instanced_group, data, total_count);
@@ -1003,6 +1006,8 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 	/* --- N-Body orbital trails (rendered after spheres, into HDR FBO) ---
 	 */
 	if (scene->nbody_mode) {
+		GPU_STAGE_PROFILER(profiler, "NBody Trails",
+		                   GPU_PROFILER_NBODY_COLOR);
 		gl_debug_push_group("NBody_Trails");
 		trail_renderer_draw(&scene->trail_renderer, view, proj,
 		                    camera_pos);

--- a/src/scene.c
+++ b/src/scene.c
@@ -1073,6 +1073,9 @@ void scene_nbody_update(Scene* scene, float delta_time)
 		return;
 	}
 
+	/* Smooth time-scale transition (decelerate → pause → reverse) */
+	nbody_update_time_scale(&scene->nbody_sim, delta_time);
+
 	/* Advance physics (Velocity Verlet, O(N²) gravity) */
 	{
 		PROFILE_ZONE(verlet_ctx, "NBody Verlet");

--- a/src/scene.c
+++ b/src/scene.c
@@ -547,6 +547,7 @@ void scene_cleanup(Scene* scene)
 #endif
 	instanced_group_cleanup(&scene->instanced_group);
 	billboard_group_cleanup(&scene->billboard_group);
+	trail_renderer_cleanup(&scene->trail_renderer);
 #ifdef USE_SSBO_RENDERING
 	ssbo_group_cleanup(&scene->ssbo_group);
 #endif
@@ -999,7 +1000,94 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 #endif
 
+	/* --- N-Body orbital trails (rendered after spheres, into HDR FBO) ---
+	 */
+	if (scene->nbody_mode) {
+		gl_debug_push_group("NBody_Trails");
+		trail_renderer_draw(&scene->trail_renderer, view, proj,
+		                    camera_pos);
+		gl_debug_pop_group();
+	}
+
 	if (scene->show_probe_grid) {
 		light_probe_render_debug(&scene->probe_grid, view, proj);
 	}
+}
+
+/* ---------------------------------------------------------------------------
+ * N-Body simulation integration
+ * ---------------------------------------------------------------------------*/
+
+void scene_toggle_nbody(Scene* scene)
+{
+	scene->nbody_mode = !scene->nbody_mode;
+
+	if (scene->nbody_mode) {
+		/* Initialize simulation and trails */
+		nbody_init_preset(&scene->nbody_sim);
+
+		int count = nbody_get_count(&scene->nbody_sim);
+		if (!trail_renderer_init(&scene->trail_renderer, count)) {
+			scene->nbody_mode = 0;
+			return;
+		}
+
+		/* Set trail colors from body albedos (HDR-scaled) */
+		for (int i = 0; i < count; i++) {
+			trail_renderer_set_color(
+			    &scene->trail_renderer, i,
+			    scene->nbody_sim.bodies[i].albedo);
+		}
+
+		/* Write initial instance data and update GPU */
+		SphereInstance instances[NBODY_MAX_BODIES];
+		nbody_write_instances(&scene->nbody_sim, instances);
+		instanced_group_update(&scene->instanced_group, instances,
+		                       count);
+
+#ifdef USE_TRANSPARENT_BILLBOARDS
+		if (scene->sphere_instances) {
+			safe_memcpy(scene->sphere_instances,
+			            sizeof(SphereInstance) * (size_t)count,
+			            instances,
+			            sizeof(SphereInstance) * (size_t)count);
+			scene->sphere_instance_count = count;
+		}
+		scene->billboard_group.instance_count = count;
+#endif
+	} else {
+		/* Restore original material grid */
+		trail_renderer_cleanup(&scene->trail_renderer);
+		scene_init_instancing(scene);
+	}
+}
+
+void scene_nbody_update(Scene* scene, float delta_time)
+{
+	if (!scene->nbody_mode) {
+		return;
+	}
+
+	/* Advance physics */
+	nbody_step(&scene->nbody_sim, delta_time);
+
+	/* Record trail positions */
+	trail_renderer_record(&scene->trail_renderer, &scene->nbody_sim,
+	                      delta_time);
+
+	/* Update instanced rendering data */
+	int count = nbody_get_count(&scene->nbody_sim);
+	SphereInstance instances[NBODY_MAX_BODIES];
+	nbody_write_instances(&scene->nbody_sim, instances);
+	instanced_group_update(&scene->instanced_group, instances, count);
+
+#ifdef USE_TRANSPARENT_BILLBOARDS
+	if (scene->sphere_instances) {
+		safe_memcpy(scene->sphere_instances,
+		            sizeof(SphereInstance) * (size_t)count, instances,
+		            sizeof(SphereInstance) * (size_t)count);
+		scene->sphere_instance_count = count;
+	}
+	scene->billboard_group.instance_count = count;
+#endif
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -1073,18 +1073,35 @@ void scene_nbody_update(Scene* scene, float delta_time)
 		return;
 	}
 
-	/* Advance physics */
-	nbody_step(&scene->nbody_sim, delta_time);
+	/* Advance physics (Velocity Verlet, O(N²) gravity) */
+	{
+		PROFILE_ZONE(verlet_ctx, "NBody Verlet");
+		nbody_step(&scene->nbody_sim, delta_time);
+		PROFILE_ZONE_END(verlet_ctx);
+	}
 
-	/* Record trail positions */
-	trail_renderer_record(&scene->trail_renderer, &scene->nbody_sim,
-	                      delta_time);
+	/* Record trail positions into ring buffers */
+	{
+		PROFILE_ZONE(trail_ctx, "NBody Trail Sample");
+		trail_renderer_record(&scene->trail_renderer, &scene->nbody_sim,
+		                      delta_time);
+		PROFILE_ZONE_END(trail_ctx);
+	}
 
-	/* Update instanced rendering data */
+	/* Build instance data and upload to GPU */
 	int count = nbody_get_count(&scene->nbody_sim);
 	SphereInstance instances[NBODY_MAX_BODIES];
-	nbody_write_instances(&scene->nbody_sim, instances);
-	instanced_group_update(&scene->instanced_group, instances, count);
+	{
+		PROFILE_ZONE(inst_ctx, "NBody Instance Build");
+		nbody_write_instances(&scene->nbody_sim, instances);
+		PROFILE_ZONE_END(inst_ctx);
+	}
+	{
+		PROFILE_ZONE(upload_ctx, "NBody VBO Upload");
+		instanced_group_update(&scene->instanced_group, instances,
+		                       count);
+		PROFILE_ZONE_END(upload_ctx);
+	}
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
 	if (scene->sphere_instances) {

--- a/src/scene.c
+++ b/src/scene.c
@@ -1061,8 +1061,18 @@ void scene_toggle_nbody(Scene* scene)
 		scene->billboard_group.instance_count = count;
 #endif
 	} else {
-		/* Restore original material grid */
+		/* Restore original material grid — clean up before re-init
+		 * to avoid leaking GPU buffers and CPU allocations */
 		trail_renderer_cleanup(&scene->trail_renderer);
+#ifdef USE_TRANSPARENT_BILLBOARDS
+		if (scene->sphere_instances) {
+			platform_aligned_free(scene->sphere_instances);
+			scene->sphere_instances = NULL;
+		}
+		sphere_sorter_cleanup(&scene->sphere_sorter);
+#endif
+		instanced_group_cleanup(&scene->instanced_group);
+		billboard_group_cleanup(&scene->billboard_group);
 		scene_init_instancing(scene);
 	}
 }

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -6,6 +6,7 @@
 #include "shader.h"
 #include "utils.h"
 #include <cglm/vec3.h>
+#include <math.h>
 #include <string.h>
 
 /* Maximum ribbon vertices: each body can produce up to
@@ -119,8 +120,10 @@ void trail_renderer_record(TrailRenderer* trail, const NBodySim* sim,
 	/* Scale sampling rate by time_scale so trail length in world units
 	 * stays constant regardless of simulation speed.  At 8× speed the
 	 * bodies move 8× faster, so we sample 8× more often — the ring
-	 * buffer evicts old points at the same *visual* pace. */
-	float effective_dt = delta_time * sim->time_scale;
+	 * buffer evicts old points at the same *visual* pace.
+	 * fabsf() ensures sampling works under time reversal (negative
+	 * time_scale) — we always accumulate positive time for sampling. */
+	float effective_dt = delta_time * fabsf(sim->time_scale);
 	trail->sample_timer += effective_dt;
 
 	/* Emit as many sub-samples as needed (catches large time_scale

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -73,9 +73,8 @@ bool trail_renderer_init(TrailRenderer* trail, int body_count)
 
 	/* Attribute 1: color (vec3) + v (float) — packed as vec4 */
 	const size_t color_offset = offsetof(TrailVertex, color);
-	glVertexAttribPointer(
-	    1, 4, GL_FLOAT, GL_FALSE, stride,
-	    (const void*)color_offset);  // NOLINT(performance-no-int-to-ptr)
+	glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, stride,
+	                      utils_buffer_offset(color_offset));
 	glEnableVertexAttribArray(1);
 
 	glBindVertexArray(0);

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -59,6 +59,8 @@ bool trail_renderer_init(TrailRenderer* trail, int body_count)
 	/* Create VAO + dynamic VBO */
 	glGenVertexArrays(1, &trail->vao);
 	glGenBuffers(1, &trail->vbo);
+	glObjectLabel(GL_VERTEX_ARRAY, trail->vao, -1, "Trail_VAO");
+	glObjectLabel(GL_BUFFER, trail->vbo, -1, "Trail_VBO");
 
 	glBindVertexArray(trail->vao);
 	glBindBuffer(GL_ARRAY_BUFFER, trail->vbo);

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -11,7 +11,7 @@
 
 /* Maximum ribbon vertices: each body can produce up to
  * (TRAIL_MAX_POINTS - 1) segments × 2 vertices + 2 degenerate = ~514.
- * With NBODY_MAX_BODIES=16: 16 × 514 = 8224 vertices.
+ * With NBODY_MAX_BODIES=32: 32 × 514 = 16448 vertices.
  * Each vertex is 32 bytes → ~256 KB. Trivially small. */
 enum { MAX_TRAIL_VERTICES = NBODY_MAX_BODIES * ((TRAIL_MAX_POINTS * 2) + 4) };
 

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -247,10 +247,10 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 	static TrailVertex staging[MAX_TRAIL_VERTICES];
 	int total_verts = 0;
 
-	/* Track per-body start offsets for separate draw calls
-	 * (triangle strips can't be concatenated without degenerates). */
-	int body_start[NBODY_MAX_BODIES];
-	int body_count_v[NBODY_MAX_BODIES];
+	/* Track per-body start offsets and vertex counts for batched draw.
+	 * glMultiDrawArrays draws N independent strips in one call. */
+	GLint body_start[NBODY_MAX_BODIES];
+	GLsizei body_count_v[NBODY_MAX_BODIES];
 	int active_bodies = 0;
 
 	{
@@ -299,13 +299,13 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 	/* Read depth but don't write — trails are transparent overlay */
 	glDepthMask(GL_FALSE);
 
-	/* Draw each body's trail as a separate triangle strip */
+	/* Draw all body trails in a single batched call.
+	 * glMultiDrawArrays draws N independent triangle strips without
+	 * degenerate vertices or per-strip driver overhead. */
 	{
 		PROFILE_ZONE(draw_ctx, "Trail Draw Calls");
-		for (int i = 0; i < active_bodies; i++) {
-			glDrawArrays(GL_TRIANGLE_STRIP, body_start[i],
-			             body_count_v[i]);
-		}
+		glMultiDrawArrays(GL_TRIANGLE_STRIP, body_start, body_count_v,
+		                  active_bodies);
 		PROFILE_ZONE_END(draw_ctx);
 	}
 

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -1,0 +1,291 @@
+#include "trail_renderer.h"
+
+#include "gl_common.h"
+#include "log.h"
+#include "shader.h"
+#include "utils.h"
+#include <cglm/vec3.h>
+#include <string.h>
+
+/* Maximum ribbon vertices: each body can produce up to
+ * (TRAIL_MAX_POINTS - 1) segments × 2 vertices + 2 degenerate = ~514.
+ * With NBODY_MAX_BODIES=16: 16 × 514 = 8224 vertices.
+ * Each vertex is 32 bytes → ~256 KB. Trivially small. */
+enum { MAX_TRAIL_VERTICES = NBODY_MAX_BODIES * ((TRAIL_MAX_POINTS * 2) + 4) };
+
+static const float EPSILON = 1e-6F;
+static const float MIN_BODY_RADIUS = 0.3F;
+static const float HALF = 0.5F;
+
+/* ---------------------------------------------------------------------------
+ * Ring buffer helpers
+ * ---------------------------------------------------------------------------*/
+
+static void ring_push(TrailRing* ring, const vec3 pos)
+{
+	ring->head = (ring->head + 1) % TRAIL_MAX_POINTS;
+	glm_vec3_copy((float*)pos, ring->points[ring->head]);
+	if (ring->count < TRAIL_MAX_POINTS) {
+		ring->count++;
+	}
+}
+
+static void ring_get(const TrailRing* ring, int age, vec3 out)
+{
+	int idx = (ring->head - age + TRAIL_MAX_POINTS) % TRAIL_MAX_POINTS;
+	out[0] = ring->points[idx][0];
+	out[1] = ring->points[idx][1];
+	out[2] = ring->points[idx][2];
+}
+
+/* ---------------------------------------------------------------------------
+ * Init / Cleanup
+ * ---------------------------------------------------------------------------*/
+
+bool trail_renderer_init(TrailRenderer* trail, int body_count)
+{
+	(void)safe_memset(trail, sizeof(*trail), 0, sizeof(*trail));
+	trail->body_count = body_count;
+
+	/* Load trail shader */
+	trail->shader = shader_load("shaders/trail.vert", "shaders/trail.frag");
+	if (!trail->shader) {
+		LOG_ERROR("suckless-ogl.trail", "Failed to load trail shader");
+		return false;
+	}
+
+	/* Create VAO + dynamic VBO */
+	glGenVertexArrays(1, &trail->vao);
+	glGenBuffers(1, &trail->vbo);
+
+	glBindVertexArray(trail->vao);
+	glBindBuffer(GL_ARRAY_BUFFER, trail->vbo);
+	glBufferData(GL_ARRAY_BUFFER,
+	             (GLsizeiptr)(MAX_TRAIL_VERTICES * sizeof(TrailVertex)),
+	             NULL, GL_STREAM_DRAW);
+
+	/* Attribute 0: position (vec3) + u (float) — packed as vec4 */
+	const GLsizei stride = (GLsizei)sizeof(TrailVertex);
+	glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, stride, NULL);
+	glEnableVertexAttribArray(0);
+
+	/* Attribute 1: color (vec3) + v (float) — packed as vec4 */
+	const size_t color_offset = offsetof(TrailVertex, color);
+	glVertexAttribPointer(
+	    1, 4, GL_FLOAT, GL_FALSE, stride,
+	    (const void*)color_offset);  // NOLINT(performance-no-int-to-ptr)
+	glEnableVertexAttribArray(1);
+
+	glBindVertexArray(0);
+
+	return true;
+}
+
+void trail_renderer_set_color(TrailRenderer* trail, int body_index,
+                              const vec3 color)
+{
+	if (body_index >= 0 && body_index < NBODY_MAX_BODIES) {
+		glm_vec3_copy((float*)color, trail->colors[body_index]);
+	}
+}
+
+void trail_renderer_cleanup(TrailRenderer* trail)
+{
+	GL_SAFE_DELETE_BUFFER(trail->vbo);
+	GL_SAFE_DELETE_VAO(trail->vao);
+	if (trail->shader) {
+		shader_destroy(trail->shader);
+		trail->shader = NULL;
+	}
+}
+
+void trail_renderer_clear(TrailRenderer* trail)
+{
+	for (int i = 0; i < trail->body_count; i++) {
+		trail->rings[i].head = 0;
+		trail->rings[i].count = 0;
+	}
+	trail->sample_timer = 0.0F;
+}
+
+/* ---------------------------------------------------------------------------
+ * Record positions (rate-limited)
+ * ---------------------------------------------------------------------------*/
+
+void trail_renderer_record(TrailRenderer* trail, const NBodySim* sim,
+                           float delta_time)
+{
+	trail->sample_timer += delta_time;
+	if (trail->sample_timer < TRAIL_SAMPLE_INTERVAL) {
+		return;
+	}
+	trail->sample_timer -= TRAIL_SAMPLE_INTERVAL;
+
+	for (int i = 0; i < sim->body_count && i < trail->body_count; i++) {
+		ring_push(&trail->rings[i], sim->bodies[i].position);
+	}
+}
+
+/* ---------------------------------------------------------------------------
+ * Ribbon geometry builder
+ *
+ * For each body's trail, generate a camera-facing triangle strip:
+ * - Two vertices per trail point, offset perpendicular to both the
+ *   trail direction and the camera-to-point vector.
+ * - Width tapers from TRAIL_MAX_WIDTH at head to 0 at tail.
+ * - UV coordinates: U = age (0=head, 1=tail), V = side (0 or 1).
+ * ---------------------------------------------------------------------------*/
+
+static int build_ribbon(const TrailRing* ring, const vec3 color,
+                        const vec3 cam_pos, float body_radius, TrailVertex* out)
+{
+	if (ring->count < 3) {
+		return 0;
+	}
+
+	int vcount = 0;
+	const int num_pts = ring->count;
+	const float inv_n = 1.0F / (float)(num_pts - 1);
+
+	for (int idx = 0; idx < num_pts - 1; idx++) {
+		vec3 pos_cur;
+		vec3 pos_next;
+		ring_get(ring, idx, pos_cur);
+		ring_get(ring, idx + 1, pos_next);
+
+		/* Trail segment direction */
+		vec3 seg_dir;
+		glm_vec3_sub(pos_next, pos_cur, seg_dir);
+		float seg_len = glm_vec3_norm(seg_dir);
+		if (seg_len < EPSILON) {
+			continue;
+		}
+		glm_vec3_scale(seg_dir, 1.0F / seg_len, seg_dir);
+
+		/* Camera-facing perpendicular (billboard) */
+		vec3 to_cam;
+		glm_vec3_sub((float*)cam_pos, pos_cur, to_cam);
+		glm_vec3_normalize(to_cam);
+
+		vec3 side;
+		glm_vec3_cross(seg_dir, to_cam, side);
+		float side_len = glm_vec3_norm(side);
+		if (side_len < EPSILON) {
+			/* Segment points directly at camera — use fallback */
+			vec3 up_dir = {0.0F, 1.0F, 0.0F};
+			glm_vec3_cross(seg_dir, up_dir, side);
+			side_len = glm_vec3_norm(side);
+			if (side_len < EPSILON) {
+				vec3 right_dir = {1.0F, 0.0F, 0.0F};
+				glm_vec3_cross(seg_dir, right_dir, side);
+				side_len = glm_vec3_norm(side);
+			}
+		}
+		if (side_len > EPSILON) {
+			glm_vec3_scale(side, 1.0F / side_len, side);
+		}
+
+		/* Age factor: 0 = newest (head), 1 = oldest (tail) */
+		float age = (float)idx * inv_n;
+
+		/* Width: cubic taper, scaled by body radius for
+		 * proportional trails. Minimum radius clamp. */
+		float base_width =
+		    TRAIL_MAX_WIDTH * fmaxf(body_radius, MIN_BODY_RADIUS);
+		float width = base_width * (1.0F - (age * age * age));
+
+		/* HDR color with quadratic intensity fade */
+		float intensity = (1.0F - age) * (1.0F - age);
+		vec3 hdr_color;
+		glm_vec3_scale((float*)color, TRAIL_HDR_INTENSITY * intensity,
+		               hdr_color);
+
+		/* Left vertex (v=0) */
+		TrailVertex* vtx_left = &out[vcount++];
+		glm_vec3_add(
+		    pos_cur,
+		    (vec3){side[0] * width, side[1] * width, side[2] * width},
+		    vtx_left->position);
+		vtx_left->u = age;
+		glm_vec3_copy(hdr_color, vtx_left->color);
+		vtx_left->v = 0.0F;
+
+		/* Right vertex (v=1) */
+		TrailVertex* vtx_right = &out[vcount++];
+		glm_vec3_sub(
+		    pos_cur,
+		    (vec3){side[0] * width, side[1] * width, side[2] * width},
+		    vtx_right->position);
+		vtx_right->u = age;
+		glm_vec3_copy(hdr_color, vtx_right->color);
+		vtx_right->v = 1.0F;
+	}
+
+	return vcount;
+}
+
+/* ---------------------------------------------------------------------------
+ * Draw
+ * ---------------------------------------------------------------------------*/
+
+void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
+                         vec3 cam_pos)
+{
+	/* Build all ribbon geometry into a staging buffer */
+	static TrailVertex staging[MAX_TRAIL_VERTICES];
+	int total_verts = 0;
+
+	/* Track per-body start offsets for separate draw calls
+	 * (triangle strips can't be concatenated without degenerates). */
+	int body_start[NBODY_MAX_BODIES];
+	int body_count_v[NBODY_MAX_BODIES];
+	int active_bodies = 0;
+
+	for (int i = 0; i < trail->body_count; i++) {
+		int start = total_verts;
+		int vcount =
+		    build_ribbon(&trail->rings[i], trail->colors[i], cam_pos,
+		                 1.0F, /* body_radius — could be passed in */
+		                 &staging[total_verts]);
+		if (vcount > 0) {
+			body_start[active_bodies] = start;
+			body_count_v[active_bodies] = vcount;
+			active_bodies++;
+			total_verts += vcount;
+		}
+	}
+
+	if (total_verts == 0) {
+		return;
+	}
+
+	/* Upload to GPU */
+	glBindBuffer(GL_ARRAY_BUFFER, trail->vbo);
+	glBufferSubData(GL_ARRAY_BUFFER, 0,
+	                (GLsizeiptr)(total_verts * sizeof(TrailVertex)),
+	                staging);
+
+	/* Set rendering state */
+	shader_use(trail->shader);
+	shader_set_mat4(trail->shader, "u_view", (const float*)view);
+	shader_set_mat4(trail->shader, "u_proj", (const float*)proj);
+
+	glBindVertexArray(trail->vao);
+
+	/* Additive blending — trails glow and accumulate */
+	glEnable(GL_BLEND);
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+
+	/* Read depth but don't write — trails are transparent overlay */
+	glDepthMask(GL_FALSE);
+
+	/* Draw each body's trail as a separate triangle strip */
+	for (int i = 0; i < active_bodies; i++) {
+		glDrawArrays(GL_TRIANGLE_STRIP, body_start[i], body_count_v[i]);
+	}
+
+	/* Restore state */
+	glDepthMask(GL_TRUE);
+	glDisable(GL_BLEND);
+	glBindVertexArray(0);
+}

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -2,6 +2,7 @@
 
 #include "gl_common.h"
 #include "log.h"
+#include "profiler.h"
 #include "shader.h"
 #include "utils.h"
 #include <cglm/vec3.h>
@@ -248,29 +249,37 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 	int body_count_v[NBODY_MAX_BODIES];
 	int active_bodies = 0;
 
-	for (int i = 0; i < trail->body_count; i++) {
-		int start = total_verts;
-		int vcount =
-		    build_ribbon(&trail->rings[i], trail->colors[i], cam_pos,
-		                 1.0F, /* body_radius — could be passed in */
-		                 &staging[total_verts]);
-		if (vcount > 0) {
-			body_start[active_bodies] = start;
-			body_count_v[active_bodies] = vcount;
-			active_bodies++;
-			total_verts += vcount;
+	{
+		PROFILE_ZONE(ribbon_ctx, "Trail Ribbon Build");
+		for (int i = 0; i < trail->body_count; i++) {
+			int start = total_verts;
+			int vcount = build_ribbon(
+			    &trail->rings[i], trail->colors[i], cam_pos,
+			    1.0F, /* body_radius — could be passed in */
+			    &staging[total_verts]);
+			if (vcount > 0) {
+				body_start[active_bodies] = start;
+				body_count_v[active_bodies] = vcount;
+				active_bodies++;
+				total_verts += vcount;
+			}
 		}
+		PROFILE_ZONE_END(ribbon_ctx);
 	}
 
 	if (total_verts == 0) {
 		return;
 	}
 
-	/* Upload to GPU */
-	glBindBuffer(GL_ARRAY_BUFFER, trail->vbo);
-	glBufferSubData(GL_ARRAY_BUFFER, 0,
-	                (GLsizeiptr)(total_verts * sizeof(TrailVertex)),
-	                staging);
+	/* Upload ribbon geometry to GPU */
+	{
+		PROFILE_ZONE(upload_ctx, "Trail VBO Upload");
+		glBindBuffer(GL_ARRAY_BUFFER, trail->vbo);
+		glBufferSubData(GL_ARRAY_BUFFER, 0,
+		                (GLsizeiptr)(total_verts * sizeof(TrailVertex)),
+		                staging);
+		PROFILE_ZONE_END(upload_ctx);
+	}
 
 	/* Set rendering state */
 	shader_use(trail->shader);
@@ -287,8 +296,13 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 	glDepthMask(GL_FALSE);
 
 	/* Draw each body's trail as a separate triangle strip */
-	for (int i = 0; i < active_bodies; i++) {
-		glDrawArrays(GL_TRIANGLE_STRIP, body_start[i], body_count_v[i]);
+	{
+		PROFILE_ZONE(draw_ctx, "Trail Draw Calls");
+		for (int i = 0; i < active_bodies; i++) {
+			glDrawArrays(GL_TRIANGLE_STRIP, body_start[i],
+			             body_count_v[i]);
+		}
+		PROFILE_ZONE_END(draw_ctx);
 	}
 
 	/* Restore state */

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -115,14 +115,21 @@ void trail_renderer_clear(TrailRenderer* trail)
 void trail_renderer_record(TrailRenderer* trail, const NBodySim* sim,
                            float delta_time)
 {
-	trail->sample_timer += delta_time;
-	if (trail->sample_timer < TRAIL_SAMPLE_INTERVAL) {
-		return;
-	}
-	trail->sample_timer -= TRAIL_SAMPLE_INTERVAL;
+	/* Scale sampling rate by time_scale so trail length in world units
+	 * stays constant regardless of simulation speed.  At 8× speed the
+	 * bodies move 8× faster, so we sample 8× more often — the ring
+	 * buffer evicts old points at the same *visual* pace. */
+	float effective_dt = delta_time * sim->time_scale;
+	trail->sample_timer += effective_dt;
 
-	for (int i = 0; i < sim->body_count && i < trail->body_count; i++) {
-		ring_push(&trail->rings[i], sim->bodies[i].position);
+	/* Emit as many sub-samples as needed (catches large time_scale
+	 * jumps that skip multiple intervals in a single frame). */
+	while (trail->sample_timer >= TRAIL_SAMPLE_INTERVAL) {
+		trail->sample_timer -= TRAIL_SAMPLE_INTERVAL;
+		for (int i = 0; i < sim->body_count && i < trail->body_count;
+		     i++) {
+			ring_push(&trail->rings[i], sim->bodies[i].position);
+		}
 	}
 }
 

--- a/tests/test_billboard_cleanup.c
+++ b/tests/test_billboard_cleanup.c
@@ -17,11 +17,13 @@
 
 void render_utils_setup_sphere_instance_attributes(GLsizei stride,
                                                    size_t offset_albedo,
-                                                   size_t offset_metallic)
+                                                   size_t offset_metallic,
+                                                   size_t offset_prev_center)
 {
 	(void)stride;
 	(void)offset_albedo;
 	(void)offset_metallic;
+	(void)offset_prev_center;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/tests/test_billboard_overflow.c
+++ b/tests/test_billboard_overflow.c
@@ -9,11 +9,13 @@
 /* Mock render_utils function */
 void render_utils_setup_sphere_instance_attributes(GLsizei stride,
                                                    size_t offset_albedo,
-                                                   size_t offset_metallic)
+                                                   size_t offset_metallic,
+                                                   size_t offset_prev_center)
 {
 	(void)stride;
 	(void)offset_albedo;
 	(void)offset_metallic;
+	(void)offset_prev_center;
 }
 
 #ifndef SYNC_ATTR_START

--- a/tests/test_gamepad_input.c
+++ b/tests/test_gamepad_input.c
@@ -1,5 +1,6 @@
 #include "camera.h"
 #include "gamepad_input.h"
+#include "log.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
 #include <math.h>
@@ -7,7 +8,7 @@
 #include <string.h>
 
 /* ---- Stub for log_message (avoids linking log.c + platform deps) ---- */
-void log_message(int level, const char* tag, const char* fmt, ...)
+void log_message(LogLevel level, const char* tag, const char* fmt, ...)
 {
 	(void)level;
 	(void)tag;

--- a/tests/test_nbody_stability.c
+++ b/tests/test_nbody_stability.c
@@ -1,0 +1,375 @@
+/**
+ * @file test_nbody_stability.c
+ * @brief N-body physics stability tests — pure CPU, no GPU required.
+ *
+ * Runs the simulation for long periods (hundreds of simulated seconds)
+ * at maximum speed and verifies invariants:
+ * - Total energy stays bounded (symplectic integrator conservation).
+ * - Center of mass does not drift.
+ * - No body escapes to infinity.
+ * - Body count remains constant.
+ */
+
+#include "nbody.h"
+#include "unity.h"
+#include <math.h>
+#include <stdio.h>
+
+/* ---------------------------------------------------------------------------
+ * Test parameters
+ * ---------------------------------------------------------------------------*/
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+/** Simulated time for the long-run test (seconds). */
+static const float SIM_DURATION = 1200.0F;
+
+/** Maximum allowed energy drift ratio: |E - E0| / |E0|. */
+static const float MAX_ENERGY_DRIFT = 0.05F;
+
+/** Maximum allowed center-of-mass drift (absolute distance). */
+static const float MAX_COM_DRIFT = 0.5F;
+
+/** Maximum allowed distance of any body from origin. */
+static const float MAX_BODY_DISTANCE = 50.0F;
+
+/** Wall-clock delta fed to nbody_step each iteration. */
+static const float STEP_DT = 1.0F / 60.0F;
+
+/** Progress report interval in simulated seconds. */
+static const float REPORT_INTERVAL = 60.0F;
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+/* ---------------------------------------------------------------------------
+ * Helpers
+ * ---------------------------------------------------------------------------*/
+
+static void compute_center_of_mass(const NBodySim* sim, float out[3])
+{
+	out[0] = 0.0F;
+	out[1] = 0.0F;
+	out[2] = 0.0F;
+	float total_mass = 0.0F;
+	for (int i = 0; i < sim->body_count; i++) {
+		for (int k = 0; k < 3; k++) {
+			out[k] +=
+			    sim->bodies[i].mass * sim->bodies[i].position[k];
+		}
+		total_mass += sim->bodies[i].mass;
+	}
+	for (int k = 0; k < 3; k++) {
+		out[k] /= total_mass;
+	}
+}
+
+static float vec3_length(const float v[3])
+{
+	return sqrtf(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+}
+
+static float max_body_distance(const NBodySim* sim)
+{
+	float max_dist = 0.0F;
+	for (int i = 0; i < sim->body_count; i++) {
+		float dist = vec3_length(sim->bodies[i].position);
+		if (dist > max_dist) {
+			max_dist = dist;
+		}
+	}
+	return max_dist;
+}
+
+/** Distance of each satellite (body 1..N) from the central star (body 0). */
+static void distances_from_star(const NBodySim* sim, float* out)
+{
+	for (int i = 1; i < sim->body_count; i++) {
+		float diff[3] = {
+		    sim->bodies[i].position[0] - sim->bodies[0].position[0],
+		    sim->bodies[i].position[1] - sim->bodies[0].position[1],
+		    sim->bodies[i].position[2] - sim->bodies[0].position[2]};
+		out[i - 1] = vec3_length(diff);
+	}
+}
+
+/* ---------------------------------------------------------------------------
+ * Tests
+ * ---------------------------------------------------------------------------*/
+
+/**
+ * Long-run stability: simulate 1200s of physics and check invariants.
+ */
+void test_nbody_long_run_stability(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+
+	const int initial_count = sim.body_count;
+	const float initial_energy = nbody_total_energy(&sim);
+
+	float com_initial[3];
+	compute_center_of_mass(&sim, com_initial);
+
+	/* Record initial distances from star for each satellite. */
+	float dist_initial[NBODY_MAX_BODIES];
+	distances_from_star(&sim, dist_initial);
+
+	/* Track peak distance per body across the entire run. */
+	float dist_peak[NBODY_MAX_BODIES];
+	for (int i = 0; i < initial_count - 1; i++) {
+		dist_peak[i] = dist_initial[i];
+	}
+
+	float sim_time = 0.0F;
+	float next_report = REPORT_INTERVAL;
+
+	printf(
+	    "\n  [nbody stability] E0 = %.4f, bodies = %d, "
+	    "simulating %.0fs...\n",
+	    (double)initial_energy, initial_count, (double)SIM_DURATION);
+
+	while (sim_time < SIM_DURATION) {
+		nbody_step(&sim, STEP_DT);
+		sim_time += STEP_DT;
+
+		/* Update peak distances from star. */
+		float dist_cur[NBODY_MAX_BODIES];
+		distances_from_star(&sim, dist_cur);
+		for (int i = 0; i < initial_count - 1; i++) {
+			if (dist_cur[i] > dist_peak[i]) {
+				dist_peak[i] = dist_cur[i];
+			}
+		}
+
+		if (sim_time >= next_report) {
+			float energy = nbody_total_energy(&sim);
+			float drift = fabsf(energy - initial_energy) /
+			              (fabsf(initial_energy) + 1e-10F);
+			float com[3];
+			compute_center_of_mass(&sim, com);
+			float com_dist = vec3_length(com);
+
+			printf(
+			    "  [%6.0fs] E=%.4f (drift=%.4f%%) "
+			    "CoM=%.4f  d_star=",
+			    (double)sim_time, (double)energy,
+			    (double)(drift * 100.0F), (double)com_dist);
+			for (int i = 0; i < initial_count - 1; i++) {
+				printf("%.1f ", (double)dist_cur[i]);
+			}
+			printf("\n");
+
+			next_report += REPORT_INTERVAL;
+		}
+	}
+
+	/* --- Assertions --- */
+	float final_energy = nbody_total_energy(&sim);
+	float energy_drift = fabsf(final_energy - initial_energy) /
+	                     (fabsf(initial_energy) + 1e-10F);
+
+	float com_final[3];
+	compute_center_of_mass(&sim, com_final);
+	float com_shift[3] = {com_final[0] - com_initial[0],
+	                      com_final[1] - com_initial[1],
+	                      com_final[2] - com_initial[2]};
+	float com_drift = vec3_length(com_shift);
+
+	float farthest = max_body_distance(&sim);
+
+	/* Per-body distances from star at the end. */
+	float dist_final[NBODY_MAX_BODIES];
+	distances_from_star(&sim, dist_final);
+
+	printf(
+	    "  [FINAL] E_drift=%.4f%%  CoM_drift=%.4f  "
+	    "max_r=%.2f  bodies=%d\n",
+	    (double)(energy_drift * 100.0F), (double)com_drift,
+	    (double)farthest, sim.body_count);
+
+	printf("  [DISTANCES from star]  initial → peak → final\n");
+	for (int i = 0; i < initial_count - 1; i++) {
+		printf("    body %d: %6.2f → %6.2f → %6.2f\n", i + 1,
+		       (double)dist_initial[i], (double)dist_peak[i],
+		       (double)dist_final[i]);
+	}
+
+	TEST_ASSERT_EQUAL_INT_MESSAGE(initial_count, sim.body_count,
+	                              "Body count changed during simulation");
+
+	TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(
+	    MAX_ENERGY_DRIFT, energy_drift,
+	    "Energy drifted beyond acceptable threshold");
+
+	TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(
+	    MAX_COM_DRIFT, com_drift,
+	    "Center of mass drifted beyond acceptable threshold");
+
+	TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(
+	    MAX_BODY_DISTANCE, farthest,
+	    "A body escaped beyond maximum allowed distance");
+
+	/* Per-body: peak distance should not exceed MAX_BODY_DISTANCE. */
+	for (int i = 0; i < initial_count - 1; i++) {
+		char msg[80];  // NOLINT(readability-magic-numbers)
+		(void)snprintf(msg, sizeof(msg),
+		               "Body %d peak distance %.1f exceeds limit",
+		               i + 1, (double)dist_peak[i]);
+		TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(MAX_BODY_DISTANCE,
+		                                    dist_peak[i], msg);
+	}
+}
+
+/**
+ * Quick check: single step does not crash or produce NaN.
+ */
+void test_nbody_single_step_sanity(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+
+	nbody_step(&sim, STEP_DT);
+
+	for (int i = 0; i < sim.body_count; i++) {
+		for (int k = 0; k < 3; k++) {
+			TEST_ASSERT_FALSE_MESSAGE(
+			    isnan(sim.bodies[i].position[k]),
+			    "NaN in body position after single step");
+			TEST_ASSERT_FALSE_MESSAGE(
+			    isnan(sim.bodies[i].velocity[k]),
+			    "NaN in body velocity after single step");
+			TEST_ASSERT_FALSE_MESSAGE(
+			    isinf(sim.bodies[i].position[k]),
+			    "Inf in body position after single step");
+			TEST_ASSERT_FALSE_MESSAGE(
+			    isinf(sim.bodies[i].velocity[k]),
+			    "Inf in body velocity after single step");
+		}
+	}
+}
+
+/**
+ * Verify symplectic energy conservation: even after a velocity
+ * perturbation, the integrator keeps energy bounded over time
+ * (no secular growth). With no energy clamp, this validates that
+ * the pure Hamiltonian integrator handles perturbations gracefully.
+ */
+void test_nbody_energy_conservation(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+
+	float energy_before = nbody_total_energy(&sim);
+
+	/* Boost body 1 velocity to inject energy */
+	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+	sim.bodies[1].velocity[0] += 10.0F;
+	sim.bodies[1].velocity[1] += 10.0F;
+	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+	float energy_boosted = nbody_total_energy(&sim);
+	TEST_ASSERT_GREATER_THAN_FLOAT(energy_before, energy_boosted);
+
+	/* Run 120 steps — energy should remain near the boosted level
+	 * (symplectic: bounded oscillation, no secular drift). */
+	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+	for (int i = 0; i < 120; i++) {
+		nbody_step(&sim, STEP_DT);
+	}
+	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+	float energy_after = nbody_total_energy(&sim);
+	printf("  [conservation] E0=%.2f  boosted=%.2f  after=%.2f\n",
+	       (double)energy_before, (double)energy_boosted,
+	       (double)energy_after);
+
+	/* Energy should stay close to the boosted level (new E0 of the
+	 * perturbed system). Drift from boosted should be small. */
+	float drift = fabsf(energy_after - energy_boosted) /
+	              (fabsf(energy_boosted) + 1e-10F);
+	TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(
+	    0.20F, drift, "Energy drifted significantly from perturbed level");
+}
+
+/**
+ * Paused simulation should not change state.
+ */
+void test_nbody_paused_no_change(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+
+	float pos_before[3] = {sim.bodies[1].position[0],
+	                       sim.bodies[1].position[1],
+	                       sim.bodies[1].position[2]};
+
+	sim.paused = true;
+	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+	for (int i = 0; i < 1000; i++) {
+		nbody_step(&sim, STEP_DT);
+	}
+	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+	TEST_ASSERT_EQUAL_FLOAT(pos_before[0], sim.bodies[1].position[0]);
+	TEST_ASSERT_EQUAL_FLOAT(pos_before[1], sim.bodies[1].position[1]);
+	TEST_ASSERT_EQUAL_FLOAT(pos_before[2], sim.bodies[1].position[2]);
+}
+
+/**
+ * Simulate what happens in the real app: large dt spikes (first frame,
+ * window resize, lag). Before the accumulator cap, these caused runaway
+ * integration that ejected light bodies.
+ */
+void test_nbody_survives_dt_spikes(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+
+	/* Simulate a realistic app session:
+	 * - 1 huge spike (first frame: 0.5s)
+	 * - then normal frames at 60fps for 60s */
+	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+	nbody_step(&sim, 0.5F); /* Lag spike */
+	nbody_step(&sim, 0.2F); /* Another spike */
+	for (int i = 0; i < 3600; i++) {
+		nbody_step(&sim, STEP_DT);
+	}
+	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+	float dist_star[NBODY_MAX_BODIES];
+	distances_from_star(&sim, dist_star);
+
+	printf(
+	    "  [spike] after 0.5s+0.2s spikes + 60s normal: "
+	    "d_star=");
+	for (int i = 0; i < sim.body_count - 1; i++) {
+		printf("%.1f ", (double)dist_star[i]);
+	}
+	printf("\n");
+
+	/* No body should have escaped. */
+	for (int i = 0; i < sim.body_count - 1; i++) {
+		TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(
+		    MAX_BODY_DISTANCE, dist_star[i],
+		    "Body escaped after dt spike");
+	}
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_nbody_single_step_sanity);
+	RUN_TEST(test_nbody_energy_conservation);
+	RUN_TEST(test_nbody_paused_no_change);
+	RUN_TEST(test_nbody_survives_dt_spikes);
+	RUN_TEST(test_nbody_long_run_stability);
+	return UNITY_END();
+}

--- a/tests/test_nbody_stability.c
+++ b/tests/test_nbody_stability.c
@@ -363,6 +363,79 @@ void test_nbody_survives_dt_spikes(void)
 	}
 }
 
+/**
+ * Verify nbody_kinetic_energy returns a positive value after init.
+ */
+void test_nbody_kinetic_energy_positive(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+
+	float kin = nbody_kinetic_energy(&sim);
+	TEST_ASSERT_GREATER_THAN_FLOAT(0.0F, kin);
+	printf("  [kinetic] Ek = %.4f J\n", (double)kin);
+}
+
+/**
+ * Verify initial_energy is stored and energy_drift starts near zero.
+ */
+void test_nbody_energy_drift_api(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+
+	/* E0 should be stored and non-zero */
+	TEST_ASSERT_NOT_EQUAL_FLOAT(0.0F, sim.initial_energy);
+
+	/* Drift at t=0 should be exactly 0 */
+	float drift = nbody_energy_drift(&sim);
+	TEST_ASSERT_FLOAT_WITHIN(1e-6F, 0.0F, drift);
+
+	/* After a few steps, drift should stay small (< 5%) */
+	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+	for (int i = 0; i < 600; i++) {
+		nbody_step(&sim, STEP_DT);
+	}
+	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+	drift = nbody_energy_drift(&sim);
+	printf("  [drift API] after 10s: drift = %.4f%%\n",
+	       (double)(drift * 100.0F));
+	TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(
+	    MAX_ENERGY_DRIFT, drift,
+	    "Energy drift API exceeded threshold after 10s");
+}
+
+/**
+ * Verify gravity=0 produces zero gravitational acceleration
+ * (bodies move in straight lines).
+ */
+void test_nbody_zero_gravity(void)
+{
+	NBodySim sim;
+	nbody_init_preset(&sim);
+	sim.gravity = 0.0F;
+
+	/* Record velocity of body 1 */
+	float vel_before[3] = {sim.bodies[1].velocity[0],
+	                       sim.bodies[1].velocity[1],
+	                       sim.bodies[1].velocity[2]};
+
+	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+	for (int i = 0; i < 120; i++) {
+		nbody_step(&sim, STEP_DT);
+	}
+	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+	/* With G=0, velocity should be unchanged (no forces). */
+	TEST_ASSERT_FLOAT_WITHIN(1e-4F, vel_before[0],
+	                         sim.bodies[1].velocity[0]);
+	TEST_ASSERT_FLOAT_WITHIN(1e-4F, vel_before[1],
+	                         sim.bodies[1].velocity[1]);
+	TEST_ASSERT_FLOAT_WITHIN(1e-4F, vel_before[2],
+	                         sim.bodies[1].velocity[2]);
+}
+
 int main(void)
 {
 	UNITY_BEGIN();
@@ -370,6 +443,9 @@ int main(void)
 	RUN_TEST(test_nbody_energy_conservation);
 	RUN_TEST(test_nbody_paused_no_change);
 	RUN_TEST(test_nbody_survives_dt_spikes);
+	RUN_TEST(test_nbody_kinetic_energy_positive);
+	RUN_TEST(test_nbody_energy_drift_api);
+	RUN_TEST(test_nbody_zero_gravity);
 	RUN_TEST(test_nbody_long_run_stability);
 	return UNITY_END();
 }

--- a/tests/test_nbody_stability.c
+++ b/tests/test_nbody_stability.c
@@ -19,8 +19,6 @@
  * Test parameters
  * ---------------------------------------------------------------------------*/
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-
 /** Simulated time for the long-run test (seconds). */
 static const float SIM_DURATION = 1200.0F;
 
@@ -39,7 +37,25 @@ static const float STEP_DT = 1.0F / 60.0F;
 /** Progress report interval in simulated seconds. */
 static const float REPORT_INTERVAL = 60.0F;
 
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+/** Velocity boost for perturbation tests. */
+static const float VELOCITY_BOOST = 10.0F;
+
+/** Maximum drift from perturbed energy level (conservation test). */
+static const float CONSERVATION_MAX_DRIFT = 0.20F;
+
+/** Lag spike delta-time values (seconds). */
+static const float LAG_SPIKE_DT = 0.5F;
+static const float SECONDARY_SPIKE_DT = 0.2F;
+
+/** Iteration counts for various tests. */
+enum {
+	CONSERVATION_STEPS = 120,
+	PAUSE_TEST_STEPS = 1000,
+	SPIKE_NORMAL_STEPS = 3600,
+	DRIFT_API_STEPS = 600,
+	ZERO_GRAV_STEPS = 120,
+	MSG_BUF_SIZE = 80,
+};
 
 void setUp(void)
 {
@@ -219,7 +235,7 @@ void test_nbody_long_run_stability(void)
 
 	/* Per-body: peak distance should not exceed MAX_BODY_DISTANCE. */
 	for (int i = 0; i < initial_count - 1; i++) {
-		char msg[80];  // NOLINT(readability-magic-numbers)
+		char msg[MSG_BUF_SIZE];
 		(void)snprintf(msg, sizeof(msg),
 		               "Body %d peak distance %.1f exceeds limit",
 		               i + 1, (double)dist_peak[i]);
@@ -270,21 +286,17 @@ void test_nbody_energy_conservation(void)
 	float energy_before = nbody_total_energy(&sim);
 
 	/* Boost body 1 velocity to inject energy */
-	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-	sim.bodies[1].velocity[0] += 10.0F;
-	sim.bodies[1].velocity[1] += 10.0F;
-	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+	sim.bodies[1].velocity[0] += VELOCITY_BOOST;
+	sim.bodies[1].velocity[1] += VELOCITY_BOOST;
 
 	float energy_boosted = nbody_total_energy(&sim);
 	TEST_ASSERT_GREATER_THAN_FLOAT(energy_before, energy_boosted);
 
 	/* Run 120 steps — energy should remain near the boosted level
 	 * (symplectic: bounded oscillation, no secular drift). */
-	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-	for (int i = 0; i < 120; i++) {
+	for (int i = 0; i < CONSERVATION_STEPS; i++) {
 		nbody_step(&sim, STEP_DT);
 	}
-	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
 	float energy_after = nbody_total_energy(&sim);
 	printf("  [conservation] E0=%.2f  boosted=%.2f  after=%.2f\n",
@@ -296,7 +308,8 @@ void test_nbody_energy_conservation(void)
 	float drift = fabsf(energy_after - energy_boosted) /
 	              (fabsf(energy_boosted) + 1e-10F);
 	TEST_ASSERT_LESS_THAN_FLOAT_MESSAGE(
-	    0.20F, drift, "Energy drifted significantly from perturbed level");
+	    CONSERVATION_MAX_DRIFT, drift,
+	    "Energy drifted significantly from perturbed level");
 }
 
 /**
@@ -312,11 +325,9 @@ void test_nbody_paused_no_change(void)
 	                       sim.bodies[1].position[2]};
 
 	sim.paused = true;
-	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-	for (int i = 0; i < 1000; i++) {
+	for (int i = 0; i < PAUSE_TEST_STEPS; i++) {
 		nbody_step(&sim, STEP_DT);
 	}
-	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
 	TEST_ASSERT_EQUAL_FLOAT(pos_before[0], sim.bodies[1].position[0]);
 	TEST_ASSERT_EQUAL_FLOAT(pos_before[1], sim.bodies[1].position[1]);
@@ -336,13 +347,11 @@ void test_nbody_survives_dt_spikes(void)
 	/* Simulate a realistic app session:
 	 * - 1 huge spike (first frame: 0.5s)
 	 * - then normal frames at 60fps for 60s */
-	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-	nbody_step(&sim, 0.5F); /* Lag spike */
-	nbody_step(&sim, 0.2F); /* Another spike */
-	for (int i = 0; i < 3600; i++) {
+	nbody_step(&sim, LAG_SPIKE_DT);
+	nbody_step(&sim, SECONDARY_SPIKE_DT);
+	for (int i = 0; i < SPIKE_NORMAL_STEPS; i++) {
 		nbody_step(&sim, STEP_DT);
 	}
-	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
 	float dist_star[NBODY_MAX_BODIES];
 	distances_from_star(&sim, dist_star);
@@ -392,11 +401,9 @@ void test_nbody_energy_drift_api(void)
 	TEST_ASSERT_FLOAT_WITHIN(1e-6F, 0.0F, drift);
 
 	/* After a few steps, drift should stay small (< 5%) */
-	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-	for (int i = 0; i < 600; i++) {
+	for (int i = 0; i < DRIFT_API_STEPS; i++) {
 		nbody_step(&sim, STEP_DT);
 	}
-	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
 	drift = nbody_energy_drift(&sim);
 	printf("  [drift API] after 10s: drift = %.4f%%\n",
@@ -421,11 +428,9 @@ void test_nbody_zero_gravity(void)
 	                       sim.bodies[1].velocity[1],
 	                       sim.bodies[1].velocity[2]};
 
-	// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-	for (int i = 0; i < 120; i++) {
+	for (int i = 0; i < ZERO_GRAV_STEPS; i++) {
 		nbody_step(&sim, STEP_DT);
 	}
-	// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
 	/* With G=0, velocity should be unchanged (no forces). */
 	TEST_ASSERT_FLOAT_WITHIN(1e-4F, vel_before[0],

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -33,3 +33,17 @@
    fun:glfwInit
    ...
 }
+{
+   mesa_gallium_cond
+   Memcheck:Cond
+   ...
+   obj:*/libgallium*.so*
+   ...
+}
+{
+   mesa_gallium_leaks
+   Memcheck:Leak
+   ...
+   obj:*/libgallium*.so*
+   ...
+}


### PR DESCRIPTION
## Summary
<img width="1918" height="1199" alt="image" src="https://github.com/user-attachments/assets/5442dd1a-7c8d-4fa9-9d34-9092e687cc9c" />
<img width="1920" height="1171" alt="image" src="https://github.com/user-attachments/assets/40d0e381-7690-4744-a2bc-9c8e65756dbd" />

Add a real-time N-body gravity simulation sandbox with particle trail visualization to the rendering engine.

## Physics Engine

- **Velocity Verlet** integrator (symplectic, 2nd order) — bounded energy oscillation, no secular drift
- **Plummer softening** with adaptive per-pair epsilon: `ε² = max(NBODY_SOFTENING_SQ, (FACTOR·(r_i+r_j))²)`
- **Softened orbital velocity** for stable circular-orbit initial conditions: `v = r · √(G·M / (r²+ε²)^{3/2})`
- **Momentum zeroing** at init to eliminate center-of-mass drift
- **Fixed timestep** (1/120s) with accumulator for frame-rate independence
- **14-body preset** with data-driven initialization table
- Up to 64 particles with O(N²) pairwise gravity
- **Progressive time reversal** (Ctrl+Shift+G) — smooth time direction change

## Trail Renderer

- Ring-buffer trail renderer using `GL_TRIANGLE_STRIP` ribbon geometry
- Per-vertex alpha fade based on trail age with soft edge anti-aliasing
- Per-trail color inherited from particle with HDR core glow
- Dedicated shader pair (`trail.vert` / `trail.frag`)
- **Batched rendering**: single `glMultiDrawArrays` call replaces N individual `glDrawArrays` (14→1 draw call)
- GL debug labels (`Trail_VAO`, `Trail_VBO`) for RenderDoc observability

## Integration

- Scene graph integration: `NBodySim` + `TrailRenderer` lifecycle in `scene.h/.c`
- Input bindings: **N** (toggle), **P** (pause), **Ctrl+R** (reset), **Ctrl+Shift+G** (time reversal)
- Simulation speed: **,** / **.** keybindings with overlay notification
- Runtime gravity control: **Shift+,** / **Shift+.** with energy drift reset
- F2 keyboard overlay updated via `app_binding.c`
- AZERTY keyboard layout auto-detection for integration tests
- Per-object motion vectors in velocity buffer for motion blur
- N-body HUD overlay: energy, gravity, stability indicator, time reversal

## Test Suite

8 stability tests validating physics over **1200s simulated time** (144,000 steps):

| Test | Threshold | Actual |
|------|-----------|--------|
| Energy conservation | < 5% drift | **0.0017%** |
| Center-of-mass drift | < 0.5 | **0.001** |
| Max body distance | < 50 | **~19.6** |
| Pause preserves state | exact equality | ✅ |
| Large dt spike resilience | no crash/NaN | ✅ |
| Kinetic energy | > 0 | ✅ |
| Energy drift API | tracks delta | ✅ |
| Zero-gravity | no forces | ✅ |

## Profiling

- Fine-grained CPU zones: `NBody Physics`, `NBody Verlet`, `Trail Ribbon Build`, `Trail Draw Calls`
- GPU stage profiler: `Instanced Render`, `NBody Trails`
- Tracy auto-port detection (fallback when 8086 is occupied)

## Code Quality

- **Zero NOLINT suppressions** — all 29 removed with proper fixes
- CI guard script (`scripts/check_nolint.sh`) prevents future suppressions
- Pre-commit + pre-push + CI enforcement at all stages

## Documentation

- `docs/nbody_physics.md` / `.fr.md` — Physics reference, profiling zones, resource lifecycle
- `docs/renderdoc_guide.md` / `.fr.md` — Section 9: Pixel History troubleshooting, batch draw guide
- `docs/profiling_tracy.md` / `.fr.md` — N-body profiling zones updated for glMultiDrawArrays
- `docs/linting_strategy.md` / `.fr.md` — NOLINT no-suppression policy
- `docs/cicd_pipeline.md` / `.fr.md` — NOLINT CI guard documentation

## Quality Gate

- ✅ `just format` — clean
- ✅ `just lint` — 0 failures (clang-tidy + shellcheck + shader validation)
- ✅ `just test-all` — 61/62 pass (1 pre-existing BAD_COMMAND: `test_shader_path_security_standalone`)
- ✅ Pre-push hooks passed (format-check + lint)
- ✅ Zero NOLINT suppressions enforced
