### PR TITLE
refactor(rendering): extract SphereInstance into sphere_types.h

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ Repository: [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
 | Subsystem | Key Files |
 |-----------|-----------|
 | **Core App** | `app.c`, `main.c`, `cli.c` |
-| **Rendering** | `renderer.c`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
+| **Rendering** | `renderer.c`, `sphere_types.h`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
 | **PBR / IBL** | `pbr.c`, `material.c`, `ibl_coordinator.c`, `light_probes.c`, `skybox.c` |
 | **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur) |
 | **Shaders** | 55+ GLSL files in `shaders/` (vertex, fragment, compute) |

--- a/docs/application_lifecycle.fr.md
+++ b/docs/application_lifecycle.fr.md
@@ -411,16 +411,18 @@ graph TD
     end
 ```
 
-Chaque instance stocke :
+Chaque instance stocke (définie dans `include/sphere_types.h`) :
 
 ```c
 typedef struct SphereInstance {
-    mat4  model;      // 64 octets — matrice de transformation 4×4
-    vec3  albedo;     // 12 octets — couleur RVB
-    float metallic;   //  4 octets
-    float roughness;  //  4 octets
-    float ao;         //  4 octets — toujours 1.0
-} SphereInstance;     // Total : 88 octets par instance
+    mat4  model;       // 64 octets — matrice de transformation 4×4
+    vec3  albedo;      // 12 octets — couleur RVB
+    float metallic;    //  4 octets
+    float roughness;   //  4 octets
+    float ao;          //  4 octets — toujours 1.0
+    float padding;     //  4 octets — alignement
+    vec3  prev_center; // 12 octets — centre frame précédente (motion blur)
+} SphereInstance;      // Total : 128 octets par instance (aligné 64 octets)
 ```
 
 Deux groupes de rendu sont créés :
@@ -1212,6 +1214,7 @@ Voici une estimation de la consommation VRAM en régime stationnaire :
 | `src/ibl_coordinator.c` | Génération IBL progressive (spéculaire, irradiance) |
 | `src/pbr.c` | Génération BRDF LUT, helpers uniforms PBR |
 | `src/material.c` | Bibliothèque matériaux (chargement JSON) |
+| `include/sphere_types.h` | Définition canonique du type `SphereInstance` |
 | `src/instanced_rendering.c` | Gestion VAO/VBO draw instancié |
 | `src/billboard_rendering.c` | Quads billboard pour sphères transparentes |
 | `src/billboard_sorting.c` | Tri transparence CPU/GPU |

--- a/docs/application_lifecycle.md
+++ b/docs/application_lifecycle.md
@@ -411,16 +411,18 @@ graph TD
     end
 ```
 
-Each instance stores:
+Each instance stores (defined in `include/sphere_types.h`):
 
 ```c
 typedef struct SphereInstance {
-    mat4  model;      // 64 bytes — 4×4 transform matrix
-    vec3  albedo;     // 12 bytes — RGB color
-    float metallic;   //  4 bytes
-    float roughness;  //  4 bytes
-    float ao;         //  4 bytes — always 1.0
-} SphereInstance;     // Total: 88 bytes per instance
+    mat4  model;       // 64 bytes — 4×4 transform matrix
+    vec3  albedo;      // 12 bytes — RGB color
+    float metallic;    //  4 bytes
+    float roughness;   //  4 bytes
+    float ao;          //  4 bytes — always 1.0
+    float padding;     //  4 bytes — alignment
+    vec3  prev_center; // 12 bytes — previous frame center (motion blur)
+} SphereInstance;      // Total: 128 bytes per instance (64-byte aligned)
 ```
 
 Two rendering groups are created:
@@ -1212,6 +1214,7 @@ Here's an estimate of VRAM consumption at steady state:
 | `src/ibl_coordinator.c` | Progressive IBL generation (specular, irradiance) |
 | `src/pbr.c` | BRDF LUT generation, PBR uniform helpers |
 | `src/material.c` | Material library (JSON loading) |
