### PR TITLE
fix(docker): optimize build context (870MB→2MB) and add GPU passthrough

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,13 @@
 # Build artifacts
 build/
 build-*/
+_deps/
+deps/
 *.o
 *.a
 *.so
+*.profraw
+*.profdata
 
 # IDE and editor files
 .vscode/
@@ -18,19 +22,38 @@ build-*/
 .gitignore
 .gitmodules
 
-# Documentation
+# Documentation & site
 docs/
+site/
+doxygen_resources/
+Doxyfile
 README.md
 *.md
+
+# Tests (not needed for container build)
+tests/
+Testing/
 
 # Makefile and scripts not needed in container
 Makefile
 run.sh
 compile_flags.txt
+compile_commands.json
+cmake_output.txt
+valgrind.supp
+lsan.supp
+requirements-dev.txt
+toolchain-mingw.cmake
+default.profraw
+
+# CI / hooks
+.github/
+hooks/
+extractions/
 
 # Docker files themselves
 Dockerfile
 .dockerignore
 
-# scripts
+# Re-include entrypoint
 !entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,12 @@ WORKDIR /src
 # Copy project files
 COPY . .
 
-# Build with static libraries
+# Build with static libraries (no tests in container)
 RUN cmake -B build -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang \
     -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTS=OFF \
     && cmake --build build --parallel
 
 # Verify static linking
@@ -47,6 +48,7 @@ RUN dnf -y update && dnf -y install \
     mesa-libGL \
     mesa-libEGL \
     mesa-dri-drivers \
+    mesa-vulkan-drivers \
     libglvnd-glx \
     libglvnd-egl \
     xorg-x11-server-Xvfb \

--- a/Justfile
+++ b/Justfile
@@ -386,11 +386,30 @@ ci-docker-test: ci-docker-build
     @{{container_engine}} run --rm -v {{justfile_directory()}}:/workspace {{ci_image_name}} \
         sh -c "cmake {{extra_cmake_flags}} -B /tmp/build-ci -DCMAKE_C_FLAGS=-Wno-unused-variable && cmake --build /tmp/build-ci --target test_shader && cd /tmp/build-ci && xvfb-run -a ./tests/test_shader"
 
-# Run the application container with X11 forwarding
+# Run the application container with X11 forwarding (software rendering)
 docker-run:
-    @echo "Running Container with X11 forwarding..."
+    @echo "Running Container with X11 forwarding (software rendering)..."
     @xhost +local: > /dev/null 2>&1 || true
     @{{container_engine}} run --rm -it \
+        --cap-add=SYS_NICE \
+        --ulimit rtprio=99 \
+        --security-opt label=disable \
+        --network host \
+        -e DISPLAY={{env_var("DISPLAY")}} \
+        -e DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus" \
+        -v /run/user/$(id -u)/bus:/run/user/$(id -u)/bus \
+        -v /var/lib/dbus/machine-id:/var/lib/dbus/machine-id:ro \
+        -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+        {{image_name}} /bin/bash -c "export DISPLAY={{env_var("DISPLAY")}} && ./app"
+
+# Run the application container with host GPU passthrough (Intel/AMD via DRI)
+docker-run-gpu:
+    @echo "Running Container with GPU passthrough..."
+    @xhost +local: > /dev/null 2>&1 || true
+    @test -d /dev/dri || (echo "ERROR: /dev/dri not found — no GPU available" && exit 1)
+    @{{container_engine}} run --rm -it \
+        --device /dev/dri \
+        --group-add video \
         --cap-add=SYS_NICE \
         --ulimit rtprio=99 \
         --security-opt label=disable \

--- a/docs/docker.fr.md
+++ b/docs/docker.fr.md
@@ -1,80 +1,232 @@
-# Configuration Docker
+# Support Docker
 
