### PR TITLE
feat: neon glow trail rendering with runtime controls

### DIFF
--- a/docs/neon_trails.fr.md
+++ b/docs/neon_trails.fr.md
@@ -1,0 +1,83 @@
+# Rendu des Traînées Néon
+
+Le système de traînées néon affiche des rubans orientés caméra derrière chaque sphère de la simulation N-corps, avec un profil de brillance inspiré des tubes néon réels. Les traînées émettent de la lumière HDR qui interagit avec le post-traitement bloom pour créer de larges halos colorés.
+
+## Profil Visuel
+
+Le fragment shader (`shaders/trail.frag`) simule un tube néon avec trois couches concentriques de luminosité :
+
+| Couche | Exposant | Poids | Rôle Visuel |
+|--------|----------|-------|-------------|
+| **Cœur** | `u_core_exp` (défaut 12.0) | 45% | Filament étroit blanc-chaud |
+| **Intérieur** | `core_exp × 0.25` | 35% | Halo coloré de taille moyenne |
+| **Extérieur** | 0.8 (fixe) | 20% | Halo diffus pour le bloom |
+
+### Centre Blanc-Chaud
+
+Les vrais tubes néon apparaissent quasi-blancs à leur point le plus lumineux. Le shader désature le centre en interpolant vers `vec3(peak)` (blanc préservant la luminance) proportionnellement à l'intensité du cœur :
+
+```glsl
+vec3 neon_color = mix(vColor, hot_white, core * 0.7);
+neon_color *= (1.0 + core * 2.0);  // Boost HDR pour le bloom
+```
+
+### Interaction HDR / Bloom
+
+La fonction `build_ribbon()` côté CPU pré-multiplie les couleurs par le paramètre d'intensité HDR. Combiné au boost du shader au niveau du cœur, le centre du ruban atteint des valeurs bien supérieures au seuil du bloom (défaut 1.0), déclenchant un halo bloom large qui forme l'éclat néon caractéristique.
+
+## Contrôles en Temps Réel
+
+Les trois paramètres néon sont ajustables en temps réel au clavier :
+
+| Touche | Action |
+|--------|--------|
+| `I` | Cycle le paramètre actif : Intensité → Cœur → Largeur |
+| `Shift+I` | Augmente le paramètre sélectionné |
+| `Ctrl+I` | Diminue le paramètre sélectionné |
+
+### Paramètres
+
+| Paramètre | Défaut | Pas | Min | Description |
+|-----------|--------|-----|-----|-------------|
+| **Intensité** | 5.0 | ±0.5 | 0.5 | Multiplicateur HDR — contrôle la luminosité globale et la réponse bloom |
+| **Cœur** | 12.0 | ±2.0 | 2.0 | Exposant de serrage — plus haut = filament fin et brillant, plus bas = lueur diffuse |
+| **Largeur** | 0.24 | ±0.02 | 0.04 | Demi-largeur du ruban en unités monde — épaisseur physique de la traînée |
+
+Chaque changement affiche une notification à l'écran avec la valeur courante.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[TrailRenderer::neon] -->|intensity, width| B[build_ribbon CPU]
+    A -->|core_exp| C[trail.frag GPU]
+    B -->|Sommets HDR| D[Upload VBO]
+    D --> E[glMultiDrawArrays]
+    C -->|Profil néon| E
+    E -->|Sortie HDR| F[Post-traitement Bloom]
+    F -->|Halo large| G[Composite Final]
+```
+
+### Fichiers Clés
+
+| Fichier | Rôle |
+|---------|------|
+| `shaders/trail.frag` | Profil néon (3 couches Gaussiennes, cœur blanc-chaud) |
+| `shaders/trail.vert` | Transformation des sommets du ruban orienté caméra |
+| `include/trail_renderer.h` | Struct `TrailNeonParams` + valeurs par défaut |
+| `src/trail_renderer.c` | Construction de la géométrie ruban + upload des uniforms |
+| `src/app_input.c` | Gestionnaires clavier `I` / `Shift+I` / `Ctrl+I` |
+| `src/app_binding.c` | Enregistrement dans l'aide F2 |
+
+## Guide de Réglage
+
+- **Plus de halo, moins de centre net** : Diminuer Cœur (ex. 4.0–6.0)
+- **Ligne brillante type laser** : Augmenter Cœur (ex. 20.0+)
+- **Halo bloom plus fort** : Augmenter Intensité (ex. 8.0–10.0)
+- **Traînées subtiles** : Diminuer Intensité (ex. 1.0–2.0) et Largeur (0.08)
+- **Gros tubes néon** : Augmenter Largeur (ex. 0.40+)
+
+## Voir Aussi
+
+- [Physique N-Corps](nbody_physics.md) — Simulation alimentant les positions des traînées
+- [Débogage Bloom](bloom_debug.fr.md) — Visualisation des étapes bloom créant le halo néon

--- a/docs/neon_trails.md
+++ b/docs/neon_trails.md
@@ -1,0 +1,83 @@
+# Neon Trail Rendering
+
+The neon trail system renders camera-facing ribbon trails behind each N-body sphere with a physically-inspired neon tube glow profile. Trails emit HDR light that interacts with the bloom post-process to create wide, colorful neon halos.
+
+## Visual Profile
+
+The fragment shader (`shaders/trail.frag`) simulates a neon tube with three concentric glow layers:
+
+| Layer | Exponent | Weight | Visual Role |
+|-------|----------|--------|-------------|
+| **Core** | `u_core_exp` (default 12.0) | 45% | Tight white-hot filament |
+| **Inner** | `core_exp × 0.25` | 35% | Medium saturated color glow |
+| **Outer** | 0.8 (fixed) | 20% | Soft diffuse halo for bloom |
+
+### White-Hot Center
+
+Real neon tubes appear near-white at their brightest point. The shader desaturates the center by mixing towards `vec3(peak)` (luminance-preserving white) proportionally to the core intensity:
+
+```glsl
+vec3 neon_color = mix(vColor, hot_white, core * 0.7);
+neon_color *= (1.0 + core * 2.0);  // HDR boost for bloom
+```
+
+### HDR / Bloom Interaction
+
+The CPU-side `build_ribbon()` function pre-multiplies colors by the HDR intensity parameter. Combined with the shader's core boost, the center of the ribbon reaches values well above the bloom threshold (default 1.0), triggering a wide bloom halo that forms the characteristic neon glow.
+
+## Runtime Controls
+
+All three neon parameters are adjustable at runtime via keyboard:
+
+| Key | Action |
+|-----|--------|
+| `I` | Cycle active parameter: Intensity → Core → Width |
+| `Shift+I` | Increase the selected parameter |
+| `Ctrl+I` | Decrease the selected parameter |
+
+### Parameters
+
+| Parameter | Default | Step | Min | Description |
+|-----------|---------|------|-----|-------------|
+| **Intensity** | 5.0 | ±0.5 | 0.5 | HDR intensity multiplier — controls overall brightness and bloom response |
+| **Core** | 12.0 | ±2.0 | 2.0 | Core tightness exponent — higher = thinner bright filament, lower = diffuse glow |
+| **Width** | 0.24 | ±0.02 | 0.04 | Ribbon half-width in world units — physical thickness of the trail |
+
+Each change displays an on-screen notification with the current value.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[TrailRenderer::neon] -->|intensity, width| B[build_ribbon CPU]
+    A -->|core_exp| C[trail.frag GPU]
+    B -->|HDR vertices| D[VBO Upload]
+    D --> E[glMultiDrawArrays]
+    C -->|Neon profile| E
+    E -->|HDR output| F[Bloom Post-Process]
+    F -->|Wide halo| G[Final Composite]
+```
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `shaders/trail.frag` | Neon glow profile (3-layer Gaussian, white-hot core) |
+| `shaders/trail.vert` | Camera-facing ribbon vertex transform |
+| `include/trail_renderer.h` | `TrailNeonParams` struct + defaults |
+| `src/trail_renderer.c` | Ribbon geometry builder + uniform upload |
+| `src/app_input.c` | `I` / `Shift+I` / `Ctrl+I` keyboard handlers |
+| `src/app_binding.c` | F2 help overlay registration |
+
+## Tuning Guide
+
+- **More glow, less sharp center**: Decrease Core (e.g., 4.0–6.0)
+- **Laser-thin bright line**: Increase Core (e.g., 20.0+)
+- **Stronger bloom halo**: Increase Intensity (e.g., 8.0–10.0)
+- **Subtle trails**: Decrease Intensity (e.g., 1.0–2.0) and Width (0.08)
+- **Fat neon tubes**: Increase Width (e.g., 0.40+)
+
+## See Also
+
+- [N-Body Physics](nbody_physics.md) — Simulation driving the trail positions
+- [Bloom Debug](bloom_debug.md) — Visualizing bloom stages that create the neon halo