+| `include/sphere_types.h` | Canonical `SphereInstance` type definition |
 | `src/instanced_rendering.c` | VAO/VBO instanced draw management |
 | `src/billboard_rendering.c` | Billboard quads for transparent spheres |
 | `src/billboard_sorting.c` | CPU/GPU transparency sorting |

--- a/include/billboard_rendering.h
+++ b/include/billboard_rendering.h
@@ -12,8 +12,8 @@
 #define BILLBOARD_RENDERING_H
 
 #include "gl_common.h"
-#include "instanced_rendering.h" /* For SphereInstance */
 #include "shader.h"
+#include "sphere_types.h"
 
 /**
  * @struct BillboardGroup

--- a/include/billboard_sorting.h
+++ b/include/billboard_sorting.h
@@ -9,7 +9,7 @@
 #ifndef BILLBOARD_SORTING_H
 #define BILLBOARD_SORTING_H
 
-#include "instanced_rendering.h"
+#include "sphere_types.h"
 #include <cglm/cglm.h>
 
 /**

--- a/include/instanced_rendering.h
+++ b/include/instanced_rendering.h
@@ -11,25 +11,7 @@
 #define INSTANCED_RENDERING_H
 
 #include "gl_common.h"
-#include <cglm/cglm.h>
-
-/**
- * @struct SphereInstance
- * @brief Per-instance data sent to the shader via an instanced VBO.
- *
- * This structure is 64-byte aligned to ensure optimal GPU throughput
- * and compatibility with SIMD-based sorting or physics.
- */
-typedef struct {
-	mat4 model;       /**< 4x4 Transformation matrix. */
-	vec3 albedo;      /**< Base color (linear RGB). */
-	float metallic;   /**< PBR metallic factor (0.0 - 1.0). */
-	float roughness;  /**< PBR roughness factor (0.0 - 1.0). */
-	float ao;         /**< Ambient occlusion factor. */
-	float padding;    /**< Alignment padding. */
-	vec3 prev_center; /**< Previous frame center (for per-object motion
-	                     blur). */
-} __attribute__((aligned(SIMD_ALIGNMENT))) SphereInstance;
+#include "sphere_types.h"
 
 /**
  * @struct InstancedGroup

--- a/include/light_probes.h
+++ b/include/light_probes.h
@@ -3,18 +3,9 @@
 
 #include "sh_math.h"
 #include "shader.h"
+#include "sphere_types.h"
 #include <cglm/cglm.h>
 #include <pthread.h>
-
-/* Forward declaration from instanced_rendering.h */
-typedef struct {
-	mat4 model;
-	vec3 albedo;
-	float metallic;
-	float roughness;
-	float ao;
-	float padding;
-} SphereInstance_POD;
 
 /** @brief Number of 3D textures used for packing SH coefficients (7 = 28
  * channels for 9 L2 coeffs) */