-Ce document décrit la configuration Docker du projet pour le développement et la CI/CD.
+Ce projet inclut un environnement de build et d'exécution conteneurisé pour des builds cohérents et reproductibles sur différents systèmes. La configuration Docker utilise une architecture multi-étapes avec mise en cache et support du rendu headless.
 
-## Architecture multi-étapes
+## Prérequis
 
-Le `Dockerfile` utilise une construction multi-étapes pour optimiser la taille de l'image finale et séparer les dépendances de build des dépendances de runtime.
+- **Docker** ou **Podman** installé (auto-détecté par le Justfile)
+- Support BuildKit activé (par défaut dans Docker/Podman modernes)
 
-### Étape 1 : Builder
+## Démarrage rapide
 
-```dockerfile
-FROM debian:13-slim AS builder
-RUN apt-get update && apt-get install -y \
-    cmake clang make \
-    libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
-```
-
-Cette étape contient tous les outils de compilation et télécharge les dépendances via FetchContent.
-
-### Étape 2 : Runtime
-
-```dockerfile
-FROM debian:13-slim AS runtime
-# Copier uniquement le binaire et les shaders
-COPY --from=builder /build/app /app/app
-COPY --from=builder /build/shaders /app/shaders
-COPY --from=builder /build/assets /app/assets
-```
-
-L'image finale ne contient que le binaire compilé, les shaders et les assets.
-
-## Rendu headless avec Xvfb
-
-Étant donné que les conteneurs Docker n'ont pas d'affichage, nous utilisons **Xvfb** (X Virtual Framebuffer) pour simuler un affichage :
+### Construire l'image
 
 ```bash
-# Démarrer Xvfb
-Xvfb :99 -screen 0 1920x1080x24 &
-export DISPLAY=:99
+just docker-build
+```
 