--- a/include/trail_renderer.h
+++ b/include/trail_renderer.h
@@ -22,11 +22,11 @@
 /** Maximum trail sample points per body. At 60 samples/sec ≈ 4.3 seconds. */
 enum { TRAIL_MAX_POINTS = 256 };
 
-/** HDR intensity multiplier — ensures bloom threshold is exceeded. */
-static const float TRAIL_HDR_INTENSITY = 3.0F;
+/** HDR intensity multiplier — drives bloom for neon glow effect. */
+static const float TRAIL_HDR_INTENSITY = 5.0F;
 
 /** Maximum ribbon half-width in world units. */
-static const float TRAIL_MAX_WIDTH = 0.18F;
+static const float TRAIL_MAX_WIDTH = 0.24F;
 
 /** Minimum time between trail samples (seconds). */
 static const float TRAIL_SAMPLE_INTERVAL = 1.0F / 60.0F;
@@ -55,6 +55,39 @@ typedef struct {
 } TrailRing;
 
 /**
+ * @enum TrailNeonParam
+ * @brief Identifies which neon parameter is being adjusted.
+ */
+typedef enum {
+	TRAIL_NEON_PARAM_INTENSITY = 0,
+	TRAIL_NEON_PARAM_CORE,
+	TRAIL_NEON_PARAM_WIDTH,
+	TRAIL_NEON_PARAM_COUNT
+} TrailNeonParam;
+
+/**
+ * @struct TrailNeonParams
+ * @brief Runtime-adjustable neon glow profile parameters.
+ */
+typedef struct {
+	float intensity; /**< HDR intensity multiplier (default 5.0). */
+	float core_exp;  /**< Core tightness exponent (default 12.0). */
+	float width;     /**< Ribbon half-width multiplier (default 0.24). */
+	TrailNeonParam active; /**< Currently selected param for adjustment. */
+} TrailNeonParams;
+
+/** Default neon parameter values. */
+static const float TRAIL_NEON_INTENSITY_DEFAULT = 5.0F;
+static const float TRAIL_NEON_CORE_EXP_DEFAULT = 12.0F;
+static const float TRAIL_NEON_WIDTH_DEFAULT = 0.24F;
+static const float TRAIL_NEON_INTENSITY_STEP = 0.5F;
+static const float TRAIL_NEON_CORE_STEP = 2.0F;
+static const float TRAIL_NEON_WIDTH_STEP = 0.02F;
+static const float TRAIL_NEON_INTENSITY_MIN = 0.5F;
+static const float TRAIL_NEON_CORE_MIN = 2.0F;
+static const float TRAIL_NEON_WIDTH_MIN = 0.04F;
+
+/**
  * @struct TrailRenderer
  * @brief Manages trail state and GPU resources for all bodies.
  */
