### PR TITLE
refactor(naming): Ubiquitous language — naming disambiguation (#206-#209)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set(SOURCES
     src/sh_math.c
     src/simd_utils.c
     src/skybox.c
-    src/sphere_sorting.c
+    src/billboard_sorting.c
     src/ssbo_rendering.c
     src/stb_image_impl.c
     src/texture.c

--- a/docs/application_lifecycle.fr.md
+++ b/docs/application_lifecycle.fr.md
@@ -341,10 +341,10 @@ Chaque subdivision : division des arêtes aux milieux, normalisation sur la sph�
 ### 4.5 — Buffers GPU
 
 ```c
-glGenVertexArrays(1, &scene->sphere_vao);
-glGenBuffers(1, &scene->sphere_vbo);   // Positions
-glGenBuffers(1, &scene->sphere_nbo);   // Normales
-glGenBuffers(1, &scene->sphere_ebo);   // Indices (triangles)
+glGenVertexArrays(1, &scene->icosphere_vao);
+glGenBuffers(1, &scene->icosphere_vbo);   // Positions
+glGenBuffers(1, &scene->icosphere_nbo);   // Normales
+glGenBuffers(1, &scene->icosphere_ebo);   // Indices (triangles)
 ```
 
 De la géométrie utilitaire supplémentaire est créée :
@@ -1214,7 +1214,7 @@ Voici une estimation de la consommation VRAM en régime stationnaire :
 | `src/material.c` | Bibliothèque matériaux (chargement JSON) |
 | `src/instanced_rendering.c` | Gestion VAO/VBO draw instancié |
 | `src/billboard_rendering.c` | Quads billboard pour sphères transparentes |
-| `src/sphere_sorting.c` | Tri transparence CPU/GPU |
+| `src/billboard_sorting.c` | Tri transparence CPU/GPU |
 | `src/async_loader.c` | Thread I/O arrière-plan (pthread) |
 | `src/camera.c` | Caméra orbitale, physique pas fixe |
 | `src/gl_debug.c` | Callback messages debug OpenGL |

--- a/docs/application_lifecycle.md
+++ b/docs/application_lifecycle.md
@@ -341,10 +341,10 @@ Each subdivision: split edges at midpoints, normalize onto unit sphere, cache mi
 ### 4.5 — GPU Buffers
 
 ```c
-glGenVertexArrays(1, &scene->sphere_vao);
-glGenBuffers(1, &scene->sphere_vbo);   // Positions
-glGenBuffers(1, &scene->sphere_nbo);   // Normals
-glGenBuffers(1, &scene->sphere_ebo);   // Indices (triangles)
+glGenVertexArrays(1, &scene->icosphere_vao);
+glGenBuffers(1, &scene->icosphere_vbo);   // Positions
+glGenBuffers(1, &scene->icosphere_nbo);   // Normals
+glGenBuffers(1, &scene->icosphere_ebo);   // Indices (triangles)
 ```
 
 Additional utility geometry is created:
@@ -1214,7 +1214,7 @@ Here's an estimate of VRAM consumption at steady state:
 | `src/material.c` | Material library (JSON loading) |
 | `src/instanced_rendering.c` | VAO/VBO instanced draw management |
 | `src/billboard_rendering.c` | Billboard quads for transparent spheres |
-| `src/sphere_sorting.c` | CPU/GPU transparency sorting |
+| `src/billboard_sorting.c` | CPU/GPU transparency sorting |
 | `src/async_loader.c` | Background I/O thread (pthread) |
 | `src/camera.c` | Orbit camera, fixed-timestep physics |
 | `src/gl_debug.c` | OpenGL debug message callback |

--- a/docs/billboard_gl_call_reduction.fr.md
+++ b/docs/billboard_gl_call_reduction.fr.md
@@ -250,7 +250,7 @@ intermédiaires.
 | `src/scene.c` | `scene_render_billboards()` — upload UBO, bind textures, bind SSBO |
 | `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — copie VBO legacy (debug uniquement) |
 | `src/billboard_rendering.c` | `billboard_group_draw()` — bind VAO, état cull, draw call |
-| `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — dispatch compute |
+| `src/billboard_sorting.c` | `billboard_sorter_sort_gpu()` — dispatch compute |
 | `shaders/billboard_instance_ssbo.glsl` | **Nouveau** — SSBO SphereInstance pour lecture directe vertex (`binding = 2`) |
 | `shaders/billboard_ubo.glsl` | Définition bloc UBO partagé (`binding = 1`) |
 | `shaders/pbr_ibl_billboard.vert` | Vertex shader — fetch SSBO via `gl_InstanceID` |

--- a/docs/billboard_gl_call_reduction.md
+++ b/docs/billboard_gl_call_reduction.md
@@ -257,7 +257,7 @@ is consumed directly by the vertex shader without intermediate copies.
 | `src/scene.c` | `scene_render_billboards()` — UBO upload, texture binding, SSBO bind |
 | `src/billboard_rendering.c` | `billboard_group_update_from_buffer()` — legacy VBO copy (debug only) |
 | `src/billboard_rendering.c` | `billboard_group_draw()` — VAO bind, cull state, draw call |
-| `src/sphere_sorting.c` | `sphere_sorter_sort_gpu()` — compute dispatch |
+| `src/billboard_sorting.c` | `billboard_sorter_sort_gpu()` — compute dispatch |
 | `shaders/billboard_instance_ssbo.glsl` | **New**: SphereInstance SSBO for direct vertex shader read (`binding = 2`) |
 | `shaders/billboard_ubo.glsl` | Shared UBO block definition (`binding = 1`) |
 | `shaders/pbr_ibl_billboard.vert` | Vertex shader — SSBO fetch via `gl_InstanceID` |

--- a/docs/diagram_index.md
+++ b/docs/diagram_index.md
@@ -781,6 +781,25 @@ ADAPT --> EXP[Exposure Tex]
   </div>
 </div>
 
+<div class="diagram-item">
+  <a href="../auto_exposure_opt_report/#architecture" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">Architecture</a> : <span style="opacity: 0.6; font-size: 0.85em;">A notification (&quot;AE Path: Fragment&quot; / &quot;AE Path: Compute&quot;) confirms the switch. The GPU Profiler label also changes dynamically to reflect which path is active.</span>
+  <div class="mermaid-preview">
+
+```mermaid
+graph TD
+SCENE[Scene Color Texture]
+SCENE --> SWITCH{active_path?}
+SWITCH -->|Fragment| FRAG["FS Quad -> FBO 64x64"]
+SWITCH -->|Compute| COMP["CS Dispatch 4x4 WG"]
+FRAG --> DS_TEX[Downsample Tex R32F]
+COMP --> DS_TEX
+DS_TEX --> ADAPT["CS: Adaptation 1x1"]
+ADAPT --> EXP[Exposure Tex]
+```
+
+  </div>
+</div>
+
 
 ## [Environment Transitions](../env_transitions/)
 
@@ -914,6 +933,31 @@ GPU-->>Main: FBOs recreated (OK)
 </div>
 
 
+## [Gamepad Camera Control](../gamepad/)
+
+<div class="diagram-item">
+  <a href="../gamepad/#architecture" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">Architecture</a> : <span style="opacity: 0.6; font-size: 0.85em;">physics step.</span>
+  <div class="mermaid-preview">
+
+```mermaid
+graph TD
+subgraph "Per Frame (1x)"
+GLFW[GLFW Gamepad API] --> POLL[gamepad_input_poll]
+POLL -->|deadzone filter| AXES[state.axes cache]
+POLL -->|edge detect| BTN[GamepadActions: L1/R1/Share]
+end
+subgraph "Per Physics Step (Nx)"
+KB[camera_build_keyboard_input] --> MI[cam.move_input]
+AXES --> WRITE[gamepad_write_input]
+WRITE -->|overlay| MI
+MI --> PHYS[camera_fixed_update]
+end
+```
+
+  </div>
+</div>
+
+
 ## [Global Illumination (1-Bounce)](../global_illumination/)
 
 <div class="diagram-item">
@@ -952,6 +996,64 @@ Note over GPU: Fragments sample irradiance from 8 adjacent probes (Trilinear Fil
 </div>
 
 
+## [Domain Model — Ubiquitous Language](../glossary/)
+
+<div class="diagram-item">
+  <a href="../glossary/#relationships" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">🔗 Relationships</a> : <span style="opacity: 0.6; font-size: 0.85em;">---</span>
+  <div class="mermaid-preview">
+
+```mermaid
+graph TD
+Scene --> InstancedGroup["Instanced Group"]
+Scene --> BillboardGroup["Billboard Group"]
+Scene --> Skybox
+Scene --> NBody["N-Body Simulation"]
+Scene --> TrailRenderer["Trail Renderer"]
+Scene --> IBLCoordinator["IBL Coordinator"]
+Scene --> LightProbeGrid["Light Probe Grid"]
+NBody -->|"contains up to 32"| Body
+Body -->|"produces per frame"| SphereInstance["Sphere Instance"]
+TrailRenderer -->|"one per Body"| TrailRing["Trail Ring"]
+IBLCoordinator -->|"generates"| IrradianceMap["Irradiance Map"]
+IBLCoordinator -->|"generates"| SpecularMap["Prefiltered Specular Map"]
+LightProbeGrid -->|"lattice of"| LightProbe["Light Probe"]
+LightProbe -->|"stores"| SH9
+PostProcess -->|"chain of"| Effect
+```
+
+  </div>
+</div>
+
+
+## [GPU Usage Monitor](../gpu_usage_monitor/)
+
+<div class="diagram-item">
+  <a href="../gpu_usage_monitor/#architecture" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">Architecture</a> : <span style="opacity: 0.6; font-size: 0.85em;">| `nouveau` | `drm-engine-gr` | NVIDIA (open-source driver) |</span>
+  <div class="mermaid-preview">
+
+```mermaid
+flowchart TD
+A[gpu_usage_init] --> B[Scan /proc/self/fdinfo/]
+B --> C{DRM render node?}
+C -->|Yes| D[Read drm-driver & drm-client-id]
+C -->|No| B
+D --> E{Duplicate client-id?}
+E -->|Yes| B
+E -->|No| F[Keep FILE* stream open]
+F --> B
+B -->|Done| G[Store driver + engine_key]
+H[gpu_usage_update] --> I{500ms elapsed?}
+I -->|No| J[Return early]
+I -->|Yes| K[Re-read all streams]
+K --> L[Sum engine time across FDs]
+L --> M["GPU% = Δgpu / Δwall × 100"]
+M --> N[Clamp 0–100%]
+```
+
+  </div>
+</div>
+
+
 ## [Motion Blur Implementation Analysis](../motion_blur_analysis/)
 
 <div class="diagram-item">
@@ -982,6 +1084,27 @@ M -->|8-frame Sampling + Interleaved Gradient Noise + Depth Weighting| O[Blurred
 graph LR
 A[Linear Blur \nStandard Suckless OGL] -->|Creates straight lines and artifacts| B(Punch trajectory)
 C[Curved Blur \nRE Engine / SF6] -->|Sampling along a circular arc| D(Anime/Manga-style stylized blur)
+```
+
+  </div>
+</div>
+
+
+## [Neon Trail Rendering](../neon_trails/)
+
+<div class="diagram-item">
+  <a href="../neon_trails/#architecture" style="font-weight: 500; font-size: 1.1em; color: var(--md-typeset-a-color);">Architecture</a> : <span style="opacity: 0.6; font-size: 0.85em;">Each change displays an on-screen notification with the current value.</span>
+  <div class="mermaid-preview">
+
+```mermaid
+graph TD
+A[TrailRenderer::neon] -->|intensity, width| B[build_ribbon CPU]
+A -->|core_exp| C[trail.frag GPU]
+B -->|HDR vertices| D[VBO Upload]
+D --> E[glMultiDrawArrays]
+C -->|Neon profile| E
+E -->|HDR output| F[Bloom Post-Process]
+F -->|Wide halo| G[Final Composite]
 ```
 
   </div>

--- a/docs/glossary.fr.md
+++ b/docs/glossary.fr.md
@@ -80,7 +80,7 @@ du projet, leurs relations et les ambiguïtés de nommage connues.
 | **Billboard** | Un quad aligné à l'écran qui rend une sphère via raycasting dans le fragment shader, moins coûteux que le rendu de maillage. | Imposteur, sprite, quad |
 | **Groupe de Billboards** (Billboard Group) | Un ensemble géré de **Billboards** avec un VAO partagé et un VBO par instance pour le dessin GPU (`BillboardGroup`). | Batch de billboards |
 | **Instance de Sphère** (Sphere Instance) | Un paquet de données par instance de 64 octets alignés (matrice modèle, matériau PBR, position précédente) envoyé au GPU (`SphereInstance`). | Données d'instance |
-| **Trieur de Sphères** (Sphere Sorter) | Le sous-système qui ordonne les **Billboards** transparents d'arrière en avant pour un mélange alpha correct (`SphereSorter`). | Passe de tri |
+| **Trieur de Billboards** (Billboard Sorter) | Le sous-système qui ordonne les **Billboards** transparents d'arrière en avant pour un mélange alpha correct (`BillboardSorter`). | Passe de tri |
 | **Mode de Tri** (Sorting Mode) | L'algorithme utilisé par le **Trieur** : qsort CPU, radix CPU ou bitonic GPU (`SortingMode`). | Stratégie de tri |
 
 ## 🎨 Rendu — Ombrage & Éclairage
@@ -215,7 +215,7 @@ graph TD
 
 > **Dev :** « Quand on rend la scène, les **Corps** sont dessinés en tant que **Billboards** ou maillages **Icosphère** ? »
 >
-> **Expert domaine :** « Les deux chemins existent. Le **Groupe Instancié** dessine les **Corps** opaques en tant que maillages **Icosphère** via `glDrawElementsInstanced`. Le **Groupe de Billboards** dessine les **Corps** transparents en tant que quads alignés à l'écran avec raycasting dans le fragment shader. Le **Trieur de Sphères** ordonne le tableau de **Billboards** d'arrière en avant avant chaque frame. »
+> **Expert domaine :** « Les deux chemins existent. Le **Groupe Instancié** dessine les **Corps** opaques en tant que maillages **Icosphère** via `glDrawElementsInstanced`. Le **Groupe de Billboards** dessine les **Corps** transparents en tant que quads alignés à l'écran avec raycasting dans le fragment shader. Le **Trieur de Billboards** ordonne le tableau de **Billboards** d'arrière en avant avant chaque frame. »
 >
 > **Dev :** « Et les données d'**Instance de Sphère** — c'est le même format pour les deux chemins ? »
 >

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -80,8 +80,8 @@ their relationships, and known naming ambiguities.
 | **Billboard** | A screen-aligned quad that renders a sphere via fragment-shader raycasting, cheaper than mesh rendering. | Impostor, sprite, quad |
 | **Billboard Group** | A managed set of **Billboards** with a shared VAO and per-instance VBO for GPU-driven drawing (`BillboardGroup`). | Billboard batch |
 | **Sphere Instance** | A 64-byte-aligned per-instance data packet (model matrix, PBR material, previous position) sent to the GPU (`SphereInstance`). | Instance data, per-object data |
-| **Sphere Sorter** | The subsystem that orders transparent **Billboards** back-to-front for correct alpha blending (`SphereSorter`). | Sort pass, transparency sort |
-| **Sorting Mode** | The algorithm used by the **Sphere Sorter**: CPU qsort, CPU radix, or GPU bitonic (`SortingMode`). | Sort strategy |
+| **Billboard Sorter** | The subsystem that orders transparent **Billboards** back-to-front for correct alpha blending (`BillboardSorter`). | Sort pass, transparency sort |
+| **Sorting Mode** | The algorithm used by the **Billboard Sorter**: CPU qsort, CPU radix, or GPU bitonic (`SortingMode`). | Sort strategy |
 
 ## 🎨 Rendering — Shading & Lighting
 
@@ -215,7 +215,7 @@ graph TD
 
 > **Dev:** "When we render the scene, are the **Bodies** drawn as **Billboards** or **Icosphere** meshes?"
 >
-> **Domain expert:** "Both paths exist. The **Instanced Group** draws opaque **Bodies** as **Icosphere** meshes via `glDrawElementsInstanced`. The **Billboard Group** draws transparent **Bodies** as screen-aligned quads with raycasting in the fragment shader. The **Sphere Sorter** orders the **Billboard** array back-to-front before each frame."
+> **Domain expert:** "Both paths exist. The **Instanced Group** draws opaque **Bodies** as **Icosphere** meshes via `glDrawElementsInstanced`. The **Billboard Group** draws transparent **Bodies** as screen-aligned quads with raycasting in the fragment shader. The **Billboard Sorter** orders the **Billboard** array back-to-front before each frame."
 >
 > **Dev:** "And the **Sphere Instance** data — is it the same for both paths?"
 >

--- a/docs/gpu_utilization_optimization.fr.md
+++ b/docs/gpu_utilization_optimization.fr.md
@@ -123,8 +123,8 @@ Ajout de marqueurs CPU `PROFILE_ZONE` aux points de synchronisation clés :
 |:---|:---|:---|
 | `"GPU Query Readback (sync)"` | `gpu_profiler.c` | Mesurer la boucle bloquante `glGetQueryObjectui64v` |
 | `"GI Probe Sync (buffer upload)"` | `scene.c` | `glBufferSubData` SSBO + packing texture 3D pour les sondes GI |
-| `"GPU Sort: SSBO Upload"` | `sphere_sorting.c` | Transfert des données d'instances vers le GPU |
-| `"GPU Sort: Compute Dispatch"` | `sphere_sorting.c` | Chaîne complète dispatch + barrières |
+| `"GPU Sort: SSBO Upload"` | `billboard_sorting.c` | Transfert des données d'instances vers le GPU |
+| `"GPU Sort: Compute Dispatch"` | `billboard_sorting.c` | Chaîne complète dispatch + barrières |
 | `"PostProcess UBO Upload"` | `postprocess.c` | Détection de sync implicite `glBufferSubData` |
 
 ## Phase 2 : Réordonnancement de la Boucle Principale (**Testé — Invalidé**)

--- a/docs/gpu_utilization_optimization.md
+++ b/docs/gpu_utilization_optimization.md
@@ -123,8 +123,8 @@ Added `PROFILE_ZONE` CPU markers at key synchronization points:
 |:---|:---|:---|
 | `"GPU Query Readback (sync)"` | `gpu_profiler.c` | Measure blocking `glGetQueryObjectui64v` loop |
 | `"GI Probe Sync (buffer upload)"` | `scene.c` | `glBufferSubData` SSBO + 3D texture packing for GI probes |
-| `"GPU Sort: SSBO Upload"` | `sphere_sorting.c` | Instance data transfer to GPU |
-| `"GPU Sort: Compute Dispatch"` | `sphere_sorting.c` | Full dispatch + barrier chain |
+| `"GPU Sort: SSBO Upload"` | `billboard_sorting.c` | Instance data transfer to GPU |
+| `"GPU Sort: Compute Dispatch"` | `billboard_sorting.c` | Full dispatch + barrier chain |
 | `"PostProcess UBO Upload"` | `postprocess.c` | `glBufferSubData` implicit sync detection |
 
 ## Phase 2: Main Loop Reordering (**Tested — Invalidated**)

--- a/docs/memory_management_audit.fr.md
+++ b/docs/memory_management_audit.fr.md
@@ -30,12 +30,12 @@ L'audit a porté sur les structures suivantes identifiées comme gérant de la m
 | `AsyncRequest` | `float_data`, `half_data` | Bas | Utilise un pattern de "transfert de propriété destructif" sécurisé dans `async_loader_poll`. |
 | `PBRMaterial` | `name` (tableau fixe) | Nul | Structure POD (Plain Old Data). Copie sûre. |
 | `MaterialLib` | `materials` (tableau dynamique) | Nul | Géré exclusivement par pointeurs (`MaterialLib*`). Pas de copie par valeur. |
-| `SphereInstance` | Aucun (Vecteurs/Matrices) | Nul | Structure POD. Copie sûre (utilisée massivement dans `sphere_sorting.c`). |
-| `scene_init_instancing` | instance VBO, billboard VBO, `sphere_instances`, `sphere_sorter` | **Corrigé** | Le chemin de ré-init N-body OFF appelle désormais le cleanup avant la ré-init pour éviter une fuite de ~27 Ko par bascule. |
+| `SphereInstance` | Aucun (Vecteurs/Matrices) | Nul | Structure POD. Copie sûre (utilisée massivement dans `billboard_sorting.c`). |
+| `scene_init_instancing` | instance VBO, billboard VBO, `billboard_instances`, `billboard_sorter` | **Corrigé** | Le chemin de ré-init N-body OFF appelle désormais le cleanup avant la ré-init pour éviter une fuite de ~27 Ko par bascule. |
 
 ### Points Particulièrement Examinés
 
-* **`sphere_sorting.c`** : Effectue des copies de `SphereInstance` lors du tri. C'est parfaitement sûr car `SphereInstance` ne contient que des types par valeur (mathématiques cglm).
+* **`billboard_sorting.c`** : Effectue des copies de `SphereInstance` lors du tri. C'est parfaitement sûr car `SphereInstance` ne contient que des types par valeur (mathématiques cglm).
 * **`async_loader.c`** : Le passage de `AsyncRequest` du thread worker au thread principal est sécurisé. Le loader met explicitement à `NULL` ses pointeurs internes après la copie vers le demandeur, évitant ainsi tout conflit de propriété.
 
 ## 4. Recommandations et Bonnes Pratiques

--- a/docs/memory_management_audit.md
+++ b/docs/memory_management_audit.md
@@ -30,12 +30,12 @@ The audit covered the following structures identified as managing dynamic memory
 | `AsyncRequest` | `float_data`, `half_data` | Low | Uses a safe destructive ownership-transfer pattern in `async_loader_poll`. |
 | `PBRMaterial` | `name` (fixed array) | None | POD (Plain Old Data) struct. Safe to copy. |
 | `MaterialLib` | `materials` (dynamic array) | None | Managed exclusively via pointers (`MaterialLib*`). No value copy. |
-| `SphereInstance` | None (Vectors/Matrices) | None | POD struct. Safe to copy (used heavily in `sphere_sorting.c`). |
-| `scene_init_instancing` | instance VBO, billboard VBO, `sphere_instances`, `sphere_sorter` | **Fixed** | N-body OFF re-init path now calls cleanup before re-init to avoid leaking ~27 KB per toggle. |
+| `SphereInstance` | None (Vectors/Matrices) | None | POD struct. Safe to copy (used heavily in `billboard_sorting.c`). |
+| `scene_init_instancing` | instance VBO, billboard VBO, `billboard_instances`, `billboard_sorter` | **Fixed** | N-body OFF re-init path now calls cleanup before re-init to avoid leaking ~27 KB per toggle. |
 
 ### Specifically Examined Points
 
-* **`sphere_sorting.c`**: Performs `SphereInstance` copies during sorting. This is entirely safe as `SphereInstance` contains only value types (cglm math types).
+* **`billboard_sorting.c`**: Performs `SphereInstance` copies during sorting. This is entirely safe as `SphereInstance` contains only value types (cglm math types).
 * **`async_loader.c`**: Passing `AsyncRequest` from the worker thread to the main thread is safe. The loader explicitly nulls its internal pointers after copying to the requester, preventing any ownership conflict.
 
 ## 4. Recommendations and Best Practices

--- a/docs/nbody_physics.fr.md
+++ b/docs/nbody_physics.fr.md
@@ -429,11 +429,11 @@ par l'appel précédent pour éviter les fuites de buffers GPU et de mémoire CP
 /* Nettoyage avant ré-init (scene.c — branche N-body OFF) */
 trail_renderer_cleanup(&scene->trail_renderer);
 #ifdef USE_TRANSPARENT_BILLBOARDS
-if (scene->sphere_instances) {
-    platform_aligned_free(scene->sphere_instances);
-    scene->sphere_instances = NULL;
+if (scene->billboard_instances) {
+    platform_aligned_free(scene->billboard_instances);
+    scene->billboard_instances = NULL;
 }
-sphere_sorter_cleanup(&scene->sphere_sorter);
+billboard_sorter_cleanup(&scene->billboard_sorter);
 #endif
 instanced_group_cleanup(&scene->instanced_group);
 billboard_group_cleanup(&scene->billboard_group);

--- a/docs/nbody_physics.md
+++ b/docs/nbody_physics.md
@@ -417,11 +417,11 @@ buffer and CPU memory leaks:
 /* Cleanup before re-init (scene.c — N-body OFF branch) */
 trail_renderer_cleanup(&scene->trail_renderer);
 #ifdef USE_TRANSPARENT_BILLBOARDS
-if (scene->sphere_instances) {
-    platform_aligned_free(scene->sphere_instances);
-    scene->sphere_instances = NULL;
+if (scene->billboard_instances) {
+    platform_aligned_free(scene->billboard_instances);
+    scene->billboard_instances = NULL;
 }
-sphere_sorter_cleanup(&scene->sphere_sorter);
+billboard_sorter_cleanup(&scene->billboard_sorter);
 #endif
 instanced_group_cleanup(&scene->instanced_group);
 billboard_group_cleanup(&scene->billboard_group);

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -142,7 +142,7 @@ digraph ProjectStructure {
 
 - `pbr.c`: Configures PBR shaders.
 - `material.c`: Manages the material library.
-- `sphere_sorting.c`: Sorts transparent instances (Back-to-Front).
+- `billboard_sorting.c`: Sorts transparent instances (Back-to-Front).
 
 ## Improvements over Original Code
 

--- a/docs/sphere_rendering.fr.md
+++ b/docs/sphere_rendering.fr.md
@@ -2,9 +2,9 @@
 
 Ce document décrit l'architecture de rendu des sphères PBR avec tri Back-to-Front et anti-aliasing analytique.
 
-## Architecture : SphereSorter
+## Architecture : BillboardSorter
 
-La classe `SphereSorter` gère le tri des sphères pour le rendu correct de la transparence.
+La classe `BillboardSorter` gère le tri des sphères pour le rendu correct de la transparence.
 
 ```c
 typedef struct {
@@ -12,7 +12,7 @@ typedef struct {
     float* depths;                // Profondeurs pré-calculées
     uint32_t* sorted_indices;     // Indices triés (Back-to-Front)
     uint32_t count;
-} SphereSorter;
+} BillboardSorter;
 ```
 
 ## Tri Back-to-Front
@@ -31,7 +31,7 @@ for (uint32_t i = 0; i < sorter->count; i++) {
 }
 
 // Tri (voir gpu_sorting.md pour les algorithmes)
-sphere_sorter_sort(sorter, sort_backend);
+billboard_sorter_sort(sorter, sort_backend);
 ```
 
 ## Anti-aliasing analytique via discriminant
@@ -71,7 +71,7 @@ Les sphères sont rendues en une seule passe via `glDrawArraysInstanced` :
 
 ```c
 // Mettre à jour le VBO des instances avec les données triées
-glBindBuffer(GL_ARRAY_BUFFER, sphere_vbo);
+glBindBuffer(GL_ARRAY_BUFFER, icosphere_vbo);
 glBufferSubData(GL_ARRAY_BUFFER, 0,
                 sorter->count * sizeof(SphereInstance),
                 sorter->sorted_instances);

--- a/docs/sphere_rendering.md
+++ b/docs/sphere_rendering.md
@@ -7,15 +7,15 @@ This document details the "High Quality" rendering implementation for sphere ins
 
 To correctly handle Transparency Alpha Blending (`GL_SRC_ALPHA`, `GL_ONE_MINUS_SRC_ALPHA`), objects must be drawn from furthest to closest (Back-to-Front) relative to the camera.
 
-### SphereSorter Architecture
-The sorting system is encapsulated in the `sphere_sorting` module (`src/sphere_sorting.c`).
+### BillboardSorter Architecture
+The sorting system is encapsulated in the `billboard_sorting` module (`src/billboard_sorting.c`).
 
 1.  **Data**:
     -   Instances (`SphereInstance`) are stored contiguously.
-    -   An intermediate structure `SphereSortEntry` contains `{ index, depth }` for each sphere.
+    -   An intermediate structure `BillboardSortEntry` contains `{ index, depth }` for each sphere.
 2.  **Algorithm**:
     -   Each frame, the squared distance (`glm_vec3_distance2`) between the camera and each sphere is calculated.
-    -   Standard `qsort` is used to sort `SphereSortEntry` keys by descending depth (Back-to-Front).
+    -   Standard `qsort` is used to sort `BillboardSortEntry` keys by descending depth (Back-to-Front).
     -   A temporary sorted instance buffer is reconstructed.
 3.  **SIMD Optimization**:
     -   Instance buffers are allocated via `aligned_alloc` with 64-byte alignment (`SIMD_ALIGNMENT`) to optimize memory access and enable potential AVX vectorization.
@@ -23,7 +23,7 @@ The sorting system is encapsulated in the `sphere_sorting` module (`src/sphere_s
 ### Rendering Pipeline
 If the `USE_TRANSPARENT_BILLBOARDS` macro is enabled and "Transparent" mode is active (Key `T`):
 1.  **Skybox Render** (First, depth write).
-2.  **CPU Sort** of spheres via `sphere_sorter_sort`.
+2.  **CPU Sort** of spheres via `billboard_sorter_sort`.
 3.  **Upload** sorted data via `glBufferSubData`.
 4.  **Draw** spheres with Blending enabled and Depth Write **disabled** (Read-Only).
 

--- a/include/app_settings.h
+++ b/include/app_settings.h
@@ -51,7 +51,7 @@ static const unsigned int DEFAULT_STENCIL_MASK = 0xFF;
  * **If Defined**:
  * - Spheres are rendered as **Transparent** billboards (`GL_BLEND` enabled).
  * - Requires CPU-side sorting (Back-to-Front) every frame in `app_render()`.
- * - Uses `sphere_sorting.c` module.
+ * - Uses `billboard_sorting.c` module.
  * - Alpha channel allows true see-through glass effects.
  *
  * **If Undefined (Legacy/Fast Calculation)**:

--- a/include/billboard_sorting.h
+++ b/include/billboard_sorting.h
@@ -1,28 +1,28 @@
 /**
- * @file sphere_sorting.h
+ * @file billboard_sorting.h
  * @brief Back-to-front sorting for transparent geometry.
  *
  * This module provides an efficient sorting mechanism for sphere instances,
  * which is required for correct alpha blending of billboarded spheres.
  */
 
-#ifndef SPHERE_SORTING_H
-#define SPHERE_SORTING_H
+#ifndef BILLBOARD_SORTING_H
+#define BILLBOARD_SORTING_H
 
 #include "instanced_rendering.h"
 #include <cglm/cglm.h>
 
 /**
- * @struct SphereSortEntry
+ * @struct BillboardSortEntry
  * @brief Lightweight proxy for sorting data without moving large structs.
  */
 typedef struct {
 	int original_index; /**< Position in the source array. */
 	float depth;        /**< Squared distance from camera. */
-} SphereSortEntry;
+} BillboardSortEntry;
 
 /**
- * @struct SphereSorter
+ * @struct BillboardSorter
  * @brief Reusable memory context for sorting operations.
  */
 typedef struct {
@@ -39,26 +39,26 @@ typedef struct {
 	GLint loc_j;         /**< u_j uniform. */
 	GLint loc_k;         /**< u_k uniform. */
 
-	SphereSortEntry* entries;       /**< Scratchpad for CPU sorting. */
-	SphereSortEntry* entries_aux;   /**< Aux scratchpad for Radix Sort. */
-	SphereInstance* temp_instances; /**< Scratchpad for reordering. */
+	BillboardSortEntry* entries;     /**< Scratchpad for CPU sorting. */
+	BillboardSortEntry* entries_aux; /**< Aux scratchpad for Radix Sort. */
+	SphereInstance* temp_instances;  /**< Scratchpad for reordering. */
 	int ssbo_capacity; /**< Current allocated size of SSBOs (GPU). */
 	int cpu_capacity;  /**< Current allocated size of CPU scratchpads. */
 	int min_capacity;  /**< Minimum capacity to maintain. */
-} SphereSorter;
+} BillboardSorter;
 
 /**
  * @brief Allocates internal buffers for the sorter.
  * @param sorter Pointer to the struct.
  * @param initial_capacity Expected number of instances.
  */
-void sphere_sorter_init(SphereSorter* sorter, int initial_capacity);
+void billboard_sorter_init(BillboardSorter* sorter, int initial_capacity);
 
 /**
  * @brief Destroys the sorter context.
  * @param sorter Pointer to the struct.
  */
-void sphere_sorter_cleanup(SphereSorter* sorter);
+void billboard_sorter_cleanup(BillboardSorter* sorter);
 
 /**
  * @brief Sorts the array of instances Back-to-Front (descending depth) on GPU.
@@ -72,9 +72,9 @@ void sphere_sorter_cleanup(SphereSorter* sorter);
  * @param camera_pos  World-space viewer position.
  * @return The SSBO handle containing the sorted instances.
  */
-GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
-                              const SphereInstance* instances, int count,
-                              const vec3 camera_pos);
+GLuint billboard_sorter_sort_gpu(BillboardSorter* sorter,
+                                 const SphereInstance* instances, int count,
+                                 const vec3 camera_pos);
 
 /**
  * @brief Sorts the array of instances Back-to-Front (descending depth) on CPU.
@@ -87,9 +87,9 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
  * @param camera_pos  World-space viewer position.
  * @return The SSBO handle containing the sorted instances.
  */
-GLuint sphere_sorter_sort_cpu(SphereSorter* sorter,
-                              const SphereInstance* instances, int count,
-                              const vec3 camera_pos);
+GLuint billboard_sorter_sort_cpu(BillboardSorter* sorter,
+                                 const SphereInstance* instances, int count,
+                                 const vec3 camera_pos);
 
 /**
  * @brief Sorts the array of instances Back-to-Front (descending depth) using
@@ -100,8 +100,8 @@ GLuint sphere_sorter_sort_cpu(SphereSorter* sorter,
  * @param camera_pos  World-space viewer position (for depth).
  * @return The SSBO handle containing the sorted instances.
  */
-GLuint sphere_sorter_sort_cpu_radix(SphereSorter* sorter,
-                                    const SphereInstance* instances, int count,
-                                    const vec3 camera_pos);
+GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* sorter,
+                                       const SphereInstance* instances,
+                                       int count, const vec3 camera_pos);
 