@@ -42,7 +33,7 @@ typedef struct {
 	int total_probes;
 
 	/* Scene Copy for Async Update */
-	SphereInstance_POD* scene_copy;
+	SphereInstance* scene_copy;
 	int scene_count;
 
 	/* Threading */

--- a/include/nbody.h
+++ b/include/nbody.h
@@ -13,7 +13,7 @@
 #ifndef NBODY_H
 #define NBODY_H
 
-#include "instanced_rendering.h"
+#include "sphere_types.h"
 #include <cglm/types.h>
 #include <stdbool.h>
 

--- a/include/sphere_types.h
+++ b/include/sphere_types.h
@@ -1,0 +1,36 @@
+/**
+ * @file sphere_types.h
+ * @brief Pure-data type for per-instance sphere attributes.
+ *
+ * This header defines the canonical SphereInstance layout shared by the
+ * instanced renderer, billboard renderer, N-body simulation, light probes,
+ * and sorting subsystems.  It depends only on cglm types and the
+ * SIMD_ALIGNMENT constant from gl_common.h — no OpenGL entry points are
+ * referenced directly.
+ */
+
+#ifndef SPHERE_TYPES_H
+#define SPHERE_TYPES_H
+
+#include "gl_common.h"
+#include <cglm/cglm.h>
+
+/**
+ * @struct SphereInstance
+ * @brief Per-instance data sent to the shader via an instanced VBO.
+ *
+ * This structure is 64-byte aligned to ensure optimal GPU throughput
+ * and compatibility with SIMD-based sorting or physics.
+ */
+typedef struct {
+	mat4 model;       /**< 4x4 Transformation matrix. */
+	vec3 albedo;      /**< Base color (linear RGB). */
+	float metallic;   /**< PBR metallic factor (0.0 - 1.0). */
+	float roughness;  /**< PBR roughness factor (0.0 - 1.0). */
+	float ao;         /**< Ambient occlusion factor. */
+	float padding;    /**< Alignment padding. */
+	vec3 prev_center; /**< Previous frame center (for per-object motion
+	                     blur). */
+} __attribute__((aligned(SIMD_ALIGNMENT))) SphereInstance;
+
+#endif /* SPHERE_TYPES_H */

--- a/src/billboard_rendering.c
+++ b/src/billboard_rendering.c
@@ -1,7 +1,6 @@
 #include "billboard_rendering.h"
 
 #include "gl_common.h"
-#include "instanced_rendering.h"
 #include "render_utils.h"
 #include <assert.h>
 #include <stddef.h>

--- a/src/billboard_sorting.c
+++ b/src/billboard_sorting.c
@@ -2,7 +2,6 @@
 
 #include "gl_common.h" /* For SIMD_ALIGNMENT */
 #include "gl_debug.h"
-#include "instanced_rendering.h" /* For SphereInstance */
 #include "log.h"
 #include "platform/platform_utils.h"
 #include "profiler.h"

--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -66,13 +66,13 @@ typedef struct {
 } CachedSphere;
 
 /* Helper to get position from POD */
-static void get_sphere_pos(const SphereInstance_POD* sphere, vec3 dest)
+static void get_sphere_pos(const SphereInstance* sphere, vec3 dest)
 {
 	glm_vec3_copy((float*)sphere->model[3], dest);
 }
 
 /* Helper to get scale from POD (assuming uniform) */
-static float get_sphere_radius(const SphereInstance_POD* sphere)
+static float get_sphere_radius(const SphereInstance* sphere)
 {
 	return glm_vec3_norm((float*)sphere->model[0]);
 }
@@ -90,8 +90,8 @@ void light_probe_grid_compute_aabb(LightProbeGrid* grid, const void* spheres,
 	vec3 max_b = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
 
 	for (int i = 0; i < count; i++) {
-		const SphereInstance_POD* inst =
-		    (const SphereInstance_POD*)(base + ((size_t)i * stride));
+		const SphereInstance* inst =
+		    (const SphereInstance*)(base + ((size_t)i * stride));
 		vec3 pos;
 		get_sphere_pos(inst, pos);
 
@@ -305,7 +305,7 @@ static void light_probe_worker_compute_probe(LightProbeGrid* grid, int grid_x,
 }
 #endif
 
-static void* precompute_cached_spheres(SphereInstance_POD* local_scene,
+static void* precompute_cached_spheres(SphereInstance* local_scene,
                                        int local_count)
 {
 	CachedSphere* cached_scene = malloc(local_count * sizeof(CachedSphere));
@@ -353,11 +353,11 @@ static void* light_probe_worker(void* arg)
 		/* Snapshot scene data under lock to avoid race with
 		 * set_scene() */
 		int local_count = grid->scene_count;
-		SphereInstance_POD* local_scene = NULL;
+		SphereInstance* local_scene = NULL;
 		if (local_count > 0 && grid->scene_copy) {
 			size_t data_size =
-			    (size_t)local_count * sizeof(SphereInstance_POD);
-			local_scene = (SphereInstance_POD*)malloc(data_size);
+			    (size_t)local_count * sizeof(SphereInstance);
+			local_scene = (SphereInstance*)malloc(data_size);
 			if (local_scene) {
 				(void)safe_memcpy(local_scene, data_size,
 				                  grid->scene_copy, data_size);
@@ -502,15 +502,14 @@ void light_probe_grid_set_scene(LightProbeGrid* grid, const void* spheres,
 	}
 	grid->scene_count = count;
 
-	size_t size = count * sizeof(SphereInstance_POD);
-	grid->scene_copy = (SphereInstance_POD*)malloc(size);
+	size_t size = count * sizeof(SphereInstance);
+	grid->scene_copy = (SphereInstance*)malloc(size);
 	if (grid->scene_copy) {
 		const char* src = (const char*)spheres;
 		for (int i = 0; i < count; i++) {
-			(void)safe_memcpy(&grid->scene_copy[i],
-			                  sizeof(SphereInstance_POD),
-			                  src + ((size_t)i * stride),
-			                  sizeof(SphereInstance_POD));
+			(void)safe_memcpy(
+			    &grid->scene_copy[i], sizeof(SphereInstance),
+			    src + ((size_t)i * stride), sizeof(SphereInstance));
 		}
 	}
 	pthread_mutex_unlock(&grid->mutex);

--- a/tests/test_benchmark_billboard_sorting.c
+++ b/tests/test_benchmark_billboard_sorting.c
@@ -1,5 +1,4 @@
 #include "billboard_sorting.h"
-#include "instanced_rendering.h"
 #include "mock_gl_standalone.h"  // For mock_gl_reset_calls if needed
 #include <cglm/vec3.h>           // For vec3
 #include <stdio.h>

--- a/tests/test_benchmark_billboard_sorting_perf.c
+++ b/tests/test_benchmark_billboard_sorting_perf.c
@@ -1,6 +1,5 @@
 #include "billboard_sorting.h"
 #include "gl_common.h"
-#include "instanced_rendering.h"
 #include "platform/platform_utils.h"
 #include <cglm/cglm.h>
 #include <stdio.h>

--- a/tests/test_sh_integration.c
+++ b/tests/test_sh_integration.c
@@ -45,7 +45,7 @@ int main()
 
 	/* Initialize Mock Spheres */
 	int count = 2;
-	SphereInstance_POD spheres[2];
+	SphereInstance spheres[2];
 
 	/* Sphere 1 at (0,0,0) with scale 1.0 */
 	glm_mat4_identity(spheres[0].model);
@@ -69,7 +69,7 @@ int main()
 
 	/* Compute AABB (New Center-Based Logic) */
 	light_probe_grid_compute_aabb(&grid, spheres, count,
-	                              sizeof(SphereInstance_POD), 1.0f);
+	                              sizeof(SphereInstance), 1.0f);
 
 	printf("Computed AABB:\n");
 	printf("Min: (%.2f, %.2f, %.2f)\n", grid.aabb_min[0], grid.aabb_min[1],


### PR DESCRIPTION
## Summary

Move the `SphereInstance` struct from `instanced_rendering.h` into a dedicated `sphere_types.h` header. This breaks the artificial coupling that forced `billboard_rendering.h`, `billboard_sorting.h`, `nbody.h` and `light_probes.h` to depend on `instanced_rendering.h` just for the type definition.

## Changes

- Create `include/sphere_types.h` with canonical `SphereInstance` definition
- Remove `SphereInstance_POD` redefinition from `light_probes.h` (fragile maintenance risk eliminated)
- Update all consumers to include `sphere_types.h` directly
- Remove redundant `instanced_rendering.h` includes from `.c` files and tests

## Quality

- `just build`: 0 errors, 0 warnings
- `just format`: clean
- `just lint`: 31 shaders validated, 0 failed
- `ctest`: 62/63 passed (1 timeout `test_app` — normal in headless)

Closes #199