@@ -71,6 +104,9 @@ typedef struct {
 
 	/* Per-body trail colors (HDR emissive). */
 	vec3 colors[NBODY_MAX_BODIES];
+
+	/* Runtime neon glow parameters */
+	TrailNeonParams neon; /**< Adjustable neon profile. */
 } TrailRenderer;
 
 /**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
 - Rendering:
   - Global Illumination: global_illumination.md
   - N-Body Physics: nbody_physics.md
+  - Neon Trails: neon_trails.md
   - PBR Sphere Rendering: sphere_rendering.md
   - Skybox: skybox_rendering.md
   - Progressive IBL: progressive_ibl.md

--- a/shaders/trail.frag
+++ b/shaders/trail.frag
@@ -1,35 +1,53 @@
 #version 430 core
 
 /*
- * trail.frag — HDR ribbon trail fragment shader.
+ * trail.frag — HDR neon ribbon trail fragment shader.
  *
  * Visual quality features:
- * 1. Soft anti-aliased edges via smoothstep across ribbon width (vV).
- * 2. Smooth age-based opacity fade along the trail (vU).
- * 3. HDR emissive output — bloom post-process picks up values > threshold.
- * 4. Core glow: brighter center, dimmer edges for a natural light-trail look.
+ * 1. Neon tube profile: white-hot narrow core + saturated color halo.
+ * 2. Multi-layer glow: tight core, medium inner glow, soft outer halo.
+ * 3. HDR emissive output — bloom post-process creates the wide neon glow.
+ * 4. Age-based opacity fade along the trail (vU).
  */
 
 in float vU;    /* Along trail: 0=head, 1=tail */
 in float vV;    /* Across ribbon: 0=left edge, 1=right edge */
 in vec3 vColor; /* HDR emissive color (pre-attenuated by age on CPU) */
 