-#endif /* SPHERE_SORTING_H */
+#endif /* BILLBOARD_SORTING_H */

--- a/include/ibl_coordinator.h
+++ b/include/ibl_coordinator.h
@@ -51,11 +51,11 @@ typedef struct {
 	GLuint pending_irr_tex;  /**< Target irradiance map handle. */
 
 	/* --- Dependencies (Injected) --- */
-	GLuint shader_spmap;     /**< Specular pre-filter compute shader. */
-	GLuint shader_irmap;     /**< Irradiance convolution compute shader. */
-	GLuint shader_lum_pass1; /**< Luminance reduction pass 1. */
-	GLuint shader_lum_pass2; /**< Luminance reduction pass 2. */
-	GLuint lum_ssbo[2];      /**< SSBOs for luminance reduction. */
+	GLuint spmap_program;     /**< Specular pre-filter compute shader. */
+	GLuint irmap_program;     /**< Irradiance convolution compute shader. */
+	GLuint lum_pass1_program; /**< Luminance reduction pass 1. */
+	GLuint lum_pass2_program; /**< Luminance reduction pass 2. */
+	GLuint lum_ssbo[2];       /**< SSBOs for luminance reduction. */
 
 	PBRSpecUniforms
 	    spec_uniforms; /**< Cached uniforms for specular shader. */
@@ -76,14 +76,14 @@ typedef struct {
 /**
  * @brief Initializes the IBL coordinator with necessary shader resources.
  * @param coord Pointer to the coordinator instance.
- * @param shader_spmap Handle to the specular pre-filter shader.
- * @param shader_irmap Handle to the irradiance convolution shader.
- * @param shader_lum_pass1 Handle to luminance pass 1 shader.
- * @param shader_lum_pass2 Handle to luminance pass 2 shader.
+ * @param spmap_program Handle to the specular pre-filter shader.
+ * @param irmap_program Handle to the irradiance convolution shader.
+ * @param lum_pass1_program Handle to luminance pass 1 shader.
+ * @param lum_pass2_program Handle to luminance pass 2 shader.
  */
-void ibl_coordinator_init(IBLCoordinator* coord, GLuint shader_spmap,
-                          GLuint shader_irmap, GLuint shader_lum_pass1,
-                          GLuint shader_lum_pass2);
+void ibl_coordinator_init(IBLCoordinator* coord, GLuint spmap_program,
+                          GLuint irmap_program, GLuint lum_pass1_program,
+                          GLuint lum_pass2_program);
 
 /**
  * @brief Cleanups any pending resources held by the coordinator.

--- a/include/light_probes.h
+++ b/include/light_probes.h
@@ -119,7 +119,7 @@ void light_probe_grid_sync(LightProbeGrid* grid);
  * @param view View matrix.
  * @param proj Projection matrix.
  */
-void light_probe_render_debug(LightProbeGrid* grid, mat4 view, mat4 proj);
+void light_probe_grid_render_debug(LightProbeGrid* grid, mat4 view, mat4 proj);
 
 /**
  * @brief Cleans up all resources (CPU, GPU, Threads).

--- a/include/scene.h
+++ b/include/scene.h
@@ -148,9 +148,10 @@ typedef struct Scene {
 #endif
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
-	SphereSorter sphere_sorter;       /**< Sorter for alpha blending. */
-	SphereInstance* sphere_instances; /**< Persistent array for sorting. */
-	int sphere_instance_count;        /**< Active sphere count. */
+	SphereSorter sphere_sorter; /**< Sorter for alpha blending. */
+	SphereInstance*
+	    billboard_instances;      /**< Persistent array for sorting. */
+	int billboard_instance_count; /**< Active billboard count. */
 #endif
 
 	Skybox skybox; /**< Environment renderer (Shaders owned by Scene). */

--- a/include/scene.h
+++ b/include/scene.h
@@ -175,10 +175,10 @@ typedef struct Scene {
 	Shader* skybox_shader;     /**< Skybox shader wrapper. */
 
 	/* --- GPU Resources --- */
-	GLuint sphere_vao;           /**< Shared geometry VAO. */
-	GLuint sphere_vbo;           /**< Shared vertex buffer. */
-	GLuint sphere_nbo;           /**< Shared normal buffer. */
-	GLuint sphere_ebo;           /**< Shared index buffer. */
+	GLuint icosphere_vao;        /**< Shared icosphere geometry VAO. */
+	GLuint icosphere_vbo;        /**< Shared icosphere vertex buffer. */
+	GLuint icosphere_nbo;        /**< Shared icosphere normal buffer. */
+	GLuint icosphere_ebo;        /**< Shared icosphere index buffer. */
 	GLuint quad_vbo;             /**< Shared full-screen quad (FSQ). */
 	GLuint wire_cube_vbo;        /**< Shared wireframe cube. */
 	GLuint wire_quad_vbo;        /**< Shared wireframe quad. */

--- a/include/scene.h
+++ b/include/scene.h
@@ -3,6 +3,7 @@
 
 #include "app_settings.h"
 #include "billboard_rendering.h"
+#include "billboard_sorting.h"
 #include "gl_common.h"
 #include "gpu_profiler.h"
 #include "ibl_coordinator.h"
@@ -13,7 +14,6 @@
 #include "nbody.h"
 #include "shader.h"
 #include "skybox.h"
-#include "sphere_sorting.h"
 #include "trail_renderer.h"
 #include <cglm/cglm.h>
 
@@ -148,7 +148,7 @@ typedef struct Scene {
 #endif
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
-	SphereSorter sphere_sorter; /**< Sorter for alpha blending. */
+	BillboardSorter billboard_sorter; /**< Sorter for alpha blending. */
 	SphereInstance*
 	    billboard_instances;      /**< Persistent array for sorting. */
 	int billboard_instance_count; /**< Active billboard count. */

--- a/include/scene.h
+++ b/include/scene.h
@@ -188,10 +188,10 @@ typedef struct Scene {
 	GLuint irradiance_tex;       /**< Active Irradiance map. */
 	GLuint brdf_lut_tex;         /**< Shared BRDF lookup table. */
 	GLuint empty_vao;            /**< Vertex-less drawing VAO. */
-	GLuint shader_spmap;         /**< Internal IBL specular shader. */
-	GLuint shader_irmap;         /**< Internal IBL irradiance shader. */
-	GLuint shader_lum_pass1;     /**< Luminance downsample pass. */
-	GLuint shader_lum_pass2;     /**< Mean luminance compute pass. */
+	GLuint spmap_program;        /**< Internal IBL specular shader. */
+	GLuint irmap_program;        /**< Internal IBL irradiance shader. */
+	GLuint lum_pass1_program;    /**< Luminance downsample pass. */
+	GLuint lum_pass2_program;    /**< Mean luminance compute pass. */
 	GLuint dummy_black_tex;      /**< Safe fallback (0,0,0,1). */
 	GLuint dummy_white_tex;      /**< Safe fallback (1,1,1,1). */
 	GLuint lum_ssbo[2]; /**< Double-buffered storage for luminance. */

--- a/src/app.c
+++ b/src/app.c
@@ -303,12 +303,13 @@ void app_run(App* app)
 
 #ifdef USE_SSBO_RENDERING
 			ssbo_group_bind_mesh(
-			    &app->scene.ssbo_group, app->scene.sphere_vbo,
-			    app->scene.sphere_nbo, app->scene.sphere_ebo);
+			    &app->scene.ssbo_group, app->scene.icosphere_vbo,
+			    app->scene.icosphere_nbo, app->scene.icosphere_ebo);
 #else
-			instanced_group_bind_mesh(
-			    &app->scene.instanced_group, app->scene.sphere_vbo,
-			    app->scene.sphere_nbo, app->scene.sphere_ebo);
+			instanced_group_bind_mesh(&app->scene.instanced_group,
+			                          app->scene.icosphere_vbo,
+			                          app->scene.icosphere_nbo,
+			                          app->scene.icosphere_ebo);
 #endif
 			last_subdiv = app->scene.subdivisions;
 			PROFILE_ZONE_END(ico_ctx);

--- a/src/billboard_sorting.c
+++ b/src/billboard_sorting.c
@@ -1,4 +1,4 @@
-#include "sphere_sorting.h"
+#include "billboard_sorting.h"
 
 #include "gl_common.h" /* For SIMD_ALIGNMENT */
 #include "gl_debug.h"
@@ -57,7 +57,7 @@ static int next_pow2(int val)
  * @brief Grow CPU scratchpads to hold at least @p count elements.
  * @return true on success, false on allocation failure.
  */
-static bool ensure_cpu_capacity(SphereSorter* sorter, int count)
+static bool ensure_cpu_capacity(BillboardSorter* sorter, int count)
 {
 	if (count <= sorter->cpu_capacity) {
 		return true;
@@ -68,9 +68,9 @@ static bool ensure_cpu_capacity(SphereSorter* sorter, int count)
 	void* new_temp = NULL;
 
 	new_entries = platform_aligned_alloc(
-	    (size_t)count * sizeof(SphereSortEntry), SIMD_ALIGNMENT);
+	    (size_t)count * sizeof(BillboardSortEntry), SIMD_ALIGNMENT);
 	new_aux = platform_aligned_alloc(
-	    (size_t)count * sizeof(SphereSortEntry), SIMD_ALIGNMENT);
+	    (size_t)count * sizeof(BillboardSortEntry), SIMD_ALIGNMENT);
 	new_temp = platform_aligned_alloc(
 	    (size_t)count * sizeof(SphereInstance), SIMD_ALIGNMENT);
 
@@ -88,8 +88,8 @@ static bool ensure_cpu_capacity(SphereSorter* sorter, int count)
 	platform_aligned_free(sorter->entries_aux);
 	platform_aligned_free(sorter->temp_instances);
 
-	sorter->entries = (SphereSortEntry*)new_entries;
-	sorter->entries_aux = (SphereSortEntry*)new_aux;
+	sorter->entries = (BillboardSortEntry*)new_entries;
+	sorter->entries_aux = (BillboardSortEntry*)new_aux;
 	sorter->temp_instances = (SphereInstance*)new_temp;
 	sorter->cpu_capacity = count;
 	return true;
@@ -99,7 +99,7 @@ static bool ensure_cpu_capacity(SphereSorter* sorter, int count)
  * @brief Upload @p count sorted instances from the CPU temp buffer to the SSBO.
  * @return The SSBO handle containing the data.
  */
-static GLuint upload_sorted_to_ssbo(SphereSorter* sorter, int count)
+static GLuint upload_sorted_to_ssbo(BillboardSorter* sorter, int count)
 {
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, sorter->instance_ssbo);
 	if (count > sorter->ssbo_capacity) {
@@ -120,12 +120,12 @@ static GLuint upload_sorted_to_ssbo(SphereSorter* sorter, int count)
 	return sorter->instance_ssbo;
 }
 
-void sphere_sorter_init(SphereSorter* sorter, int initial_capacity)
+void billboard_sorter_init(BillboardSorter* sorter, int initial_capacity)
 {
 	sorter->compute_program =
 	    shader_load_compute("shaders/sphere_sort.glsl");
 	if (sorter->compute_program == 0) {
-		LOG_ERROR("SphereSorter", "Failed to load compute shader");
+		LOG_ERROR("BillboardSorter", "Failed to load compute shader");
 	}
 
 	/* Cache uniform locations once. */
@@ -149,18 +149,18 @@ void sphere_sorter_init(SphereSorter* sorter, int initial_capacity)
 	sorter->cpu_capacity = sorter->min_capacity;
 
 	/* Pre-allocate scratchpad for CPU sorting with SIMD alignment */
-	sorter->entries = (SphereSortEntry*)platform_aligned_alloc(
-	    (size_t)sorter->min_capacity * sizeof(SphereSortEntry),
+	sorter->entries = (BillboardSortEntry*)platform_aligned_alloc(
+	    (size_t)sorter->min_capacity * sizeof(BillboardSortEntry),
 	    SIMD_ALIGNMENT);
-	sorter->entries_aux = (SphereSortEntry*)platform_aligned_alloc(
-	    (size_t)sorter->min_capacity * sizeof(SphereSortEntry),
+	sorter->entries_aux = (BillboardSortEntry*)platform_aligned_alloc(
+	    (size_t)sorter->min_capacity * sizeof(BillboardSortEntry),
 	    SIMD_ALIGNMENT);
 	sorter->temp_instances = (SphereInstance*)platform_aligned_alloc(
 	    (size_t)sorter->min_capacity * sizeof(SphereInstance),
 	    SIMD_ALIGNMENT);
 }
 
-void sphere_sorter_cleanup(SphereSorter* sorter)
+void billboard_sorter_cleanup(BillboardSorter* sorter)
 {
 	GL_SAFE_DELETE_BUFFER(sorter->instance_ssbo);
 	GL_SAFE_DELETE_BUFFER(sorter->index_ssbo);
@@ -177,9 +177,9 @@ void sphere_sorter_cleanup(SphereSorter* sorter)
 	sorter->min_capacity = 0;
 }
 
-GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
-                              const SphereInstance* instances, int count,
-                              const vec3 camera_pos)
+GLuint billboard_sorter_sort_gpu(BillboardSorter* sorter,
+                                 const SphereInstance* instances, int count,
+                                 const vec3 camera_pos)
 {
 	if (count <= 0 || sorter->compute_program == 0) {
 		return sorter->instance_ssbo;
@@ -311,8 +311,8 @@ GLuint sphere_sorter_sort_gpu(SphereSorter* sorter,
 }
 static int compare_sphere_entries(const void* lhs, const void* rhs)
 {
-	const SphereSortEntry* entry_lhs = (const SphereSortEntry*)lhs;
-	const SphereSortEntry* entry_rhs = (const SphereSortEntry*)rhs;
+	const BillboardSortEntry* entry_lhs = (const BillboardSortEntry*)lhs;
+	const BillboardSortEntry* entry_rhs = (const BillboardSortEntry*)rhs;
 
 	/* Back-to-Front (descending depth) */
 	if (entry_lhs->depth > entry_rhs->depth) {
@@ -324,9 +324,9 @@ static int compare_sphere_entries(const void* lhs, const void* rhs)
 	return 0;
 }
 
-GLuint sphere_sorter_sort_cpu(SphereSorter* sorter,
-                              const SphereInstance* instances, int count,
-                              const vec3 camera_pos)
+GLuint billboard_sorter_sort_cpu(BillboardSorter* sorter,
+                                 const SphereInstance* instances, int count,
+                                 const vec3 camera_pos)
 {
 	if (count <= 0 || !instances) {
 		return sorter->instance_ssbo;
@@ -354,7 +354,7 @@ GLuint sphere_sorter_sort_cpu(SphereSorter* sorter,
 	}
 
 	/* 3. Sort entries */
-	qsort(sorter->entries, (size_t)count, sizeof(SphereSortEntry),
+	qsort(sorter->entries, (size_t)count, sizeof(BillboardSortEntry),
 	      compare_sphere_entries);
 
 	/* 4. Reorder instances based on sorted entries */
@@ -384,9 +384,9 @@ static inline uint32_t float_to_sortable_uint(float f_val)
 	return val_conv.uint_val ^ mask;
 }
 
-GLuint sphere_sorter_sort_cpu_radix(SphereSorter* sorter,
-                                    const SphereInstance* instances, int count,
-                                    const vec3 camera_pos)
+GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* sorter,
+                                       const SphereInstance* instances,
+                                       int count, const vec3 camera_pos)
 {
 	if (count <= 0 || !instances) {
 		return sorter->instance_ssbo;
@@ -405,25 +405,31 @@ GLuint sphere_sorter_sort_cpu_radix(SphereSorter* sorter,
 		float depth = glm_vec3_distance2((float*)instances[i].model[3],
 		                                 (float*)camera_pos);
 		sorter->entries[i].original_index = i;
-		/* Use memcpy to write the sortable key into the depth field
-		 * without violating strict aliasing. */
-		uint32_t key = float_to_sortable_uint(depth);
-		// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-		memcpy(&sorter->entries[i].depth, &key, sizeof(uint32_t));
+		/* Write sortable key into the depth field via union to avoid
+		 * strict aliasing issues (same approach as
+		 * float_to_sortable_uint). */
+		union {
+			float f;
+			uint32_t u;
+		} pun;
+		pun.u = float_to_sortable_uint(depth);
+		sorter->entries[i].depth = pun.f;
 	}
 
 	/* 3. Radix Sort (4 passes of 8 bits) */
-	SphereSortEntry* current_in = sorter->entries;
-	SphereSortEntry* current_out = sorter->entries_aux;
+	BillboardSortEntry* current_in = sorter->entries;
+	BillboardSortEntry* current_out = sorter->entries_aux;
 
 	for (int shift = 0; shift < RADIX_SHIFT_LIMIT;
 	     shift += RADIX_BITS_PER_PASS) {
 		int counts[RADIX_BUCKETS] = {0};
 		for (int i = 0; i < count; i++) {
-			uint32_t key = 0;
-			// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-			memcpy(&key, &current_in[i].depth, sizeof(uint32_t));
-			counts[((unsigned int)key >> (unsigned int)shift) &
+			union {
+				float f;
+				uint32_t u;
+			} pun;
+			pun.f = current_in[i].depth;
+			counts[((unsigned int)pun.u >> (unsigned int)shift) &
 			       (unsigned int)RADIX_MASK]++;
 		}
 
@@ -437,17 +443,19 @@ GLuint sphere_sorter_sort_cpu_radix(SphereSorter* sorter,
 		}
 
 		for (int i = 0; i < count; i++) {
-			uint32_t key = 0;
-			// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-			memcpy(&key, &current_in[i].depth, sizeof(uint32_t));
+			union {
+				float f;
+				uint32_t u;
+			} pun;
+			pun.f = current_in[i].depth;
 			unsigned int bucket =
-			    ((unsigned int)key >> (unsigned int)shift) &
+			    ((unsigned int)pun.u >> (unsigned int)shift) &
 			    (unsigned int)RADIX_MASK;
 			current_out[offsets[bucket]++] = current_in[i];
 		}
 
 		/* Ping-pong */
-		SphereSortEntry* temp_ptr = current_in;
+		BillboardSortEntry* temp_ptr = current_in;
 		current_in = current_out;
 		current_out = temp_ptr;
 	}

--- a/src/ibl_coordinator.c
+++ b/src/ibl_coordinator.c
@@ -125,21 +125,21 @@ static void ibl_stats_log_summary(IBLCoordinator* ctx, uint64_t frame,
 	         ctx->stage_gpu_sum, wall_ms);
 }
 
-void ibl_coordinator_init(IBLCoordinator* coord, GLuint shader_spmap,
-                          GLuint shader_irmap, GLuint shader_lum_pass1,
-                          GLuint shader_lum_pass2)
+void ibl_coordinator_init(IBLCoordinator* coord, GLuint spmap_program,
+                          GLuint irmap_program, GLuint lum_pass1_program,
+                          GLuint lum_pass2_program)
 {
 	safe_memset(coord, sizeof(IBLCoordinator), 0, sizeof(IBLCoordinator));
 	coord->state = IBL_STATE_IDLE;
 
-	coord->shader_spmap = shader_spmap;
-	coord->shader_irmap = shader_irmap;
-	coord->shader_lum_pass1 = shader_lum_pass1;
-	coord->shader_lum_pass2 = shader_lum_pass2;
+	coord->spmap_program = spmap_program;
+	coord->irmap_program = irmap_program;
+	coord->lum_pass1_program = lum_pass1_program;
+	coord->lum_pass2_program = lum_pass2_program;
 
-	pbr_get_spec_uniforms(shader_spmap, &coord->spec_uniforms);
-	pbr_get_irr_uniforms(shader_irmap, &coord->irr_uniforms);
-	pbr_get_lum_uniforms(shader_lum_pass2, &coord->lum_uniforms);
+	pbr_get_spec_uniforms(spmap_program, &coord->spec_uniforms);
+	pbr_get_irr_uniforms(irmap_program, &coord->irr_uniforms);
+	pbr_get_lum_uniforms(lum_pass2_program, &coord->lum_uniforms);
 }
 
 void ibl_coordinator_cleanup(IBLCoordinator* coord)
@@ -195,7 +195,7 @@ static IBLState process_luminance(IBLCoordinator* coord,
 		LOG_INFO("suckless-ogl.ibl", "[Frame %llu] - Luminance...",
 		         frame);
 		compute_mean_luminance_gpu_start(
-		    coord->shader_lum_pass1, coord->shader_lum_pass2,
+		    coord->lum_pass1_program, coord->lum_pass2_program,
 		    coord->pending_hdr_tex, coord->width, coord->height,
 		    coord->lum_ssbo, &coord->lum_uniforms);
 	}
@@ -283,7 +283,7 @@ static IBLState process_specular_mips(IBLCoordinator* coord,
 			for (int mip = coord->current_mip;
 			     mip < coord->total_mips; ++mip) {
 				pbr_prefilter_mip(
-				    coord->shader_spmap, &coord->spec_uniforms,
+				    coord->spmap_program, &coord->spec_uniforms,
 				    coord->pending_hdr_tex,
 				    coord->pending_spec_tex,
 				    PREFILTERED_SPECULAR_MAP_SIZE,
@@ -313,7 +313,7 @@ static IBLState process_specular_mips(IBLCoordinator* coord,
 		HYBRID_MEASURE_DEBUG_MS(gpu_ms, label)
 		{
 			pbr_prefilter_mip(
-			    coord->shader_spmap, &coord->spec_uniforms,
+			    coord->spmap_program, &coord->spec_uniforms,
 			    coord->pending_hdr_tex, coord->pending_spec_tex,
 			    PREFILTERED_SPECULAR_MAP_SIZE,
 			    PREFILTERED_SPECULAR_MAP_SIZE, coord->current_mip,
@@ -353,7 +353,7 @@ static IBLState process_irradiance(IBLCoordinator* coord,
 	HYBRID_MEASURE_DEBUG_MS(gpu_ms, label)
 	{
 		pbr_irradiance_slice_compute(
-		    coord->shader_irmap, &coord->irr_uniforms,
+		    coord->irmap_program, &coord->irr_uniforms,
 		    coord->pending_hdr_tex, coord->pending_irr_tex,
 		    IRIDIANCE_MAP_SIZE, coord->current_slice,
 		    coord->total_slices, coord->threshold);

--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -662,7 +662,7 @@ void light_probe_grid_cleanup(LightProbeGrid* grid)
 	light_probe_grid_free_cpu(grid);
 }
 
-void light_probe_render_debug(LightProbeGrid* grid, mat4 view, mat4 proj)
+void light_probe_grid_render_debug(LightProbeGrid* grid, mat4 view, mat4 proj)
 {
 	if (!grid || !grid->ssbo) {
 		return;

--- a/src/scene.c
+++ b/src/scene.c
@@ -325,21 +325,21 @@ static int scene_init_billboard_shader(Scene* scene)
 
 static int scene_init_compute_resources(Scene* scene)
 {
-	scene->shader_spmap = shader_load_compute("shaders/IBL/spmap.glsl");
-	scene->shader_irmap = shader_load_compute("shaders/IBL/irmap.glsl");
-	scene->shader_lum_pass1 =
+	scene->spmap_program = shader_load_compute("shaders/IBL/spmap.glsl");
+	scene->irmap_program = shader_load_compute("shaders/IBL/irmap.glsl");
+	scene->lum_pass1_program =
 	    shader_load_compute("shaders/IBL/luminance_reduce_pass1.glsl");
-	scene->shader_lum_pass2 =
+	scene->lum_pass2_program =
 	    shader_load_compute("shaders/IBL/luminance_reduce_pass2.glsl");
 
-	if (!scene->shader_spmap || !scene->shader_irmap ||
-	    !scene->shader_lum_pass1 || !scene->shader_lum_pass2) {
+	if (!scene->spmap_program || !scene->irmap_program ||
+	    !scene->lum_pass1_program || !scene->lum_pass2_program) {
 		return 0;
 	}
 
-	ibl_coordinator_init(&scene->ibl_coord, scene->shader_spmap,
-	                     scene->shader_irmap, scene->shader_lum_pass1,
-	                     scene->shader_lum_pass2);
+	ibl_coordinator_init(&scene->ibl_coord, scene->spmap_program,
+	                     scene->irmap_program, scene->lum_pass1_program,
+	                     scene->lum_pass2_program);
 	return 1;
 }
 
@@ -480,8 +480,8 @@ static void scene_cleanup_pbr_shaders(Scene* scene)
 #ifdef USE_SSBO_RENDERING
 	SHADER_SAFE_DESTROY(scene->pbr_ssbo_shader);
 #endif
-	GL_SAFE_DELETE_PROGRAM(scene->shader_spmap);
-	GL_SAFE_DELETE_PROGRAM(scene->shader_irmap);
+	GL_SAFE_DELETE_PROGRAM(scene->spmap_program);
+	GL_SAFE_DELETE_PROGRAM(scene->irmap_program);
 }
 
 static void scene_cleanup_shaders(Scene* scene)
@@ -491,8 +491,8 @@ static void scene_cleanup_shaders(Scene* scene)
 	SHADER_SAFE_DESTROY(scene->debug_shader);
 	SHADER_SAFE_DESTROY(scene->debug_line_shader);
 	SHADER_SAFE_DESTROY(scene->skybox_shader);
-	GL_SAFE_DELETE_PROGRAM(scene->shader_lum_pass1);
-	GL_SAFE_DELETE_PROGRAM(scene->shader_lum_pass2);
+	GL_SAFE_DELETE_PROGRAM(scene->lum_pass1_program);
+	GL_SAFE_DELETE_PROGRAM(scene->lum_pass2_program);
 }
 
 static void scene_cleanup_geometry_buffers(Scene* scene)

--- a/src/scene.c
+++ b/src/scene.c
@@ -135,11 +135,11 @@ static void scene_init_instancing(Scene* scene)
 	void* raw_mem = platform_aligned_alloc(
 	    sizeof(SphereInstance) * (size_t)total_count, SIMD_ALIGNMENT);
 	if (raw_mem) {
-		scene->sphere_instances = (SphereInstance*)raw_mem;
-		safe_memcpy(scene->sphere_instances,
+		scene->billboard_instances = (SphereInstance*)raw_mem;
+		safe_memcpy(scene->billboard_instances,
 		            sizeof(SphereInstance) * (size_t)total_count, data,
 		            sizeof(SphereInstance) * (size_t)total_count);
-		scene->sphere_instance_count = total_count;
+		scene->billboard_instance_count = total_count;
 		sphere_sorter_init(&scene->sphere_sorter, total_count);
 	}
 #endif
@@ -542,9 +542,9 @@ void scene_cleanup(Scene* scene)
 	icosphere_free(&scene->geometry);
 	skybox_cleanup(&scene->skybox);
 #ifdef USE_TRANSPARENT_BILLBOARDS
-	if (scene->sphere_instances) {
-		platform_aligned_free(scene->sphere_instances);
-		scene->sphere_instances = NULL;
+	if (scene->billboard_instances) {
+		platform_aligned_free(scene->billboard_instances);
+		scene->billboard_instances = NULL;
 	}
 	sphere_sorter_cleanup(&scene->sphere_sorter);
 #endif
@@ -877,32 +877,31 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 				switch (scene->sorting_mode) {
 					case SORTING_MODE_CPU_QSORT:
-						sorted_ssbo =
-						    sphere_sorter_sort_cpu(
-						        &scene->sphere_sorter,
-						        scene->sphere_instances,
-						        scene
-						            ->sphere_instance_count,
-						        camera_pos);
+						sorted_ssbo = sphere_sorter_sort_cpu(
+						    &scene->sphere_sorter,
+						    scene->billboard_instances,
+						    scene
+						        ->billboard_instance_count,
+						    camera_pos);
 						break;
 					case SORTING_MODE_CPU_RADIX:
 						sorted_ssbo =
 						    sphere_sorter_sort_cpu_radix(
 						        &scene->sphere_sorter,
-						        scene->sphere_instances,
 						        scene
-						            ->sphere_instance_count,
+						            ->billboard_instances,
+						        scene
+						            ->billboard_instance_count,
 						        camera_pos);
 						break;
 					case SORTING_MODE_GPU_BITONIC:
 					default:
-						sorted_ssbo =
-						    sphere_sorter_sort_gpu(
-						        &scene->sphere_sorter,
-						        scene->sphere_instances,
-						        scene
-						            ->sphere_instance_count,
-						        camera_pos);
+						sorted_ssbo = sphere_sorter_sort_gpu(
+						    &scene->sphere_sorter,
+						    scene->billboard_instances,
+						    scene
+						        ->billboard_instance_count,
+						    camera_pos);
 						break;
 				}
 			}
@@ -911,14 +910,14 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			 * sort functions — vertex shader reads it directly
 			 * via gl_InstanceID (no VBO copy needed). */
 			scene->billboard_group.instance_count =
-			    scene->sphere_instance_count;
+			    scene->billboard_instance_count;
 
 			/* Legacy VBO copy only for debug wireframe overlay
 			 * (debug_line_shader reads per-instance attributes) */
 			if (scene->wireframe) {
 				billboard_group_update_from_buffer(
 				    &scene->billboard_group, sorted_ssbo,
-				    scene->sphere_instance_count);
+				    scene->billboard_instance_count);
 			}
 
 			/* 2. Actual Billboard Rendering */
@@ -1051,12 +1050,12 @@ void scene_toggle_nbody(Scene* scene)
 		                       count);
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
-		if (scene->sphere_instances) {
-			safe_memcpy(scene->sphere_instances,
+		if (scene->billboard_instances) {
+			safe_memcpy(scene->billboard_instances,
 			            sizeof(SphereInstance) * (size_t)count,
 			            instances,
 			            sizeof(SphereInstance) * (size_t)count);
-			scene->sphere_instance_count = count;
+			scene->billboard_instance_count = count;
 		}
 		scene->billboard_group.instance_count = count;
 #endif
@@ -1065,9 +1064,9 @@ void scene_toggle_nbody(Scene* scene)
 		 * to avoid leaking GPU buffers and CPU allocations */
 		trail_renderer_cleanup(&scene->trail_renderer);
 #ifdef USE_TRANSPARENT_BILLBOARDS
-		if (scene->sphere_instances) {
-			platform_aligned_free(scene->sphere_instances);
-			scene->sphere_instances = NULL;
+		if (scene->billboard_instances) {
+			platform_aligned_free(scene->billboard_instances);
+			scene->billboard_instances = NULL;
 		}
 		sphere_sorter_cleanup(&scene->sphere_sorter);
 #endif
@@ -1117,11 +1116,11 @@ void scene_nbody_update(Scene* scene, float delta_time)
 	}
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
-	if (scene->sphere_instances) {
-		safe_memcpy(scene->sphere_instances,
+	if (scene->billboard_instances) {
+		safe_memcpy(scene->billboard_instances,
 		            sizeof(SphereInstance) * (size_t)count, instances,
 		            sizeof(SphereInstance) * (size_t)count);
-		scene->sphere_instance_count = count;
+		scene->billboard_instance_count = count;
 	}
 	scene->billboard_group.instance_count = count;
 #endif

--- a/src/scene.c
+++ b/src/scene.c
@@ -2,6 +2,7 @@
 
 #include "app_settings.h"
 #include "billboard_rendering.h"
+#include "billboard_sorting.h"
 #include "gl_debug.h"
 #include "glad/glad.h"
 #include "ibl_coordinator.h"
@@ -14,7 +15,6 @@
 #include "profiler.h"
 #include "render_utils.h"
 #include "shader.h"
-#include "sphere_sorting.h"
 #include "utils.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -140,7 +140,7 @@ static void scene_init_instancing(Scene* scene)
 		            sizeof(SphereInstance) * (size_t)total_count, data,
 		            sizeof(SphereInstance) * (size_t)total_count);
 		scene->billboard_instance_count = total_count;
-		sphere_sorter_init(&scene->sphere_sorter, total_count);
+		billboard_sorter_init(&scene->billboard_sorter, total_count);
 	}
 #endif
 
@@ -237,7 +237,7 @@ static void scene_init_state(Scene* scene)
 	scene->billboard_ubo_ptr = NULL;
 
 	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-	memset(&scene->sphere_sorter, 0, sizeof(SphereSorter));
+	memset(&scene->billboard_sorter, 0, sizeof(BillboardSorter));
 
 	scene->dummy_black_tex =
 	    render_utils_create_color_texture(0.0F, 0.0F, 0.0F, 0.0F);
@@ -546,7 +546,7 @@ void scene_cleanup(Scene* scene)
 		platform_aligned_free(scene->billboard_instances);
 		scene->billboard_instances = NULL;
 	}
-	sphere_sorter_cleanup(&scene->sphere_sorter);
+	billboard_sorter_cleanup(&scene->billboard_sorter);
 #endif
 	instanced_group_cleanup(&scene->instanced_group);
 	billboard_group_cleanup(&scene->billboard_group);
@@ -877,17 +877,21 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 				switch (scene->sorting_mode) {
 					case SORTING_MODE_CPU_QSORT:
-						sorted_ssbo = sphere_sorter_sort_cpu(
-						    &scene->sphere_sorter,
-						    scene->billboard_instances,
-						    scene
-						        ->billboard_instance_count,
-						    camera_pos);
+						sorted_ssbo =
+						    billboard_sorter_sort_cpu(
+						        &scene
+						             ->billboard_sorter,
+						        scene
+						            ->billboard_instances,
+						        scene
+						            ->billboard_instance_count,
+						        camera_pos);
 						break;
 					case SORTING_MODE_CPU_RADIX:
 						sorted_ssbo =
-						    sphere_sorter_sort_cpu_radix(
-						        &scene->sphere_sorter,
+						    billboard_sorter_sort_cpu_radix(
+						        &scene
+						             ->billboard_sorter,
 						        scene
 						            ->billboard_instances,
 						        scene
@@ -896,12 +900,15 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 						break;
 					case SORTING_MODE_GPU_BITONIC:
 					default:
-						sorted_ssbo = sphere_sorter_sort_gpu(
-						    &scene->sphere_sorter,
-						    scene->billboard_instances,
-						    scene
-						        ->billboard_instance_count,
-						    camera_pos);
+						sorted_ssbo =
+						    billboard_sorter_sort_gpu(
+						        &scene
+						             ->billboard_sorter,
+						        scene
+						            ->billboard_instances,
+						        scene
+						            ->billboard_instance_count,
+						        camera_pos);
 						break;
 				}
 			}
@@ -1068,7 +1075,7 @@ void scene_toggle_nbody(Scene* scene)
 			platform_aligned_free(scene->billboard_instances);
 			scene->billboard_instances = NULL;
 		}
-		sphere_sorter_cleanup(&scene->sphere_sorter);
+		billboard_sorter_cleanup(&scene->billboard_sorter);
 #endif
 		instanced_group_cleanup(&scene->instanced_group);
 		billboard_group_cleanup(&scene->billboard_group);

--- a/src/scene.c
+++ b/src/scene.c
@@ -922,7 +922,8 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			    scene->billboard_instance_count;
 
 			/* Legacy VBO copy only for debug wireframe overlay
-			 * (debug_line_shader reads per-instance attributes) */
+			 * (debug_line_shader reads per-SphereInstance
+			 * attributes) */
 			if (scene->wireframe) {
 				billboard_group_update_from_buffer(
 				    &scene->billboard_group, sorted_ssbo,
@@ -1052,7 +1053,7 @@ void scene_toggle_nbody(Scene* scene)
 			    scene->nbody_sim.bodies[i].albedo);
 		}
 
-		/* Write initial instance data and update GPU */
+		/* Write initial SphereInstance data and upload to GPU */
 		SphereInstance instances[NBODY_MAX_BODIES];
 		nbody_write_instances(&scene->nbody_sim, instances);
 		instanced_group_update(&scene->instanced_group, instances,
@@ -1109,7 +1110,7 @@ void scene_nbody_update(Scene* scene, float delta_time)
 		PROFILE_ZONE_END(trail_ctx);
 	}
 
-	/* Build instance data and upload to GPU */
+	/* Build SphereInstance data and upload to GPU */
 	int count = nbody_get_count(&scene->nbody_sim);
 	SphereInstance instances[NBODY_MAX_BODIES];
 	{

--- a/src/scene.c
+++ b/src/scene.c
@@ -144,8 +144,8 @@ static void scene_init_instancing(Scene* scene)
 	}
 #endif
 
-	instanced_group_bind_mesh(&scene->instanced_group, scene->sphere_vbo,
-	                          scene->sphere_nbo, scene->sphere_ebo);
+	instanced_group_bind_mesh(&scene->instanced_group, scene->icosphere_vbo,
+	                          scene->icosphere_nbo, scene->icosphere_ebo);
 	billboard_group_init(&scene->billboard_group, data, total_count);
 	billboard_group_prepare(&scene->billboard_group, scene->quad_vbo,
 	                        scene->wire_quad_vbo, scene->wire_cube_vbo);
@@ -204,8 +204,8 @@ static void scene_init_ssbo(Scene* scene)
 	}
 
 	ssbo_group_init(&scene->ssbo_group, data, total_count);
-	ssbo_group_bind_mesh(&scene->ssbo_group, scene->sphere_vbo,
-	                     scene->sphere_nbo, scene->sphere_ebo);
+	ssbo_group_bind_mesh(&scene->ssbo_group, scene->icosphere_vbo,
+	                     scene->icosphere_nbo, scene->icosphere_ebo);
 
 	/* Initialize Light Probe Grid with Scene Data (SSBO Mode) */
 	light_probe_grid_set_scene(&scene->probe_grid, data, total_count,
@@ -428,10 +428,10 @@ int scene_init(Scene* scene)
 	skybox_init(&scene->skybox, scene->skybox_shader);
 	icosphere_init(&scene->geometry);
 
-	glGenVertexArrays(1, &scene->sphere_vao);
-	glGenBuffers(1, &scene->sphere_vbo);
-	glGenBuffers(1, &scene->sphere_nbo);
-	glGenBuffers(1, &scene->sphere_ebo);
+	glGenVertexArrays(1, &scene->icosphere_vao);
+	glGenBuffers(1, &scene->icosphere_vbo);
+	glGenBuffers(1, &scene->icosphere_nbo);
+	glGenBuffers(1, &scene->icosphere_ebo);
 
 	scene->material_lib =
 	    material_load_presets("assets/materials/pbr_materials.json");
@@ -497,10 +497,10 @@ static void scene_cleanup_shaders(Scene* scene)
 
 static void scene_cleanup_geometry_buffers(Scene* scene)
 {
-	GL_SAFE_DELETE_VAO(scene->sphere_vao);
-	GL_SAFE_DELETE_BUFFER(scene->sphere_vbo);
-	GL_SAFE_DELETE_BUFFER(scene->sphere_nbo);
-	GL_SAFE_DELETE_BUFFER(scene->sphere_ebo);
+	GL_SAFE_DELETE_VAO(scene->icosphere_vao);
+	GL_SAFE_DELETE_BUFFER(scene->icosphere_vbo);
+	GL_SAFE_DELETE_BUFFER(scene->icosphere_nbo);
+	GL_SAFE_DELETE_BUFFER(scene->icosphere_ebo);
 }
 
 static void scene_cleanup_buffers(Scene* scene)
@@ -591,20 +591,20 @@ const char* aa_mode_to_string(AAMode mode)
 
 void scene_update_gpu_buffers(Scene* scene)
 {
-	glBindVertexArray(scene->sphere_vao);
-	glBindBuffer(GL_ARRAY_BUFFER, scene->sphere_vbo);
+	glBindVertexArray(scene->icosphere_vao);
+	glBindBuffer(GL_ARRAY_BUFFER, scene->icosphere_vbo);
 	glBufferData(GL_ARRAY_BUFFER,
 	             (GLsizeiptr)(scene->geometry.vertices.size * sizeof(vec3)),
 	             scene->geometry.vertices.data, GL_STATIC_DRAW);
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(vec3), (void*)0);
 	glEnableVertexAttribArray(0);
-	glBindBuffer(GL_ARRAY_BUFFER, scene->sphere_nbo);
+	glBindBuffer(GL_ARRAY_BUFFER, scene->icosphere_nbo);
 	glBufferData(GL_ARRAY_BUFFER,
 	             (GLsizeiptr)(scene->geometry.normals.size * sizeof(vec3)),
 	             scene->geometry.normals.data, GL_STATIC_DRAW);
 	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(vec3), (void*)0);
 	glEnableVertexAttribArray(1);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, scene->sphere_ebo);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, scene->icosphere_ebo);
 	glBufferData(
 	    GL_ELEMENT_ARRAY_BUFFER,
 	    (GLsizeiptr)(scene->geometry.indices.size * sizeof(unsigned int)),

--- a/src/scene.c
+++ b/src/scene.c
@@ -613,9 +613,10 @@ void scene_update_gpu_buffers(Scene* scene)
 }
 
 /**
- * @brief Binds SH 3D textures (units 8-14) and probe SSBO only when changed.
- * Units 8-14 and SSBO binding 3 are exclusive to PBR passes — safe to cache.
- * Invalidated after light_probe_grid_sync() which clobbers GL_TEXTURE_3D.
+ * @brief Binds SH 3D textures (units 8-14) and light probe grid SSBO only when
+ * changed. Units 8-14 and SSBO binding 3 are exclusive to PBR passes — safe to
+ * cache. Invalidated after light_probe_grid_sync() which clobbers
+ * GL_TEXTURE_3D.
  */
 static void scene_bind_probe_textures(Scene* scene)
 {
@@ -837,7 +838,8 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 	/* GI Probe SSBO sync — must happen before Spheres read it */
 	if (scene->gi_mode != GI_MODE_OFF || scene->show_probe_grid) {
-		PROFILE_ZONE(gi_sync_ctx, "GI Probe Sync (buffer upload)");
+		PROFILE_ZONE(gi_sync_ctx,
+		             "GI Light Probe Grid Sync (buffer upload)");
 		light_probe_grid_sync(&scene->probe_grid);
 		/* Sync clobbers 3D texture bindings on the current unit
 		 * via glBindTexture(GL_TEXTURE_3D, 0) — invalidate cache
@@ -1021,7 +1023,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 	}
 
 	if (scene->show_probe_grid) {
-		light_probe_render_debug(&scene->probe_grid, view, proj);
+		light_probe_grid_render_debug(&scene->probe_grid, view, proj);
 	}
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,9 +73,9 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shader_limit\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_camera_input\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_gamepad_input\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_ibl_coordinator\\.c$")
-list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_benchmark_sphere_sorting\\.c$")
-list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_sphere_sorting\\.c$")
-list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_benchmark_sphere_sorting_perf\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_benchmark_billboard_sorting\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_billboard_sorting\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_benchmark_billboard_sorting_perf\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_sh_precision\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_sh_integration\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_coordinator\\.c$")
@@ -480,17 +480,17 @@ endif()
 
 # TEST BENCHMARK SPHERE SORTING (MOCKED)
 # =============================================================================
-add_executable(test_benchmark_sphere_sorting
-    test_benchmark_sphere_sorting.c
-    ${CMAKE_SOURCE_DIR}/src/sphere_sorting.c
+add_executable(test_benchmark_billboard_sorting
+    test_benchmark_billboard_sorting.c
+    ${CMAKE_SOURCE_DIR}/src/billboard_sorting.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_shader_compute.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
     ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
 )
-target_sources(test_benchmark_sphere_sorting PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
+target_sources(test_benchmark_billboard_sorting PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
 
-target_include_directories(test_benchmark_sphere_sorting PRIVATE
+target_include_directories(test_benchmark_billboard_sorting PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
     ${CMAKE_SOURCE_DIR}/src
@@ -498,14 +498,14 @@ target_include_directories(test_benchmark_sphere_sorting PRIVATE
     ${stb_SOURCE_DIR}
 )
 
-target_link_libraries(test_benchmark_sphere_sorting PRIVATE cglm m)
+target_link_libraries(test_benchmark_billboard_sorting PRIVATE cglm m)
 
 if(WIN32)
-    add_test(NAME test_benchmark_sphere_sorting
-             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_benchmark_sphere_sorting>)
+    add_test(NAME test_benchmark_billboard_sorting
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_benchmark_billboard_sorting>)
 else()
-    add_test(NAME test_benchmark_sphere_sorting
-             COMMAND test_benchmark_sphere_sorting)
+    add_test(NAME test_benchmark_billboard_sorting
+             COMMAND test_benchmark_billboard_sorting)
 endif()
 # NOTES ET DOCUMENTATION
 # =============================================================================
@@ -537,18 +537,18 @@ endif()
 # =============================================================================
 # SPHERE SORTING TESTS (MOCKED)
 # =============================================================================
-add_executable(test_sphere_sorting
-    test_sphere_sorting.c
+add_executable(test_billboard_sorting
+    test_billboard_sorting.c
     ${unity_SOURCE_DIR}/src/unity.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_shader_compute.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
-    ${CMAKE_SOURCE_DIR}/src/sphere_sorting.c
+    ${CMAKE_SOURCE_DIR}/src/billboard_sorting.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
     ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
 )
-target_sources(test_sphere_sorting PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
-target_include_directories(test_sphere_sorting PRIVATE
+target_sources(test_billboard_sorting PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
+target_include_directories(test_billboard_sorting PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
     ${CMAKE_SOURCE_DIR}/src
@@ -556,25 +556,25 @@ target_include_directories(test_sphere_sorting PRIVATE
     ${stb_SOURCE_DIR}
     ${unity_SOURCE_DIR}/src
 )
-target_link_libraries(test_sphere_sorting PRIVATE cglm m)
+target_link_libraries(test_billboard_sorting PRIVATE cglm m)
 if(WIN32)
-    add_test(NAME test_sphere_sorting
-             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_sphere_sorting>)
+    add_test(NAME test_billboard_sorting
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_billboard_sorting>)
 else()
-    add_test(NAME test_sphere_sorting COMMAND test_sphere_sorting)
+    add_test(NAME test_billboard_sorting COMMAND test_billboard_sorting)
 endif()
 
-add_executable(test_benchmark_sphere_sorting_perf
-    test_benchmark_sphere_sorting_perf.c
+add_executable(test_benchmark_billboard_sorting_perf
+    test_benchmark_billboard_sorting_perf.c
     ${unity_SOURCE_DIR}/src/unity.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_shader_compute.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
-    ${CMAKE_SOURCE_DIR}/src/sphere_sorting.c
+    ${CMAKE_SOURCE_DIR}/src/billboard_sorting.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
 )
-target_sources(test_benchmark_sphere_sorting_perf PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
-target_include_directories(test_benchmark_sphere_sorting_perf PRIVATE
+target_sources(test_benchmark_billboard_sorting_perf PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c)
+target_include_directories(test_benchmark_billboard_sorting_perf PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
     ${CMAKE_SOURCE_DIR}/src
@@ -582,12 +582,12 @@ target_include_directories(test_benchmark_sphere_sorting_perf PRIVATE
     ${stb_SOURCE_DIR}
     ${unity_SOURCE_DIR}/src
 )
-target_link_libraries(test_benchmark_sphere_sorting_perf PRIVATE cglm m)
+target_link_libraries(test_benchmark_billboard_sorting_perf PRIVATE cglm m)
 if(WIN32)
-    add_test(NAME test_benchmark_sphere_sorting_perf
-             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_benchmark_sphere_sorting_perf>)
+    add_test(NAME test_benchmark_billboard_sorting_perf
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_benchmark_billboard_sorting_perf>)
 else()
-    add_test(NAME test_benchmark_sphere_sorting_perf COMMAND test_benchmark_sphere_sorting_perf)
+    add_test(NAME test_benchmark_billboard_sorting_perf COMMAND test_benchmark_billboard_sorting_perf)
 endif()
 
 # =============================================================================

--- a/tests/test_benchmark_billboard_sorting.c
+++ b/tests/test_benchmark_billboard_sorting.c
@@ -1,7 +1,7 @@
+#include "billboard_sorting.h"
 #include "instanced_rendering.h"
 #include "mock_gl_standalone.h"  // For mock_gl_reset_calls if needed
-#include "sphere_sorting.h"
-#include <cglm/vec3.h>  // For vec3
+#include <cglm/vec3.h>           // For vec3
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -12,8 +12,8 @@ int main()
 {
 	printf("Starting Sphere Sorting Benchmark...\n");
 
-	SphereSorter sorter;
-	sphere_sorter_init(&sorter, TEST_INITIAL_CAPACITY);
+	BillboardSorter sorter;
+	billboard_sorter_init(&sorter, TEST_INITIAL_CAPACITY);
 
 	int count = TEST_COUNT;
 	SphereInstance* instances = calloc(count, sizeof(SphereInstance));
@@ -26,11 +26,11 @@ int main()
 
 	vec3 camera_pos = {0.0f, 0.0f, 0.0f};
 	GLuint ssbo =
-	    sphere_sorter_sort_gpu(&sorter, instances, count, camera_pos);
+	    billboard_sorter_sort_gpu(&sorter, instances, count, camera_pos);
 
 	printf("Sort dispatched. SSBO: %u\n", ssbo);
 
-	sphere_sorter_cleanup(&sorter);
+	billboard_sorter_cleanup(&sorter);
 	free(instances);
 
 	printf("Done.\n");

--- a/tests/test_benchmark_billboard_sorting_perf.c
+++ b/tests/test_benchmark_billboard_sorting_perf.c
@@ -1,7 +1,7 @@
+#include "billboard_sorting.h"
 #include "gl_common.h"
 #include "instanced_rendering.h"
 #include "platform/platform_utils.h"
-#include "sphere_sorting.h"
 #include <cglm/cglm.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,8 +18,8 @@ void tearDown(void)
 /* Baseline logic extracted from previous implementation */
 static int compare_depth_desc(const void* lhs, const void* rhs)
 {
-	const SphereSortEntry* entry_a = (const SphereSortEntry*)lhs;
-	const SphereSortEntry* entry_b = (const SphereSortEntry*)rhs;
+	const BillboardSortEntry* entry_a = (const BillboardSortEntry*)lhs;
+	const BillboardSortEntry* entry_b = (const BillboardSortEntry*)rhs;
 
 	if (entry_a->depth < entry_b->depth) {
 		return 1;
@@ -31,9 +31,9 @@ static int compare_depth_desc(const void* lhs, const void* rhs)
 }
 
 /* Re-implementation of the baseline sort logic (memcpy) */
-void sphere_sorter_sort_baseline(SphereSorter* sorter,
-                                 SphereInstance* instances, int count,
-                                 const vec3 camera_pos)
+void billboard_sorter_sort_baseline(BillboardSorter* sorter,
+                                    SphereInstance* instances, int count,
+                                    const vec3 camera_pos)
 {
 	if (count <= 0 || !instances) {
 		return;
@@ -41,8 +41,9 @@ void sphere_sorter_sort_baseline(SphereSorter* sorter,
 
 	/* Ensure scratchpad capacity */
 	if (count > sorter->min_capacity && count > sorter->ssbo_capacity) {
-		void* new_entries = realloc(
-		    sorter->entries, (size_t)count * sizeof(SphereSortEntry));
+		void* new_entries =
+		    realloc(sorter->entries,
+		            (size_t)count * sizeof(BillboardSortEntry));
 		void* new_temp =
 		    realloc(sorter->temp_instances,
 		            (size_t)count * sizeof(SphereInstance));
@@ -66,7 +67,7 @@ void sphere_sorter_sort_baseline(SphereSorter* sorter,
 	}
 
 	/* Sort Indices */
-	qsort(sorter->entries, (size_t)count, sizeof(SphereSortEntry),
+	qsort(sorter->entries, (size_t)count, sizeof(BillboardSortEntry),
 	      compare_depth_desc);
 
 	/* Reorder to Temp */
@@ -89,11 +90,11 @@ int main(void)
 	printf("Instances: %d\n", COUNT);
 	printf("Iterations: %d\n", ITERATIONS);
 
-	SphereSorter sorter_baseline;
-	SphereSorter sorter_optimized;
+	BillboardSorter sorter_baseline;
+	BillboardSorter sorter_optimized;
 
-	sphere_sorter_init(&sorter_baseline, COUNT);
-	sphere_sorter_init(&sorter_optimized, COUNT);
+	billboard_sorter_init(&sorter_baseline, COUNT);
+	billboard_sorter_init(&sorter_optimized, COUNT);
 
 	SphereInstance* instances_baseline = NULL;
 	SphereInstance* instances_optimized = NULL;
@@ -125,7 +126,7 @@ int main(void)
 	for (int i = 0; i < ITERATIONS; ++i) {
 		/* Randomize positions slightly to force sort work */
 		instances_baseline[0].model[3][2] = (float)(rand() % 1000);
-		sphere_sorter_sort_baseline(
+		billboard_sorter_sort_baseline(
 		    &sorter_baseline, instances_baseline, COUNT, camera_pos);
 	}
 	clock_t end_base = clock();
@@ -135,8 +136,8 @@ int main(void)
 	clock_t start_opt = clock();
 	for (int i = 0; i < ITERATIONS; ++i) {
 		instances_optimized[0].model[3][2] = (float)(rand() % 1000);
-		sphere_sorter_sort_cpu(&sorter_optimized, instances_optimized,
-		                       COUNT, camera_pos);
+		billboard_sorter_sort_cpu(
+		    &sorter_optimized, instances_optimized, COUNT, camera_pos);
 	}
 	clock_t end_opt = clock();
 	double time_opt = (double)(end_opt - start_opt) / CLOCKS_PER_SEC;
@@ -150,8 +151,8 @@ int main(void)
 	       (time_opt / ITERATIONS) * 1000.0);
 
 	/* Cleanup */
-	sphere_sorter_cleanup(&sorter_baseline);
-	sphere_sorter_cleanup(&sorter_optimized);
+	billboard_sorter_cleanup(&sorter_baseline);
+	billboard_sorter_cleanup(&sorter_optimized);
 
 	/* Free the buffers we allocated initially */
 	platform_aligned_free(instances_baseline);

--- a/tests/test_billboard_sorting.c
+++ b/tests/test_billboard_sorting.c
@@ -1,5 +1,5 @@
+#include "billboard_sorting.h"
 #include "platform/platform_utils.h"
-#include "sphere_sorting.h"
 #include "unity.h"
 #include <cglm/cglm.h>
 #include <stdlib.h>
@@ -33,7 +33,7 @@ static SphereInstance* create_dummy_instances(int count, int min_capacity)
 	int alloc_count = (count > min_capacity) ? count : min_capacity;
 	SphereInstance* instances = NULL;
 	/* Use platform_aligned_alloc to match sorter allocation strategy */
-	/* SIMD_ALIGNMENT is available via sphere_sorting.h ->
+	/* SIMD_ALIGNMENT is available via billboard_sorting.h ->
 	 * instanced_rendering.h -> gl_common.h */
 	instances = (SphereInstance*)platform_aligned_alloc(
 	    (size_t)alloc_count * sizeof(SphereInstance), SIMD_ALIGNMENT);
@@ -62,10 +62,10 @@ static void set_position(SphereInstance* inst, float x_coord, float y_coord,
 	inst->model[Z_INDEX][Z_OFFSET] = z_coord;
 }
 
-void test_SphereSorter_Init_ShouldAllocateBuffers(void)
+void test_BillboardSorter_Init_ShouldAllocateBuffers(void)
 {
-	SphereSorter sorter;
-	sphere_sorter_init(&sorter, INIT_CAPACITY);
+	BillboardSorter sorter;
+	billboard_sorter_init(&sorter, INIT_CAPACITY);
 
 	TEST_ASSERT_NOT_NULL(sorter.entries);
 	TEST_ASSERT_NOT_NULL(sorter.entries_aux);
@@ -74,14 +74,14 @@ void test_SphereSorter_Init_ShouldAllocateBuffers(void)
 	TEST_ASSERT_EQUAL_INT(INIT_CAPACITY, sorter.cpu_capacity);
 	TEST_ASSERT_EQUAL_INT(INIT_CAPACITY, sorter.min_capacity);
 
-	sphere_sorter_cleanup(&sorter);
+	billboard_sorter_cleanup(&sorter);
 }
 
-void test_SphereSorter_Cleanup_ShouldFreeBuffers(void)
+void test_BillboardSorter_Cleanup_ShouldFreeBuffers(void)
 {
-	SphereSorter sorter;
-	sphere_sorter_init(&sorter, INIT_CAPACITY);
-	sphere_sorter_cleanup(&sorter);
+	BillboardSorter sorter;
+	billboard_sorter_init(&sorter, INIT_CAPACITY);
+	billboard_sorter_cleanup(&sorter);
 
 	TEST_ASSERT_NULL(sorter.entries);
 	TEST_ASSERT_NULL(sorter.temp_instances);
@@ -89,10 +89,10 @@ void test_SphereSorter_Cleanup_ShouldFreeBuffers(void)
 	TEST_ASSERT_EQUAL_INT(0, sorter.min_capacity);
 }
 
-void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
+void test_BillboardSorter_Sort_ShouldOrderBackToFront(void)
 {
-	SphereSorter sorter;
-	sphere_sorter_init(&sorter, TEST_COUNT_4);
+	BillboardSorter sorter;
+	billboard_sorter_init(&sorter, TEST_COUNT_4);
 
 	int count = TEST_COUNT_3;
 	/* Ensure allocated buffer is at least min_capacity (4) even if count is
@@ -119,7 +119,7 @@ void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
 	/* Expected Order: Far (-20), Middle (-10), Near (-5) */
 	/* Indices should become: 1, 2, 0 */
 
-	(void)sphere_sorter_sort_cpu(&sorter, instances, count, camera_pos);
+	(void)billboard_sorter_sort_cpu(&sorter, instances, count, camera_pos);
 
 	/* Check First (Furthest) */
 	const int MAT_Z_INDEX = 3;
@@ -145,13 +145,13 @@ void test_SphereSorter_Sort_ShouldOrderBackToFront(void)
 	                         sorter.temp_instances[2].roughness);
 
 	platform_aligned_free(instances);
-	sphere_sorter_cleanup(&sorter);
+	billboard_sorter_cleanup(&sorter);
 }
 
-void test_SphereSorter_SortRadix_ShouldOrderBackToFront(void)
+void test_BillboardSorter_SortRadix_ShouldOrderBackToFront(void)
 {
-	SphereSorter sorter;
-	sphere_sorter_init(&sorter, TEST_COUNT_4);
+	BillboardSorter sorter;
+	billboard_sorter_init(&sorter, TEST_COUNT_4);
 
 	int count = TEST_COUNT_3;
 	SphereInstance* instances =
@@ -171,8 +171,8 @@ void test_SphereSorter_SortRadix_ShouldOrderBackToFront(void)
 	set_position(&instances[2], COORD_ZERO, COORD_ZERO, COORD_NEG_10);
 	instances[2].roughness = ROUGHNESS_C;
 
-	(void)sphere_sorter_sort_cpu_radix(&sorter, instances, count,
-	                                   camera_pos);
+	(void)billboard_sorter_sort_cpu_radix(&sorter, instances, count,
+	                                      camera_pos);
 
 	const int MAT_Z_INDEX = 3;
 	const int MAT_Z_OFFSET = 2;
@@ -195,13 +195,13 @@ void test_SphereSorter_SortRadix_ShouldOrderBackToFront(void)
 	                         sorter.temp_instances[2].roughness);
 
 	platform_aligned_free(instances);
-	sphere_sorter_cleanup(&sorter);
+	billboard_sorter_cleanup(&sorter);
 }
 
-void test_SphereSorter_Resize_ShouldHandleMoreThanCapacity(void)
+void test_BillboardSorter_Resize_ShouldHandleMoreThanCapacity(void)
 {
-	SphereSorter sorter;
-	sphere_sorter_init(&sorter, SMALL_CAPACITY); /* Small capacity (2) */
+	BillboardSorter sorter;
+	billboard_sorter_init(&sorter, SMALL_CAPACITY); /* Small capacity (2) */
 
 	int count = TEST_COUNT_5; /* 5 */
 	/* Allocates max(5, 2) = 5 */
@@ -210,19 +210,19 @@ void test_SphereSorter_Resize_ShouldHandleMoreThanCapacity(void)
 	vec3 camera_pos = {COORD_ZERO, COORD_ZERO, COORD_ZERO};
 
 	/* Just check it doesn't crash and resizes */
-	(void)sphere_sorter_sort_cpu(&sorter, instances, count, camera_pos);
+	(void)billboard_sorter_sort_cpu(&sorter, instances, count, camera_pos);
 
 	/* Check that capacity grew */
 	TEST_ASSERT_GREATER_OR_EQUAL(count, sorter.cpu_capacity);
 
 	platform_aligned_free(instances);
-	sphere_sorter_cleanup(&sorter);
+	billboard_sorter_cleanup(&sorter);
 }
 
-void test_SphereSorter_CapacitySync_ShouldNotCrash(void)
+void test_BillboardSorter_CapacitySync_ShouldNotCrash(void)
 {
-	SphereSorter sorter;
-	sphere_sorter_init(&sorter, SMALL_CAPACITY);
+	BillboardSorter sorter;
+	billboard_sorter_init(&sorter, SMALL_CAPACITY);
 
 	/* Simulate GPU path growing 'ssbo_capacity' to 100 */
 	sorter.ssbo_capacity = 100;
@@ -236,22 +236,22 @@ void test_SphereSorter_CapacitySync_ShouldNotCrash(void)
 	vec3 camera_pos = {COORD_ZERO, COORD_ZERO, COORD_ZERO};
 
 	/* This would SIGSEGV if capacity sync is broken */
-	(void)sphere_sorter_sort_cpu(&sorter, instances, count, camera_pos);
+	(void)billboard_sorter_sort_cpu(&sorter, instances, count, camera_pos);
 
 	TEST_ASSERT_GREATER_OR_EQUAL(count, sorter.cpu_capacity);
 
 	platform_aligned_free(instances);
-	sphere_sorter_cleanup(&sorter);
+	billboard_sorter_cleanup(&sorter);
 }
 
 int main(void)
 {
 	UNITY_BEGIN();
-	RUN_TEST(test_SphereSorter_Init_ShouldAllocateBuffers);
-	RUN_TEST(test_SphereSorter_Cleanup_ShouldFreeBuffers);
-	RUN_TEST(test_SphereSorter_Sort_ShouldOrderBackToFront);
-	RUN_TEST(test_SphereSorter_SortRadix_ShouldOrderBackToFront);
-	RUN_TEST(test_SphereSorter_Resize_ShouldHandleMoreThanCapacity);
-	RUN_TEST(test_SphereSorter_CapacitySync_ShouldNotCrash);
+	RUN_TEST(test_BillboardSorter_Init_ShouldAllocateBuffers);
+	RUN_TEST(test_BillboardSorter_Cleanup_ShouldFreeBuffers);
+	RUN_TEST(test_BillboardSorter_Sort_ShouldOrderBackToFront);
+	RUN_TEST(test_BillboardSorter_SortRadix_ShouldOrderBackToFront);
+	RUN_TEST(test_BillboardSorter_Resize_ShouldHandleMoreThanCapacity);
+	RUN_TEST(test_BillboardSorter_CapacitySync_ShouldNotCrash);
 	return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Implements the 4 naming disambiguation issues from the ubiquitous language analysis (#205):

### #206 — Disambiguate "Sphere" in Scene struct
- **Phase 1**: `sphere_instances` → `billboard_instances` (the array holds billboard data, not generic sphere data)
- **Phase 2**: `sphere_vao/vbo/nbo/ebo` → `icosphere_vao/vbo/nbo/ebo` (these hold the icosphere mesh geometry)
- **Phase 3**: `SphereSorter` → `BillboardSorter`, `sphere_sorting.h/c` → `billboard_sorting.h/c` (the sorter orders billboards for alpha blending)
  - Also removes 3 `NOLINTNEXTLINE` suppressions by replacing `memcpy` type-punning with union-based approach

### #207 — Disambiguate "Shader" in IBL coordinator
- `shader_spmap` → `spmap_program`
- `shader_irmap` → `irmap_program`
- `shader_lum_pass1` → `lum_pass1_program`
- `shader_lum_pass2` → `lum_pass2_program`

These `GLuint` fields hold compiled **program** handles, not shader stage objects.

### #208 — Disambiguate "Probe"
- `light_probe_render_debug()` → `light_probe_grid_render_debug()` (operates on `LightProbeGrid*`, not single `LightProbe`)
- Qualified ambiguous "probe" in comments with "light probe grid"

### #209 — Disambiguate "Instance"
- Qualified bare "instance" in `scene.c` comments with "SphereInstance" where it refers to per-object GPU data packets

### Documentation
- Updated 15 doc files (EN + FR) to reflect all renames
- Glossary: "Sphere Sorter" → "Billboard Sorter" / "Trieur de Sphères" → "Trieur de Billboards"

## Commits (7, SoC)
1. `refactor(naming): rename sphere_instances → billboard_instances in Scene`
2. `refactor(naming): rename sphere_vao/vbo/nbo/ebo → icosphere_* in Scene`
3. `refactor(naming): rename SphereSorter → BillboardSorter`
4. `refactor(naming): rename shader_* → *_program in IBL coordinator`
5. `refactor(naming): disambiguate Probe — rename grid-level function`
6. `refactor(naming): disambiguate Instance — qualify bare usage in comments`
7. `docs: synchronize documentation with naming renames`

## Validation
- ✅ 63/63 tests pass
- ✅ `just format` — 0 changes
- ✅ `just lint` (clang-tidy) — 0 warnings
- ✅ All pre-commit + pre-push hooks pass
- ✅ `check-nolint` pass (3 NOLINTs removed, not just renamed)

Closes #206, Closes #207, Closes #208, Closes #209