### PR TITLE
fix(build): resolve Unity Build GL header conflict in gamepad_input

### DIFF
--- a/src/gamepad_input.c
+++ b/src/gamepad_input.c
@@ -2,6 +2,9 @@
 
 #include "camera.h"
 #include "log.h"
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
 #include <GLFW/glfw3.h>
 #include <math.h>
 

--- a/tests/test_gamepad_input.c
+++ b/tests/test_gamepad_input.c
@@ -1,5 +1,6 @@
 #include "camera.h"
 #include "gamepad_input.h"
+#include "log.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
 #include <math.h>
@@ -7,7 +8,7 @@
 #include <string.h>
 
 /* ---- Stub for log_message (avoids linking log.c + platform deps) ---- */
-void log_message(int level, const char* tag, const char* fmt, ...)
+void log_message(LogLevel level, const char* tag, const char* fmt, ...)
 {
 	(void)level;
 	(void)tag;


### PR DESCRIPTION
## Summary

Fix Unity Build (`build-ultra`) compilation failure caused by GLFW pulling system GL headers in `gamepad_input.c`, conflicting with glad's headers in the concatenated translation unit.

## Changes

- **`src/gamepad_input.c`**: Add `GLFW_INCLUDE_NONE` guard before `<GLFW/glfw3.h>` — this file only uses gamepad/joystick APIs, no GL calls
- **`tests/test_gamepad_input.c`**: Fix `log_message` stub signature (`int` → `LogLevel`) and add missing `log.h` include

## Validation

- `just build` ✅
- `just ultra-release` ✅ (was broken, now fixed)
- `just format` ✅
- `just lint` ✅ (0 warnings)
- `just test-all` ✅ (61/61)