+/* Runtime-adjustable neon profile parameter */
+uniform float u_core_exp; /* Core tightness (default 12.0) */
+
 layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-	/* --- Soft edge anti-aliasing ---
-	 * Map vV from [0,1] to a centered coordinate [-1,1],
-	 * then apply a smooth falloff at the edges.
-	 * This creates a soft, rounded ribbon profile. */
-	float center = abs(vV * 2.0 - 1.0); /* 0 at center, 1 at edges */
-	float edge_softness = 1.0 - smoothstep(0.6, 1.0, center);
+	/* Map vV from [0,1] to a centered coordinate: 0 at center, 1 at edges
+	 */
+	float center = abs(vV * 2.0 - 1.0);
 
-	/* --- Core glow ---
-	 * Brighter at the center of the ribbon, dimmer at edges.
-	 * Creates a natural volumetric light appearance. */
-	float core = exp(-center * center * 2.0);
-	float glow = mix(0.4, 1.0, core);
+	/* --- Neon tube glow profile ---
+	 * Three layers simulate the light distribution of a real neon tube:
+	 * - Core: very tight, intense center filament (u_core_exp)
+	 * - Inner glow: medium spread colored light (core_exp / 4)
+	 * - Outer halo: soft diffuse edge for bloom to amplify */
+	float core = exp(-center * center * u_core_exp);
+	float inner = exp(-center * center * (u_core_exp * 0.25));
+	float outer = exp(-center * center * 0.8);
+	float glow = core * 0.45 + inner * 0.35 + outer * 0.20;
+
+	/* --- Soft edge anti-aliasing --- */
+	float edge = 1.0 - smoothstep(0.75, 1.0, center);
+
+	/* --- White-hot center desaturation ---
+	 * Real neon tubes appear near-white at the brightest point,
+	 * with saturated color visible in the surrounding glow.
+	 * Mix towards luminance-preserving white at the core. */
+	float peak = max(vColor.r, max(vColor.g, vColor.b));
+	vec3 hot_white = vec3(peak);
+	vec3 neon_color = mix(vColor, hot_white, core * 0.7);
+
+	/* Intensity boost at core — drives bloom hard for wide neon halo */
+	neon_color *= (1.0 + core * 2.0);
 
 	/* --- Age-based fade ---
 	 * Quadratic fade: newer parts fully opaque, tail fades smoothly.
@@ -37,14 +55,14 @@ void main()
 	float age_alpha = (1.0 - vU) * (1.0 - vU);
 
 	/* --- Final composite ---
-	 * Color is HDR (already > 1.0 from CPU), bloom catches the excess.
+	 * High HDR values at center trigger strong bloom response.
 	 * Alpha controls additive blend contribution. */
-	float alpha = edge_softness * glow * age_alpha;
+	float alpha = edge * glow * age_alpha;
 
 	/* Discard near-invisible fragments to avoid depth/blend artifacts */
 	if (alpha < 0.005) {
 		discard;
 	}
 
-	FragColor = vec4(vColor * glow, alpha);
+	FragColor = vec4(neon_color * glow, alpha);
 }

--- a/src/app_binding.c
+++ b/src/app_binding.c
@@ -139,6 +139,16 @@ void app_binding_registry_init(AppBindingRegistry* registry)
 	add_binding(GLFW_KEY_COMMA, GLFW_MOD_SHIFT, "Gravity Down",
 	            "Halves G (min 0.125, then OFF).", BINDING_CAT_VISUALS,
 	            BINDING_TYPE_CYCLE);