-# Lancer l'application
+Cela crée une image conteneur optimisée avec :
+
+- Construction multi-étapes (builder + runtime minimal)
+- Persistance du cache CMake
+- Xvfb pour le rendu OpenGL headless
+
+### Lancer l'application
+
+```bash
+# Rendu logiciel (Mesa llvmpipe)
+just docker-run
+
+# Rendu accéléré GPU (Intel/AMD)
+just docker-run-gpu
+```
+
+Lance l'application dans un conteneur avec transfert X11 vers l'affichage hôte.
+
+## Architecture
+
+### Construction multi-étapes
+
+Le [`Dockerfile`](https://github.com/yoyonel/suckless-ogl/blob/main/Dockerfile) utilise deux étapes :
+
+#### Étape 1 : Builder (fedora:41)
+
+- Chaîne de compilation complète (clang, cmake, ninja, git)
+- **Montage cache BuildKit** sur `/src/build` pour les builds incrémentaux
+- Compilation en mode Release avec build parallèle
+- Copie uniquement le binaire final vers `/tmp/app`
+
+```dockerfile
+RUN --mount=type=cache,target=/src/build \
+    cmake -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTS=OFF \
+    && cmake --build build --parallel \
+    && cp build/app /tmp/app
+```
+
+#### Étape 2 : Runtime (fedora:41)
+
+- Dépendances runtime minimales uniquement :
+  - `glfw` — Gestion des fenêtres et entrées
+  - `mesa-libGL`, `mesa-libEGL`, `mesa-dri-drivers` — Rendu OpenGL logiciel
+  - `mesa-vulkan-drivers` — Support Vulkan/DRI pour le passthrough GPU
+  - `xorg-x11-server-Xvfb` — Framebuffer virtuel pour le rendu headless
+  - `gamemode` — Bibliothèque runtime pour le mode Performance
+- Utilisateur non-root (`appuser`) pour la sécurité
+- Contient uniquement : binaire, assets, shaders, script d'entrée
+
+### Rendu headless avec Xvfb
+
+Le script [`entrypoint.sh`](https://github.com/yoyonel/suckless-ogl/blob/main/entrypoint.sh) gère l'affichage virtuel :
+
+```bash
+#!/bin/bash
+set -e
+Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &
+sleep 2
+export DISPLAY=:99
 ./app
 ```
 
-Le script `entrypoint.sh` gère automatiquement le démarrage de Xvfb.
+### Optimisation du contexte de build
 
-## Cibles Makefile / Just
+Le fichier `.dockerignore` exclut agressivement les fichiers non nécessaires du contexte de build.
+Seuls les fichiers sources essentiels, shaders, assets et la configuration CMake sont envoyés à Docker :
 
-| Commande | Description |
-|---------|-------------|
-| `just docker-build` | Construction de l'image (multi-étapes) |
-| `just docker-run` | Exécution avec transfert X11 |
-| `just docker-test` | Tests dans le conteneur |
-| `just docker-clean-all` | Nettoyage complet (images, conteneurs, cache) |
-| `just ci-docker-all` | Pipeline CI complet (lint + build + test) |
-
-## Cache BuildKit
-
-Pour accélérer les rebuilds, le projet utilise les montages de cache BuildKit :
-
-```dockerfile
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && apt-get install -y cmake ...
+```text
+build/          # Artefacts de build
+build-*/        # Builds coverage/debug
+_deps/          # Cache FetchContent CMake (reconstruit dans le conteneur)
+deps/           # Dépendances pré-compilées
+.git/           # Historique Git
+docs/           # Documentation
+site/           # Sortie MkDocs
+tests/          # Suite de tests (désactivée via -DBUILD_TESTS=OFF)
+Testing/        # Artefacts CTest
+*.md            # Fichiers Markdown
+*.profraw       # Données de profilage LLVM
+*.profdata      # Données de couverture LLVM
 ```
 
-Cela évite de re-télécharger les paquets apt à chaque build.
+Cela réduit le transfert de contexte de **~870 Mo à ~2 Mo**, accélérant considérablement `docker build`.
 
-## Permissions GameMode
+!!! note "Tests désactivés dans le conteneur"
+    Le build conteneur utilise `-DBUILD_TESTS=OFF` car le répertoire `tests/` est exclu
+    du contexte de build. C'est intentionnel — les tests unitaires s'exécutent nativement via `just test-all`.
 
-Si GameMode est disponible sur l'hôte, le conteneur peut l'utiliser pour améliorer les performances :
+## Passthrough GPU
+
+Par défaut, `just docker-run` utilise le **rendu logiciel** (Mesa llvmpipe) via Xvfb.
+Pour le rendu accéléré matériellement, utilisez `just docker-run-gpu` qui passe le GPU hôte
+au conteneur via le DRI (Direct Rendering Infrastructure).
+
+### Prérequis
+
+- Hôte Linux avec GPU Intel ou AMD
+- Répertoire `/dev/dri` accessible
+- Utilisateur dans le groupe `video` sur l'hôte
+- Affichage X11 disponible (`$DISPLAY` défini)
+
+### Utilisation
 
 ```bash
-# Ajouter l'utilisateur au groupe gamemode
-sudo usermod -aG gamemode $USER
+just docker-run-gpu
+```
 
-# Exécuter avec les permissions étendues
-docker run --device /dev/dri --group-add gamemode app
+Cela monte le périphérique GPU de l'hôte et ajoute le groupe `video` :
+
+```bash
+docker run --rm -it \
+    --device /dev/dri \
+    --group-add video \
+    ...
+    suckless-ogl:latest /bin/bash -c "export DISPLAY=$DISPLAY && ./app"
+```
+
+### Comparaison de performance
+
+| Mode | Renderer | Temps IBL BRDF LUT |
+|------|----------|---------------------|
+| Logiciel (`docker-run`) | llvmpipe (Mesa) | ~1000 ms |
+| GPU (`docker-run-gpu`) | Mesa Intel Iris Xe | ~88 ms |
+
+!!! warning "GPUs NVIDIA"
+    Les GPUs NVIDIA nécessitent le [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html)
+    et `--gpus all` au lieu de `--device /dev/dri`. Cela n'est pas encore supporté par le projet.
+
+## Cibles Justfile
+
+### Cibles de build et d'exécution
+
+| Cible | Description | Commande `just` |
+|-------|-------------|-----------------|
+| Build Image | Construction avec cache de couches | `just docker-build` |
+| Build No Cache | Reconstruction complète forcée | `just docker-build-no-cache` |
+| Run (Logiciel) | Exécution avec transfert X11 (Mesa llvmpipe) | `just docker-run` |
+| Run (GPU) | Exécution avec passthrough GPU hôte (Intel/AMD) | `just docker-run-gpu` |
+
+### Cibles de maintenance
+
+| Cible | Description | Commande `just` |
+|-------|-------------|-----------------|
+| Clean Dangling | Suppression des images orphelines | `just docker-clean` |
+| Clean All | Purge de toutes les images et du cache | `just docker-clean-all` |
+| Disk Usage | Statistiques d'utilisation disque | `just docker-usage` |
+
+## Utilisation avancée
+
+### Moteur de conteneur personnalisé
+
+Le Justfile auto-détecte Docker ou Podman. Pour forcer un moteur spécifique :
+
+```bash
+container_engine=podman just docker-build
+```
+
+### Builds incrémentaux
+
+Grâce aux montages cache BuildKit, les builds suivants sont rapides :
+
+```bash
+# Premier build : ~2-3 minutes (fetch deps, compilation complète)
+just docker-build
+
+# Modifier src/shader.c
+# Deuxième build : ~10-20 secondes (recompile uniquement les fichiers modifiés)
+just docker-build
+```
+
+### GameMode & priorité temps réel
+
+Pour activer le **mode Performance** (SCHED_FIFO) et GameMode dans le conteneur, des permissions spécifiques sont nécessaires :
+
+- `--cap-add=SYS_NICE` : Permet au conteneur de définir des politiques d'ordonnancement temps réel
+- `--ulimit rtprio=99` : Permet à l'utilisateur non-root de demander la priorité temps réel
+- **Montage D-Bus** : Essentiel pour que `libgamemode` communique avec le démon GameMode de l'hôte
+
+## Dépannage
+
+### Le cache de build ne fonctionne pas
+
+Assurez-vous que BuildKit est activé :
+
+```bash
+# Docker
+export DOCKER_BUILDKIT=1
+
+# Podman (activé par défaut)
+```
+
+### Xvfb ne démarre pas
+
+Vérifiez que le port :99 est disponible :
+
+```bash
+docker run --rm -it suckless-ogl /bin/bash
+# Dans le conteneur :
+Xvfb :99 -screen 0 1920x1080x24
+```
+
+### Permission X11 refusée
+
+Réinitialisez les permissions xhost :
+
+```bash
+xhost +local:
+just docker-run
 ```
 
 ## CI/CD local
@@ -82,16 +234,9 @@ docker run --device /dev/dri --group-add gamemode app
 Pour reproduire exactement le pipeline GitHub Actions localement :
 
 ```bash
-# Exécuter tous les jobs CI dans Docker
 just ci-docker-all
 ```
 
-Cette commande enchaîne :
-1. `just ci-docker lint` — Analyse statique
-2. `just ci-docker Release` — Build + tests Release
-3. `just ci-docker Debug` — Build + tests Debug avec sanitizers
-
 ## Voir aussi
 
-- [cicd_pipeline.md](./cicd_pipeline.md) — Pipeline GitHub Actions
 - [build.md](./build.md) — Compilation sans Docker

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,8 +11,8 @@ This project includes a containerized build and runtime environment for consiste
 
 ### Build the Image
 
-```sh
-make docker-build
+```bash
+just docker-build
 ```
 
 This creates an optimized container image with:
@@ -23,8 +23,12 @@ This creates an optimized container image with:
 
 ### Run the Application
 
-```sh
-make docker-run
+```bash
+# Software rendering (Mesa llvmpipe)
+just docker-run
+
+# Hardware-accelerated rendering (Intel/AMD GPU)
+just docker-run-gpu
 ```
 
 Runs the application in a container with X11 forwarding to your host display.
@@ -47,6 +51,8 @@ RUN --mount=type=cache,target=/src/build \
     cmake -B build -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTS=OFF \
     && cmake --build build --parallel \
     && cp build/app /tmp/app
 ```
@@ -58,8 +64,8 @@ RUN --mount=type=cache,target=/src/build \
 
 - Minimal runtime dependencies only:
   - `glfw` - Window and input handling
-  - `mesa-*` - OpenGL drivers
-  - `mesa-*` - OpenGL drivers
+  - `mesa-libGL`, `mesa-libEGL`, `mesa-dri-drivers` - OpenGL software rendering
+  - `mesa-vulkan-drivers` - Vulkan/DRI support for GPU passthrough
   - `xorg-x11-server-Xvfb` - Virtual framebuffer for headless rendering
   - `gamemode` - Runtime library for Performance Mode
 - Non-root user (`appuser`) for security
@@ -101,37 +107,90 @@ This enables:
 - **Headless rendering** for automated screenshots/validation
 - **Consistent environment** across different systems
 
-### Build Cache Optimization
+### Build Context Optimization
 
-The `.dockerignore` file excludes unnecessary files from the build context:
+The `.dockerignore` file aggressively excludes unnecessary files from the build context.
+Only the essential source files, shaders, assets, and CMake configuration are sent to Docker:
 
-```
+```text
 build/          # Build artifacts
 build-*/        # Coverage/debug builds
+_deps/          # CMake FetchContent cache (rebuilt in container)
+deps/           # Pre-built dependencies
 .git/           # Git history
 docs/           # Documentation
+site/           # MkDocs output
+tests/          # Test suite (disabled in container via -DBUILD_TESTS=OFF)
+Testing/        # CTest artifacts
 *.md            # Markdown files
+*.profraw       # LLVM profiling data
+*.profdata      # LLVM coverage data
 ```
 
-This reduces context size and speeds up `docker build`.
+This reduces context transfer from **~870 MB to ~2 MB**, dramatically speeding up `docker build`.
 
-## Makefile Targets
+!!! note "Tests disabled in container"
+    The container build uses `-DBUILD_TESTS=OFF` since the `tests/` directory is excluded
+    from the build context. This is intentional — unit tests run natively via `just test-all`.
 
-### Build Targets
+## Justfile Targets
 
-| Target | Description | `make` | `just` |
-|--------|-------------|--------|--------|
-| Build Image | Build image with layer caching | `docker-build` | `docker-build` |
-| Build No Cache | Force full rebuild | `docker-build-no-cache` | `docker-build-no-cache` |
-| Run App | Run with X11 forwarding | `docker-run` | `docker-run` |
+### Build & Run Targets
+
+| Target | Description | `just` command |
+|--------|-------------|----------------|
+| Build Image | Build image with layer caching | `just docker-build` |
+| Build No Cache | Force full rebuild | `just docker-build-no-cache` |
+| Run (Software) | Run with X11 forwarding (Mesa llvmpipe) | `just docker-run` |
+| Run (GPU) | Run with host GPU passthrough (Intel/AMD) | `just docker-run-gpu` |
 
 ### Maintenance Targets
 
-| Target | Description | `make` | `just` |
-|--------|-------------|--------|--------|
-| Clean Dangling | Remove dangling images | `docker-clean` | `docker-clean` |
-| Clean All | Prune all images and cache | `docker-clean-all` | `docker-clean-all` |
-| Disk Usage | Show disk usage stats | `docker-usage` | `docker-usage` |
+| Target | Description | `just` command |
+|--------|-------------|----------------|
+| Clean Dangling | Remove dangling images | `just docker-clean` |
+| Clean All | Prune all images and cache | `just docker-clean-all` |
+| Disk Usage | Show disk usage stats | `just docker-usage` |
+
+## GPU Passthrough
+
+By default, `just docker-run` uses **software rendering** (Mesa llvmpipe) via Xvfb.
+For hardware-accelerated rendering, use `just docker-run-gpu` which passes the host GPU
+through to the container via the DRI (Direct Rendering Infrastructure).
+
+### Requirements
+
+- Linux host with Intel or AMD GPU
+- `/dev/dri` device directory accessible
+- User in the `video` group on the host
+- X11 display available (`$DISPLAY` set)
+
+### How It Works
+
+```bash
+just docker-run-gpu
+```
+
+This mounts the host's GPU device and adds the `video` group:
+
+```bash
+docker run --rm -it \
+    --device /dev/dri \
+    --group-add video \
+    ...
+    suckless-ogl:latest /bin/bash -c "export DISPLAY=$DISPLAY && ./app"
+```
+
+### Performance Comparison
+
+| Mode | Renderer | IBL BRDF LUT Time |
+|------|----------|-------------------|
+| Software (`docker-run`) | llvmpipe (Mesa) | ~1000 ms |
+| GPU (`docker-run-gpu`) | Mesa Intel Iris Xe | ~88 ms |
+
+!!! warning "NVIDIA GPUs"
+    NVIDIA GPUs require the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html)
+    and `--gpus all` instead of `--device /dev/dri`. This is not yet supported by the project.
 
 ## Advanced Usage
 
@@ -162,12 +221,12 @@ make docker-build
 make docker-build
 ```
 
-### Running with Host X11
+### Running with Host X11 (Software Rendering)
 
-The `docker-run` target forwards X11:
+The `docker-run` target forwards X11 and uses software rendering:
 
-```sh
-make docker-run
+```bash
+just docker-run
 # Equivalent to:
 docker run --rm -it \
     --cap-add=SYS_NICE \
@@ -181,6 +240,8 @@ docker run --rm -it \
     -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
     suckless-ogl /bin/bash -c "export DISPLAY=$DISPLAY && ./app"
 ```
+
+For hardware-accelerated rendering with the host GPU, see [GPU Passthrough](#gpu-passthrough) above.
 
 ### GameMode & Real-Time Priority
 


### PR DESCRIPTION
## Summary

Fixes Docker build context bloat and adds GPU passthrough support for hardware-accelerated rendering in containers.

## Changes

### 1. Build context optimization (`ci(docker)`)
- Rewrote `.dockerignore` to exclude `deps/` (636MB), `_deps/`, `tests/`, `Testing/`, `site/`, `.github/`, `hooks/`, profiling data, and other non-essential files
- **Result: context transfer reduced from ~870MB to ~2MB**
- Added `-DBUILD_TESTS=OFF` to Dockerfile (tests excluded from context)
- Added `mesa-vulkan-drivers` to runtime stage for DRI support

### 2. GPU passthrough (`feat(docker)`)
- New `just docker-run-gpu` recipe with `--device /dev/dri` and `--group-add video`
- Pre-flight check for `/dev/dri` existence
- Supports Intel/AMD GPUs via DRI (Direct Rendering Infrastructure)
- **Performance: IBL BRDF LUT ~88ms (GPU) vs ~1000ms (software)**

### 3. Documentation (`docs(docker)`)
- Updated EN + FR Docker guides with context optimization details
- Added GPU passthrough section (requirements, usage, performance comparison)
- Fixed outdated code snippets and dependency lists
- Rewrote FR translation (was referencing Debian instead of Fedora 41)

## Testing
- `just lint` ✅ (0 warnings)
- `just test-all` ✅ (63/63 tests passed)
- `just docker-build` ✅ (context: 2.19MB)
- `just docker-run` ✅ (software rendering — llvmpipe)
- `just docker-run-gpu` ✅ (Mesa Intel Iris Xe Graphics, OpenGL 4.6)