### PR TITLE
feat: GPU utilization monitor via DRM fdinfo (MangoHud-ISO)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(SOURCES
     src/gl_debug.c
     src/gpu_profiler.c
     src/gpu_profiler_ui.c
+    src/gpu_usage.c
     src/ibl_coordinator.c
     src/icosphere.c
     src/instanced_rendering.c

--- a/docs/gpu_usage_monitor.fr.md
+++ b/docs/gpu_usage_monitor.fr.md
@@ -1,0 +1,107 @@
+# Moniteur d'utilisation GPU
+
+Pourcentage d'utilisation GPU en temps réel via Linux DRM fdinfo — la même approche utilisée par [MangoHud](https://github.com/flightlessmango/MangoHud).
+
+## Vue d'ensemble
+
+Le moniteur d'utilisation GPU lit le temps moteur GPU par processus depuis `/proc/self/fdinfo/` et calcule l'utilisation comme un simple ratio de delta. Cela fournit une métrique GPU% légère, par processus, sans nécessiter de privilèges root ni d'outils externes.
+
+## Pilotes supportés
+
+| Pilote | Clé moteur | GPUs |
+|:---|:---|:---|
+| `i915` | `drm-engine-render` | Intel Gen9+ (HD 500/600, UHD, Iris Xe…) |
+| `xe` | `drm-engine-render` | Intel Arc / Xe discret & iGPUs récents |
+| `amdgpu` | `drm-engine-gfx` | AMD Radeon (GCN+, RDNA) |
+| `nouveau` | `drm-engine-gr` | NVIDIA (pilote open-source) |
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[gpu_usage_init] --> B[Scanner /proc/self/fdinfo/]
+    B --> C{Nœud de rendu DRM ?}
+    C -->|Oui| D[Lire drm-driver & drm-client-id]
+    C -->|Non| B
+    D --> E{client-id dupliqué ?}
+    E -->|Oui| B
+    E -->|Non| F[Garder le flux FILE* ouvert]
+    F --> B
+    B -->|Terminé| G[Stocker driver + engine_key]
+
+    H[gpu_usage_update] --> I{500ms écoulées ?}
+    I -->|Non| J[Retour immédiat]
+    I -->|Oui| K[Relire tous les flux]
+    K --> L[Sommer le temps moteur]
+    L --> M["GPU% = Δgpu / Δwall × 100"]
+    M --> N[Clamper 0–100%]
+```
+
+## Compatibilité MangoHud
+
+Cette implémentation est **ISO avec le chemin fdinfo de MangoHud** :
+
+- Même scan de `/proc/self/fdinfo/`
+- Même déduplication par `drm-client-id` (évite le double comptage des contextes partagés)
+- Même formule `delta_gpu_time / delta_wall_time × 100`
+- Même période de mise à jour de 500ms (`METRICS_UPDATE_PERIOD_MS`)
+- Aucun lissage ni moyenne supplémentaire (delta brut, identique à MangoHud)
+
+## Affichage HUD
+
+Lorsqu'un pilote supporté est détecté, l'overlay affiche :
+
+```text
+GPU: 63%
+```
+
+La métrique apparaît dans l'overlay d'informations principal (F1), sous la ligne FPS. Elle est masquée si aucun pilote DRM supporté n'est trouvé.
+
+## Référence API
+
+### `gpu_usage_init(GPUUsageMonitor* mon)`
+
+Scanne `/proc/self/fdinfo/` pour les descripteurs de fichiers des nœuds de rendu DRM. Ouvre des flux `FILE*` persistants pour une relecture efficace. Positionne `mon->available = true` si un pilote supporté est trouvé.
+
+### `gpu_usage_cleanup(GPUUsageMonitor* mon)`
+
+Ferme tous les flux fdinfo ouverts et réinitialise l'état du moniteur.
+
+### `gpu_usage_update(GPUUsageMonitor* mon)`
+
+Relit tous les flux fdinfo, somme le temps moteur et calcule le pourcentage de charge GPU basé sur le delta. Limité à des intervalles de 500ms. No-op si le moniteur n'est pas disponible.
+
+### `gpu_usage_get_load(const GPUUsageMonitor* mon)`
+
+Retourne la dernière charge GPU calculée (0.0–100.0), ou -1.0 si le moniteur n'est pas disponible.
+
+### `gpu_usage_is_available(const GPUUsageMonitor* mon)`
+
+Retourne `true` si un pilote DRM supporté a été détecté lors de l'initialisation.
+
+## Support des plateformes
+
+| Plateforme | Statut | Notes |
+|:---|:---:|:---|
+| Linux | ✅ | Support complet via DRM fdinfo |
+| Windows | ⊘ | Stub (no-op) : `available = false` |
+| macOS | ⊘ | Stub (no-op) : `available = false` |
+
+L'implémentation est protégée par `#ifdef __linux__`. Sur les plateformes non-Linux, `gpu_usage_init()` positionne `available = false` et affiche un avertissement. Toutes les autres fonctions sont des no-ops sûrs.
+
+## Intégration
+
+Le moniteur est intégré dans le cycle de vie de la structure `App` :
+
+```c
+// app.c
+app_init()  → gpu_usage_init(&app->gpu_usage)
+app_run()   → gpu_usage_update(&app->gpu_usage)   // dans la zone de mise à jour UI
+app_cleanup() → gpu_usage_cleanup(&app->gpu_usage)
+```
+
+## Voir aussi
+
+- [Profilage GPU](gpu_profiling.md) — Profilage par étapes basé sur GL Timer Query
+- [Optimisation de l'utilisation GPU](gpu_utilization_optimization.md) — Analyse d'optimisation avec les baselines MangoHud
+- [Guide de profilage](profiling_guide.md) — Vue d'ensemble du profilage

--- a/docs/gpu_usage_monitor.md
+++ b/docs/gpu_usage_monitor.md
@@ -1,0 +1,107 @@
+# GPU Usage Monitor
+
+Real-time GPU utilization percentage via Linux DRM fdinfo — the same approach used by [MangoHud](https://github.com/flightlessmango/MangoHud).
+
+## Overview
+
+The GPU Usage Monitor reads per-process GPU engine time from `/proc/self/fdinfo/` and computes utilization as a simple delta ratio. This provides a lightweight, per-process GPU% metric without requiring root privileges or external tools.
+
+## Supported Drivers
+
+| Driver | Engine Key | GPUs |
+|:---|:---|:---|
+| `i915` | `drm-engine-render` | Intel Gen9+ (HD 500/600, UHD, Iris Xe…) |
+| `xe` | `drm-engine-render` | Intel Arc / Xe discrete & newer iGPUs |
+| `amdgpu` | `drm-engine-gfx` | AMD Radeon (GCN+, RDNA) |
+| `nouveau` | `drm-engine-gr` | NVIDIA (open-source driver) |
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[gpu_usage_init] --> B[Scan /proc/self/fdinfo/]
+    B --> C{DRM render node?}
+    C -->|Yes| D[Read drm-driver & drm-client-id]
+    C -->|No| B
+    D --> E{Duplicate client-id?}
+    E -->|Yes| B
+    E -->|No| F[Keep FILE* stream open]
+    F --> B
+    B -->|Done| G[Store driver + engine_key]
+
+    H[gpu_usage_update] --> I{500ms elapsed?}
+    I -->|No| J[Return early]
+    I -->|Yes| K[Re-read all streams]
+    K --> L[Sum engine time across FDs]
+    L --> M["GPU% = Δgpu / Δwall × 100"]
+    M --> N[Clamp 0–100%]
+```
+
+## MangoHud Compatibility
+
+This implementation is **ISO with MangoHud's fdinfo codepath**:
+
+- Same `/proc/self/fdinfo/` scanning
+- Same `drm-client-id` deduplication (avoids double-counting shared contexts)
+- Same `delta_gpu_time / delta_wall_time × 100` formula
+- Same 500ms update period (`METRICS_UPDATE_PERIOD_MS`)
+- No additional smoothing or averaging (raw delta, same as MangoHud)
+
+## HUD Display
+
+When a supported driver is detected, the overlay shows:
+
+```text
+GPU: 63%
+```
+
+The metric appears in the main info overlay (F1), below the FPS line. It is hidden when no supported DRM driver is found.
+
+## API Reference
+
+### `gpu_usage_init(GPUUsageMonitor* mon)`
+
+Scans `/proc/self/fdinfo/` for DRM render node file descriptors. Opens persistent `FILE*` streams for efficient re-reading. Sets `mon->available = true` if a supported driver is found.
+
+### `gpu_usage_cleanup(GPUUsageMonitor* mon)`
+
+Closes all open fdinfo streams and resets the monitor state.
+
+### `gpu_usage_update(GPUUsageMonitor* mon)`
+
+Re-reads all fdinfo streams, sums engine time, and computes the delta-based GPU load percentage. Rate-limited to 500ms intervals. No-op if the monitor is unavailable.
+
+### `gpu_usage_get_load(const GPUUsageMonitor* mon)`
+
+Returns the last computed GPU load (0.0–100.0), or -1.0 if the monitor is unavailable.
+
+### `gpu_usage_is_available(const GPUUsageMonitor* mon)`
+
+Returns `true` if a supported DRM driver was detected during init.
+
+## Platform Support
+
+| Platform | Status | Notes |
+|:---|:---:|:---|
+| Linux | ✅ | Full support via DRM fdinfo |
+| Windows | ⊘ | Stub (no-op): `available = false` |
+| macOS | ⊘ | Stub (no-op): `available = false` |
+
+The implementation is guarded by `#ifdef __linux__`. On non-Linux platforms, `gpu_usage_init()` sets `available = false` and logs a warning. All other functions are safe no-ops.
+
+## Integration
+
+The monitor is integrated into the `App` struct lifecycle:
+
+```c
+// app.c
+app_init()  → gpu_usage_init(&app->gpu_usage)
+app_run()   → gpu_usage_update(&app->gpu_usage)   // in UI update zone
+app_cleanup() → gpu_usage_cleanup(&app->gpu_usage)
+```
+
+## See Also
+
+- [GPU Profiling](gpu_profiling.md) — GL Timer Query based stage profiling
+- [GPU Utilization Optimization](gpu_utilization_optimization.md) — Optimization analysis using MangoHud baselines
+- [Profiling Guide](profiling_guide.md) — General profiling overview

--- a/docs/linting_strategy.fr.md
+++ b/docs/linting_strategy.fr.md
@@ -112,7 +112,12 @@ Un garde automatisé (`scripts/check_nolint.sh`) applique cette règle à chaque
 
 ### Fonctionnement
 
-Le script compare `git diff <base_ref>...HEAD` sur les fichiers `*.c` et `*.h`, en cherchant les lignes ajoutées (`+`) contenant `NOLINT`. Si des occurrences sont trouvées, le check échoue avec la liste de toutes les violations.
+Le script vérifie les nouveaux ajouts de `NOLINT` dans les fichiers `*.c` et `*.h` avec une approche à deux niveaux :
+
+1. **Changements commités** : `git diff <base_ref>...HEAD` détecte les NOLINT dans le code déjà commité.
+2. **Changements stagés** : `git diff --cached <base_ref>` détecte les NOLINT dans le contenu sur le point d'être commité (index). C'est essentiel lors du `pre-commit`, où `HEAD` pointe encore sur le commit précédent et le contenu stagé serait autrement invisible.
+
+Lorsque des fichiers stagés existent, leur contenu final est comparé à la ref de base, gérant correctement les cas où les changements stagés *ajoutent* ou *suppriment* des suppressions NOLINT. Si des lignes NOLINT nettes sont trouvées, le check échoue avec la liste de toutes les violations.
 
 ```bash
 # Utilisation locale

--- a/docs/linting_strategy.md
+++ b/docs/linting_strategy.md
@@ -112,7 +112,12 @@ An automated guard (`scripts/check_nolint.sh`) enforces this at every stage of t
 
 ### How it Works
 
-The script compares `git diff <base_ref>...HEAD` on `*.c` and `*.h` files, searching for added lines (`+`) containing `NOLINT`. If any are found, the check fails with a listing of all violations.
+The script checks for new `NOLINT` additions in `*.c` and `*.h` files using a two-layer approach:
+
+1. **Committed changes**: `git diff <base_ref>...HEAD` detects NOLINT in already-committed code.
+2. **Staged changes**: `git diff --cached <base_ref>` detects NOLINT in content about to be committed (index). This is critical during `pre-commit`, where `HEAD` still points to the previous commit and staged content would otherwise be invisible.
+
+When staged files exist, their final content is compared against the base ref, correctly handling cases where staged changes *add* or *remove* NOLINT suppressions. If any net new NOLINT lines are found, the check fails with a listing of all violations.
 
 ```bash
 # Local usage

--- a/include/app.h
+++ b/include/app.h
@@ -15,6 +15,7 @@
 #include "gl_common.h"
 #include "gpu_profiler.h"
 #include "gpu_profiler_ui.h"
+#include "gpu_usage.h"
 #include "perf_mode.h"
 #include "postprocess.h"
 #include "scene.h"
@@ -69,7 +70,8 @@ typedef struct App {
 	PerfModeContext perf_context; /**< Performance mode state context. */
 	ActionNotifier notifier;      /**< Temporary user notifications. */
 	EffectBenchmark effect_bench; /**< A/B effect cost measurement. */
-	int log_gpu_metrics; /**< Toggle console logging of GPU stats. */
+	int log_gpu_metrics;       /**< Toggle console logging of GPU stats. */
+	GPUUsageMonitor gpu_usage; /**< GPU utilization % via DRM fdinfo. */
 
 	/* --- Global GPU Resources --- */
 	GLuint lum_ssbo[2];     /**< Double-buffered storage for luminance. */

--- a/include/gpu_usage.h
+++ b/include/gpu_usage.h
@@ -1,0 +1,66 @@
+#ifndef GPU_USAGE_H
+#define GPU_USAGE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+enum {
+	GPU_USAGE_MAX_FDS = 64,
+	GPU_USAGE_MAX_KEY_LEN = 48,
+};
+
+/**
+ * @struct GPUUsageMonitor
+ * @brief Reads GPU utilization % via Linux DRM fdinfo (same method as
+ * MangoHud).
+ *
+ * Scans /proc/self/fdinfo/ for DRM render node file descriptors,
+ * reads cumulative engine time (drm-engine-render for i915, drm-engine-gfx
+ * for amdgpu, etc.), and computes utilization as delta_gpu_time /
+ * delta_wall_time.
+ *
+ * Supported drivers: i915, xe, amdgpu, nouveau.
+ */
+typedef struct {
+	FILE* streams[GPU_USAGE_MAX_FDS];
+	int stream_count;
+
+	uint64_t prev_gpu_time_ns;
+	uint64_t prev_wall_time_ns;
+
+	float load_percent;
+	char driver[GPU_USAGE_MAX_KEY_LEN];
+	char engine_key[GPU_USAGE_MAX_KEY_LEN];
+
+	bool available;
+} GPUUsageMonitor;
+
+/**
+ * @brief Scans /proc/self/fdinfo/ and opens streams for GPU engine time
+ * reading.
+ */
+void gpu_usage_init(GPUUsageMonitor* mon);
+
+/**
+ * @brief Closes all open fdinfo streams.
+ */
+void gpu_usage_cleanup(GPUUsageMonitor* mon);
+
+/**
+ * @brief Re-reads fdinfo streams and computes GPU load %.
+ * Should be called periodically (e.g., every 500ms).
+ */
+void gpu_usage_update(GPUUsageMonitor* mon);
+
+/**
+ * @brief Returns the last computed GPU load (0.0–100.0).
+ */
+float gpu_usage_get_load(const GPUUsageMonitor* mon);
+
+/**
+ * @brief Returns true if a supported DRM driver was detected.
+ */
+bool gpu_usage_is_available(const GPUUsageMonitor* mon);
+
+#endif /* GPU_USAGE_H */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,7 @@ nav:
   - CPU Profiling (FlameGraph): cpu_profiling_flamegraph.md
   - GPU Profiling: gpu_profiling.md
   - GPU Utilization Optimization: gpu_utilization_optimization.md
+  - GPU Usage Monitor: gpu_usage_monitor.md
   - Effect Benchmark: effect_benchmark.md
   - Perf Troubleshooting: perf_profiling.md
   - Performance Benchmarking Protocol: perf_benchmarking_protocol.md

--- a/scripts/check_nolint.sh
+++ b/scripts/check_nolint.sh
@@ -25,7 +25,37 @@ DIFF_TMP=$(mktemp)
 NOLINT_TMP=$(mktemp)
 trap 'rm -f "${DIFF_TMP}" "${NOLINT_TMP}"' EXIT
 
-git -c color.diff=false diff "${BASE_REF}"...HEAD -- '*.c' '*.h' > "${DIFF_TMP}"
+# Build a combined diff that represents what CI will see:
+# 1. Committed changes: origin/master...HEAD
+# 2. Staged changes: what's about to be committed (--cached vs HEAD)
+# By merging both, we catch NOLINT in already-pushed commits AND in
+# the current staged content. Crucially, if staged changes *remove*
+# NOLINT from a previous commit, the staged diff cancels them out.
+#
+# Strategy: extract the final state of staged C/H files and diff
+# that against origin/master, rather than naively concatenating diffs.
+
+STAGED_C_FILES=$(git diff --cached --name-only --diff-filter=d -- '*.c' '*.h' || true)
+
+if [ -n "${STAGED_C_FILES}" ]; then
+    # For files that are staged, diff their staged content vs base ref.
+    # For all other files, use the regular HEAD-based diff.
+    # shellcheck disable=SC2086
+    git -c color.diff=false diff --cached "${BASE_REF}" -- ${STAGED_C_FILES} > "${DIFF_TMP}"
+
+    # Non-staged tracked files: regular diff
+    NON_STAGED=$(git -c color.diff=false diff "${BASE_REF}"...HEAD --name-only -- '*.c' '*.h' || true)
+    for f in ${NON_STAGED}; do
+        # Skip files that are staged (already handled above)
+        if echo "${STAGED_C_FILES}" | grep -qxF "${f}"; then
+            continue
+        fi
+        git -c color.diff=false diff "${BASE_REF}"...HEAD -- "${f}" >> "${DIFF_TMP}"
+    done
+else
+    # No staged C/H files — use the regular committed diff only.
+    git -c color.diff=false diff "${BASE_REF}"...HEAD -- '*.c' '*.h' > "${DIFF_TMP}"
+fi
 
 # Match added lines containing NOLINT (exclude diff header "+++" lines).
 grep -E '^\+[^+].*NOLINT' "${DIFF_TMP}" > "${NOLINT_TMP}" || true

--- a/src/app.c
+++ b/src/app.c
@@ -139,6 +139,7 @@ int app_init(App* app, int width, int height, const char* title)
 
 	gpu_profiler_init(&app->gpu_profiler);
 	gpu_profiler_ui_init(&app->timeline_ui);
+	gpu_usage_init(&app->gpu_usage);
 	effect_benchmark_init(&app->effect_bench, &app->postprocess,
 	                      &app->gpu_profiler);
 	app->log_gpu_metrics = 0; /* Console logging off by default */
@@ -178,6 +179,7 @@ void app_cleanup(App* app)
 
 	gpu_profiler_cleanup(&app->gpu_profiler);
 	gpu_profiler_ui_cleanup(&app->timeline_ui);
+	gpu_usage_cleanup(&app->gpu_usage);
 
 	window_destroy(app->window);
 	app->window = NULL;
@@ -244,6 +246,7 @@ void app_run(App* app)
 			app_ui_update(&app->overlay, app->delta_time);
 			postprocess_update_time(&app->postprocess,
 			                        (float)app->delta_time);
+			gpu_usage_update(&app->gpu_usage);
 			PROFILE_ZONE_END(ui_notif_ctx);
 		}
 

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -1084,6 +1084,14 @@ static void draw_main_info_overlay(const App* app, UILayout* layout)
 	                    current_fps, frame_time_ms);
 	ui_layout_text(layout, fps_text, DEFAULT_FONT_COLOR);
 
+	/* GPU Utilization (via DRM fdinfo, same as MangoHud) */
+	if (gpu_usage_is_available(&app->gpu_usage)) {
+		char gpu_text[MAX_FPS_TEXT_LENGTH];
+		(void)safe_snprintf(gpu_text, sizeof(gpu_text), "GPU: %.0f%%",
+		                    gpu_usage_get_load(&app->gpu_usage));
+		ui_layout_text(layout, gpu_text, DEFAULT_FONT_COLOR);
+	}
+
 	if (app->overlay.text_overlay_mode >= 2) {
 		static const size_t AVG_TEXT_SIZE = 64;
 		char avg_text[AVG_TEXT_SIZE];

--- a/src/gpu_usage.c
+++ b/src/gpu_usage.c
@@ -1,0 +1,328 @@
+#include "gpu_usage.h"
+
+#include "log.h"
+#include "platform/platform_time.h"
+#include "utils.h"
+#include <dirent.h>
+#include <errno.h>
+#include <string.h>
+
+/* --- Constants --- */
+enum {
+	FDINFO_LINE_MAX = 256,
+	FDINFO_PATH_MAX = 128,
+	CLIENT_ID_MAX = 64,
+	STRTOUL_BASE_DEC = 10,
+};
+
+static const float GPU_LOAD_CLAMP_MAX = 100.0F;
+
+/* MangoHud-ISO: METRICS_UPDATE_PERIOD_MS = 500 */
+static const uint64_t UPDATE_PERIOD_NS = 500000000ULL;
+
+/**
+ * @brief Determine the DRM engine key for a given driver.
+ * @return Engine key string or NULL if unsupported.
+ */
+static const char* engine_key_for_driver(const char* driver)
+{
+	if (strcmp(driver, "i915") == 0) {
+		return "drm-engine-render";
+	}
+	if (strcmp(driver, "xe") == 0) {
+		return "drm-engine-render";
+	}
+	if (strcmp(driver, "amdgpu") == 0) {
+		return "drm-engine-gfx";
+	}
+	if (strcmp(driver, "nouveau") == 0) {
+		return "drm-engine-gr";
+	}
+	return NULL;
+}
+
+/**
+ * @brief Parse a single fdinfo file to extract driver, client-id, and engine
+ * time.
+ */
+static bool parse_fdinfo(FILE* file_ptr, char* out_driver, size_t driver_sz,
+                         char* out_client_id, size_t client_sz,
+                         uint64_t* out_engine_ns, const char* engine_key)
+{
+	char line[FDINFO_LINE_MAX];
+	bool found_engine = false;
+
+	out_driver[0] = '\0';
+	out_client_id[0] = '\0';
+	*out_engine_ns = 0;
+
+	if (fseek(file_ptr, 0, SEEK_SET) != 0) {
+		return false;
+	}
+	errno = 0;
+
+	while (fgets(line, sizeof(line), file_ptr) != NULL) {
+		/* Skip lines starting with whitespace */
+		if (line[0] == ' ' || line[0] == '\t') {
+			continue;
+		}
+
+		char* colon = strchr(line, ':');
+		if (!colon || colon[1] == '\0') {
+			continue;
+		}
+
+		/* Split key:value */
+		*colon = '\0';
+		const char* key = line;
+		const char* val = colon + 1;
+
+		/* Skip leading whitespace in value */
+		while (*val == ' ' || *val == '\t') {
+			val++;
+		}
+
+		/* Strip trailing newline */
+		size_t vlen = strlen(val);
+		char val_buf[FDINFO_LINE_MAX];
+		safe_strncpy(val_buf, sizeof(val_buf), val, vlen);
+		vlen = strlen(val_buf);
+		while (vlen > 0 && (val_buf[vlen - 1] == '\n' ||
+		                    val_buf[vlen - 1] == '\r')) {
+			val_buf[--vlen] = '\0';
+		}
+
+		if (strcmp(key, "drm-driver") == 0) {
+			safe_strncpy(out_driver, driver_sz, val_buf,
+			             driver_sz - 1);
+		} else if (strcmp(key, "drm-client-id") == 0) {
+			safe_strncpy(out_client_id, client_sz, val_buf,
+			             client_sz - 1);
+		} else if (engine_key && strcmp(key, engine_key) == 0) {
+			/* Value format: "12345 ns" or "12345" */
+			*out_engine_ns =
+			    strtoull(val_buf, NULL, STRTOUL_BASE_DEC);
+			found_engine = true;
+		}
+	}
+
+	return found_engine;
+}
+
+/**
+ * @brief Check whether a client-id has already been seen.
+ */
+static bool is_duplicate_client(char seen_clients[][CLIENT_ID_MAX],
+                                int seen_count, const char* client_id)
+{
+	for (int idx = 0; idx < seen_count; idx++) {
+		if (strcmp(seen_clients[idx], client_id) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * @brief Try to register one fdinfo entry as a GPU monitor stream.
+ * @return true if the stream was consumed (kept open or closed), false on
+ * error.
+ */
+static bool try_register_fdinfo(GPUUsageMonitor* mon, const char* path,
+                                char seen_clients[][CLIENT_ID_MAX],
+                                int* seen_count, char* detected_driver,
+                                size_t driver_sz, const char** out_engine_key)
+{
+	FILE* file_ptr = fopen(path, "r");
+	if (!file_ptr) {
+		return false;
+	}
+
+	char driver[GPU_USAGE_MAX_KEY_LEN] = {0};
+	char client_id[CLIENT_ID_MAX] = {0};
+	uint64_t engine_ns = 0;
+
+	(void)parse_fdinfo(file_ptr, driver, sizeof(driver), client_id,
+	                   sizeof(client_id), &engine_ns, NULL);
+
+	if (driver[0] == '\0') {
+		(void)fclose(file_ptr);
+		return false;
+	}
+
+	const char* eng_key = engine_key_for_driver(driver);
+	if (!eng_key) {
+		(void)fclose(file_ptr);
+		return false;
+	}
+
+	if (is_duplicate_client(seen_clients, *seen_count, client_id)) {
+		(void)fclose(file_ptr);
+		return false;
+	}
+
+	if (*seen_count < GPU_USAGE_MAX_FDS) {
+		safe_strncpy(seen_clients[*seen_count], sizeof(seen_clients[0]),
+		             client_id, sizeof(seen_clients[0]) - 1);
+		(*seen_count)++;
+	}
+
+	(void)parse_fdinfo(file_ptr, driver, sizeof(driver), client_id,
+	                   sizeof(client_id), &engine_ns, eng_key);
+
+	if (mon->stream_count < GPU_USAGE_MAX_FDS) {
+		mon->streams[mon->stream_count++] = file_ptr;
+		safe_strncpy(detected_driver, driver_sz, driver, driver_sz - 1);
+		*out_engine_key = eng_key;
+	} else {
+		(void)fclose(file_ptr);
+	}
+
+	return true;
+}
+
+void gpu_usage_init(GPUUsageMonitor* mon)
+{
+	if (!mon) {
+		return;
+	}
+
+	*mon = (GPUUsageMonitor){0};
+	mon->available = false;
+
+	DIR* dir = opendir("/proc/self/fdinfo");
+	if (!dir) {
+		LOG_WARN("gpu_usage", "Cannot open /proc/self/fdinfo");
+		return;
+	}
+
+	char seen_clients[GPU_USAGE_MAX_FDS][CLIENT_ID_MAX];
+	int seen_count = 0;
+	char detected_driver[GPU_USAGE_MAX_KEY_LEN] = {0};
+	const char* engine_key = NULL;
+
+	struct dirent* entry = NULL;
+	while ((entry = readdir(dir)) != NULL) {
+		if (entry->d_name[0] == '.') {
+			continue;
+		}
+
+		char path[FDINFO_PATH_MAX];
+		(void)safe_snprintf(path, sizeof(path), "/proc/self/fdinfo/%s",
+		                    entry->d_name);
+
+		(void)try_register_fdinfo(mon, path, seen_clients, &seen_count,
+		                          detected_driver,
+		                          sizeof(detected_driver), &engine_key);
+	}
+
+	(void)closedir(dir);
+
+	if (mon->stream_count > 0 && engine_key != NULL) {
+		safe_strncpy(mon->driver, sizeof(mon->driver), detected_driver,
+		             sizeof(mon->driver) - 1);
+		safe_strncpy(mon->engine_key, sizeof(mon->engine_key),
+		             engine_key, strlen(engine_key));
+		mon->prev_wall_time_ns = platform_get_time_ns();
+		mon->prev_gpu_time_ns = 0;
+		mon->available = true;
+
+		LOG_INFO("gpu_usage",
+		         "Detected driver \"%s\" with %d unique fd(s), "
+		         "engine key: %s",
+		         mon->driver, mon->stream_count, mon->engine_key);
+	} else {
+		LOG_WARN("gpu_usage",
+		         "No supported DRM driver found in fdinfo");
+	}
+}
+
+void gpu_usage_cleanup(GPUUsageMonitor* mon)
+{
+	if (!mon) {
+		return;
+	}
+
+	for (int i = 0; i < mon->stream_count; i++) {
+		if (mon->streams[i]) {
+			(void)fclose(mon->streams[i]);
+			mon->streams[i] = NULL;
+		}
+	}
+	mon->stream_count = 0;
+	mon->available = false;
+}
+
+void gpu_usage_update(GPUUsageMonitor* mon)
+{
+	if (!mon || !mon->available || mon->stream_count == 0) {
+		return;
+	}
+
+	/* MangoHud-ISO: only update every METRICS_UPDATE_PERIOD_MS (500ms) */
+	uint64_t now = platform_get_time_ns();
+	if (mon->prev_wall_time_ns > 0 &&
+	    (now - mon->prev_wall_time_ns) < UPDATE_PERIOD_NS) {
+		return;
+	}
+
+	uint64_t total_engine_ns = 0;
+
+	for (int i = 0; i < mon->stream_count; i++) {
+		FILE* file_ptr = mon->streams[i];
+		if (!file_ptr) {
+			continue;
+		}
+
+		char driver[GPU_USAGE_MAX_KEY_LEN];
+		char client_id[CLIENT_ID_MAX];
+		uint64_t engine_ns = 0;
+
+		(void)parse_fdinfo(file_ptr, driver, sizeof(driver), client_id,
+		                   sizeof(client_id), &engine_ns,
+		                   mon->engine_key);
+
+		total_engine_ns += engine_ns;
+	}
+
+	/* First update: just record baseline, no computation */
+	if (mon->prev_gpu_time_ns == 0) {
+		mon->prev_gpu_time_ns = total_engine_ns;
+		mon->prev_wall_time_ns = now;
+		return;
+	}
+
+	uint64_t delta_wall = now - mon->prev_wall_time_ns;
+	uint64_t delta_gpu = total_engine_ns - mon->prev_gpu_time_ns;
+
+	if (delta_wall > 0) {
+		float load =
+		    (float)delta_gpu / (float)delta_wall * GPU_LOAD_CLAMP_MAX;
+		if (load > GPU_LOAD_CLAMP_MAX) {
+			load = GPU_LOAD_CLAMP_MAX;
+		}
+		if (load < 0.0F) {
+			load = 0.0F;
+		}
+		mon->load_percent = load;
+	}
+
+	mon->prev_gpu_time_ns = total_engine_ns;
+	mon->prev_wall_time_ns = now;
+}
+
+float gpu_usage_get_load(const GPUUsageMonitor* mon)
+{
+	if (!mon || !mon->available) {
+		return -1.0F;
+	}
+	return mon->load_percent;
+}
+
+bool gpu_usage_is_available(const GPUUsageMonitor* mon)
+{
+	if (mon == NULL) {
+		return false;
+	}
+	return mon->available;
+}

--- a/src/gpu_usage.c
+++ b/src/gpu_usage.c
@@ -1,11 +1,13 @@
 #include "gpu_usage.h"
 
 #include "log.h"
-#include "platform/platform_time.h"
 #include "utils.h"
+#include <string.h>
+
+#ifdef __linux__
+#include "platform/platform_time.h"
 #include <dirent.h>
 #include <errno.h>
-#include <string.h>
 
 /* --- Constants --- */
 enum {
@@ -310,6 +312,34 @@ void gpu_usage_update(GPUUsageMonitor* mon)
 	mon->prev_gpu_time_ns = total_engine_ns;
 	mon->prev_wall_time_ns = now;
 }
+
+#else /* !__linux__ */
+
+void gpu_usage_init(GPUUsageMonitor* mon)
+{
+	if (!mon) {
+		return;
+	}
+	*mon = (GPUUsageMonitor){0};
+	mon->available = false;
+	LOG_WARN("gpu_usage", "DRM fdinfo not available on this platform");
+}
+
+void gpu_usage_cleanup(GPUUsageMonitor* mon)
+{
+	if (!mon) {
+		return;
+	}
+	mon->stream_count = 0;
+	mon->available = false;
+}
+
+void gpu_usage_update(GPUUsageMonitor* mon)
+{
+	(void)mon;
+}
+
+#endif /* __linux__ */
 
 float gpu_usage_get_load(const GPUUsageMonitor* mon)
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ if(WIN32)
     list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader\\.c$")
     list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_api\\.c$")
     list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_uniforms_loc\\.c$")
+    list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_gpu_usage\\.c$")
 endif()
 
 # Tests qui nécessitent OpenGL (à mettre dans Xvfb)

--- a/tests/test_gpu_usage.c
+++ b/tests/test_gpu_usage.c
@@ -1,0 +1,109 @@
+// tests/test_gpu_usage.c
+#include "gpu_usage.h"
+#include "unity.h"
+#include <string.h>
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_gpu_usage_init_cleanup_lifecycle(void)
+{
+	GPUUsageMonitor mon;
+	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
+	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+
+	gpu_usage_init(&mon);
+	/* On any platform, init should succeed without crash */
+	gpu_usage_cleanup(&mon);
+	TEST_ASSERT_FALSE(mon.available);
+	TEST_ASSERT_EQUAL_INT(0, mon.stream_count);
+}
+
+void test_gpu_usage_init_null_safe(void)
+{
+	/* Must not crash on NULL */
+	gpu_usage_init(NULL);
+	gpu_usage_cleanup(NULL);
+	gpu_usage_update(NULL);
+	TEST_PASS();
+}
+
+void test_gpu_usage_get_load_null(void)
+{
+	float load = gpu_usage_get_load(NULL);
+	TEST_ASSERT_EQUAL_FLOAT(-1.0F, load);
+}
+
+void test_gpu_usage_is_available_null(void)
+{
+	TEST_ASSERT_FALSE(gpu_usage_is_available(NULL));
+}
+
+void test_gpu_usage_get_load_unavailable(void)
+{
+	GPUUsageMonitor mon;
+	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
+	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+	mon.available = false;
+
+	float load = gpu_usage_get_load(&mon);
+	TEST_ASSERT_EQUAL_FLOAT(-1.0F, load);
+}
+
+void test_gpu_usage_update_unavailable_noop(void)
+{
+	GPUUsageMonitor mon;
+	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
+	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+	mon.available = false;
+	mon.load_percent = 0.0F;
+
+	/* update on unavailable monitor should be a no-op */
+	gpu_usage_update(&mon);
+	TEST_ASSERT_EQUAL_FLOAT(0.0F, mon.load_percent);
+}
+
+void test_gpu_usage_cleanup_resets_state(void)
+{
+	GPUUsageMonitor mon;
+	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
+	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+
+	gpu_usage_init(&mon);
+	gpu_usage_cleanup(&mon);
+
+	TEST_ASSERT_FALSE(mon.available);
+	TEST_ASSERT_EQUAL_INT(0, mon.stream_count);
+}
+
+void test_gpu_usage_double_cleanup_safe(void)
+{
+	GPUUsageMonitor mon;
+	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
+	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+
+	gpu_usage_init(&mon);
+	gpu_usage_cleanup(&mon);
+	/* Second cleanup should not crash */
+	gpu_usage_cleanup(&mon);
+	TEST_PASS();
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_gpu_usage_init_cleanup_lifecycle);
+	RUN_TEST(test_gpu_usage_init_null_safe);
+	RUN_TEST(test_gpu_usage_get_load_null);
+	RUN_TEST(test_gpu_usage_is_available_null);
+	RUN_TEST(test_gpu_usage_get_load_unavailable);
+	RUN_TEST(test_gpu_usage_update_unavailable_noop);
+	RUN_TEST(test_gpu_usage_cleanup_resets_state);
+	RUN_TEST(test_gpu_usage_double_cleanup_safe);
+	return UNITY_END();
+}

--- a/tests/test_gpu_usage.c
+++ b/tests/test_gpu_usage.c
@@ -1,7 +1,6 @@
 // tests/test_gpu_usage.c
 #include "gpu_usage.h"
 #include "unity.h"
-#include <string.h>
 
 void setUp(void)
 {
@@ -13,9 +12,7 @@ void tearDown(void)
 
 void test_gpu_usage_init_cleanup_lifecycle(void)
 {
-	GPUUsageMonitor mon;
-	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
-	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+	GPUUsageMonitor mon = {0};
 
 	gpu_usage_init(&mon);
 	/* On any platform, init should succeed without crash */
@@ -46,9 +43,7 @@ void test_gpu_usage_is_available_null(void)
 
 void test_gpu_usage_get_load_unavailable(void)
 {
-	GPUUsageMonitor mon;
-	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
-	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+	GPUUsageMonitor mon = {0};
 	mon.available = false;
 
 	float load = gpu_usage_get_load(&mon);
@@ -57,9 +52,7 @@ void test_gpu_usage_get_load_unavailable(void)
 
 void test_gpu_usage_update_unavailable_noop(void)
 {
-	GPUUsageMonitor mon;
-	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
-	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+	GPUUsageMonitor mon = {0};
 	mon.available = false;
 	mon.load_percent = 0.0F;
 
@@ -70,9 +63,7 @@ void test_gpu_usage_update_unavailable_noop(void)
 
 void test_gpu_usage_cleanup_resets_state(void)
 {
-	GPUUsageMonitor mon;
-	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
-	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+	GPUUsageMonitor mon = {0};
 
 	gpu_usage_init(&mon);
 	gpu_usage_cleanup(&mon);
@@ -83,9 +74,7 @@ void test_gpu_usage_cleanup_resets_state(void)
 
 void test_gpu_usage_double_cleanup_safe(void)
 {
-	GPUUsageMonitor mon;
-	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.bzero)
-	(void)memset(&mon, 0, sizeof(GPUUsageMonitor));
+	GPUUsageMonitor mon = {0};
 
 	gpu_usage_init(&mon);
 	gpu_usage_cleanup(&mon);


### PR DESCRIPTION
## Summary
<img width="1165" height="295" alt="image" src="https://github.com/user-attachments/assets/3fea0241-414b-446c-bf6b-1306f5399eb9" />

Add real-time GPU utilization % monitoring to the HUD overlay, using the same DRM fdinfo approach as MangoHud.

## Changes

### Commit 1: `feat(profiling): add GPU usage monitor via DRM fdinfo`
- New `GPUUsageMonitor` module (`include/gpu_usage.h`, `src/gpu_usage.c`)
- Reads `/proc/self/fdinfo/` for per-process GPU engine time
- Deduplicates file descriptors by `drm-client-id` (same as MangoHud)
- Computes `GPU% = delta_gpu_time / delta_wall_time * 100`
- Rate-limited to 500ms updates (ISO MangoHud `METRICS_UPDATE_PERIOD_MS`)
- Supports: i915, xe, amdgpu, nouveau drivers
- Graceful degradation when no supported driver detected

### Commit 2: `feat(ui): display GPU utilization in HUD overlay`
- Integrate `GPUUsageMonitor` into App struct lifecycle (init/update/cleanup)
- Display "GPU: XX%" in main info overlay next to FPS
- Only shown when a supported DRM driver is detected

## Testing
- Build: ✅ (all targets)
- Lint: ✅ (0 warnings, 0 errors)
- Tests: ✅ (62/62 pass)
- Validated on Intel Iris Xe (i915 driver)

## MangoHud Compatibility
This implementation is ISO with MangoHud's fdinfo codepath:
- Same `/proc/self/fdinfo/` scanning
- Same client-id deduplication
- Same `delta_gpu / delta_wall * 100` formula
- Same 500ms update period (no additional smoothing/averaging)