+	add_binding(
+	    GLFW_KEY_I, 0, "Cycle Neon Param",
+	    "Cycles through neon trail parameters (Intensity/Core/Width).",
+	    BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);
+	add_binding(GLFW_KEY_I, GLFW_MOD_SHIFT, "Neon Param +",
+	            "Increases the currently selected neon trail parameter.",
+	            BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);
+	add_binding(GLFW_KEY_I, GLFW_MOD_CONTROL, "Neon Param -",
+	            "Decreases the currently selected neon trail parameter.",
+	            BINDING_CAT_VISUALS, BINDING_TYPE_CYCLE);
 	add_binding(GLFW_KEY_H, 0, "Toggle DOF", "Toggles Depth of Field blur.",
 	            BINDING_CAT_POSTFX, BINDING_TYPE_TOGGLE);
 	add_binding(GLFW_KEY_H, GLFW_MOD_SHIFT, "Toggle DOF Debug",

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -567,6 +567,72 @@ static void handle_o_key_input(App* app)
 	action_notifier_push(&app->notifier, notif_name, NOTIF_DUR_NORMAL);
 }
 
+static const char* const NEON_PARAM_NAMES[] = {"Intensity", "Core", "Width"};
+
+static void handle_neon_cycle(App* app)
+{
+	TrailNeonParams* neon = &app->scene.trail_renderer.neon;
+	neon->active = (neon->active + 1) % TRAIL_NEON_PARAM_COUNT;
+	char buf[NOTIF_BUF_SIZE];
+	(void)safe_snprintf(buf, sizeof(buf), "Neon: %s selected",
+	                    NEON_PARAM_NAMES[neon->active]);
+	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+}
+
+static void handle_neon_adjust(App* app, int increase)
+{
+	TrailNeonParams* neon = &app->scene.trail_renderer.neon;
+	float sign = (increase != 0) ? 1.0F : -1.0F;
+	const char* name = NEON_PARAM_NAMES[neon->active];
+	float val = 0.0F;
+
+	switch (neon->active) {
+		case TRAIL_NEON_PARAM_INTENSITY:
+			neon->intensity += sign * TRAIL_NEON_INTENSITY_STEP;
+			if (neon->intensity < TRAIL_NEON_INTENSITY_MIN) {
+				neon->intensity = TRAIL_NEON_INTENSITY_MIN;
+			}
+			val = neon->intensity;
+			break;
+		case TRAIL_NEON_PARAM_CORE:
+			neon->core_exp += sign * TRAIL_NEON_CORE_STEP;
+			if (neon->core_exp < TRAIL_NEON_CORE_MIN) {
+				neon->core_exp = TRAIL_NEON_CORE_MIN;
+			}
+			val = neon->core_exp;
+			break;
+		case TRAIL_NEON_PARAM_WIDTH:
+			neon->width += sign * TRAIL_NEON_WIDTH_STEP;
+			if (neon->width < TRAIL_NEON_WIDTH_MIN) {
+				neon->width = TRAIL_NEON_WIDTH_MIN;
+			}
+			val = neon->width;
+			break;
+		default:
+			break;
+	}
+
+	char buf[NOTIF_BUF_SIZE];
+	(void)safe_snprintf(buf, sizeof(buf), "Neon %s: %.2f", name,
+	                    (double)val);
+	action_notifier_push(&app->notifier, buf, NOTIF_DUR_SHORT);
+}
+
+static int handle_neon_input(App* app, int key, int mods)
+{
+	if (key != GLFW_KEY_I) {
+		return 0;
+	}
+	if (check_flag(mods, GLFW_MOD_SHIFT)) {
+		handle_neon_adjust(app, 1);
+	} else if (check_flag(mods, GLFW_MOD_CONTROL)) {
+		handle_neon_adjust(app, 0);
+	} else {
+		handle_neon_cycle(app);
+	}
+	return 1;
+}
+
 void handle_app_input(App* app, int key, int mods)
 {
 	if (key >= GLFW_KEY_F1 && key <= GLFW_KEY_F12) {
@@ -659,6 +725,9 @@ void handle_app_input(App* app, int key, int mods)
 			break;
 		case GLFW_KEY_COMMA:
 			handle_sim_or_gravity_input(app, mods, false);
+			break;
+		case GLFW_KEY_I:
+			handle_neon_input(app, key, mods);
 			break;
 		default:
 			break;

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -81,6 +81,11 @@ bool trail_renderer_init(TrailRenderer* trail, int body_count)
 
 	glBindVertexArray(0);
 
+	/* Initialize neon glow defaults */
+	trail->neon.intensity = TRAIL_NEON_INTENSITY_DEFAULT;
+	trail->neon.core_exp = TRAIL_NEON_CORE_EXP_DEFAULT;
+	trail->neon.width = TRAIL_NEON_WIDTH_DEFAULT;
+
 	return true;
 }
 
@@ -149,7 +154,8 @@ void trail_renderer_record(TrailRenderer* trail, const NBodySim* sim,
  * ---------------------------------------------------------------------------*/
 
 static int build_ribbon(const TrailRing* ring, const vec3 color,
-                        const vec3 cam_pos, float body_radius, TrailVertex* out)
+                        const vec3 cam_pos, float body_radius,
+                        float hdr_intensity, float max_width, TrailVertex* out)
 {
 	if (ring->count < 3) {
 		return 0;
@@ -203,13 +209,13 @@ static int build_ribbon(const TrailRing* ring, const vec3 color,
 		/* Width: cubic taper, scaled by body radius for
 		 * proportional trails. Minimum radius clamp. */
 		float base_width =
-		    TRAIL_MAX_WIDTH * fmaxf(body_radius, MIN_BODY_RADIUS);
+		    max_width * fmaxf(body_radius, MIN_BODY_RADIUS);
 		float width = base_width * (1.0F - (age * age * age));
 
 		/* HDR color with quadratic intensity fade */
 		float intensity = (1.0F - age) * (1.0F - age);
 		vec3 hdr_color;
-		glm_vec3_scale((float*)color, TRAIL_HDR_INTENSITY * intensity,
+		glm_vec3_scale((float*)color, hdr_intensity * intensity,
 		               hdr_color);
 
 		/* Left vertex (v=0) */
@@ -260,6 +266,7 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 			int vcount = build_ribbon(
 			    &trail->rings[i], trail->colors[i], cam_pos,
 			    1.0F, /* body_radius — could be passed in */
+			    trail->neon.intensity, trail->neon.width,
 			    &staging[total_verts]);
 			if (vcount > 0) {
 				body_start[active_bodies] = start;
@@ -289,6 +296,7 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 	shader_use(trail->shader);
 	shader_set_mat4(trail->shader, "u_view", (const float*)view);
 	shader_set_mat4(trail->shader, "u_proj", (const float*)proj);
+	shader_set_float(trail->shader, "u_core_exp", trail->neon.core_exp);
 
 	glBindVertexArray(trail->vao);
 


### PR DESCRIPTION
## Summary

[2026-04-24_16-40-48.webm](https://github.com/user-attachments/assets/dc2dad35-0207-43c3-be35-b76c5d986cce)

Add a neon glow visual profile for ribbon trails with runtime parameter controls.

### Changes

**Shader & Rendering** (`feat(shader)`)
- 3-layer Gaussian glow profile (core / inner / outer) in `trail.frag`
- `u_core_exp` uniform for runtime core sharpness control
- White-hot desaturation + HDR boost for neon look
- `TrailNeonParam` enum and `TrailNeonParams` struct with named constants
- Parameterized `build_ribbon()` with `hdr_intensity` and `max_width`

**Controls** (`feat(controls)`)
- `I` — cycle active neon parameter (Intensity → Core → Width)
- `Shift+I` — increase current parameter
- `Ctrl+I` — decrease current parameter
- AZERTY-friendly keybindings (no AltGr needed)
- F2 overlay updated with 3 new bindings

**Documentation** (`docs(neon-trails)`)
- `docs/neon_trails.md` — EN documentation (visual profile, controls, architecture diagram, tuning guide)
- `docs/neon_trails.fr.md` — synchronized FR translation
- `mkdocs.yml` — added Neon Trails under Rendering section

### Quality
- `just format` ✅
- `just lint` ✅ (61 C files + 29 shaders, 0 failures)
- `just test-all` ✅ (63/63 tests passed)
