### PR TITLE
refactor(input): introduce AppInputContext seam for app_input.h

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ Repository: [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
 | **PBR / IBL** | `pbr.c`, `material.c`, `ibl_coordinator.c`, `light_probes.c`, `skybox.c` |
 | **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur) |
 | **Shaders** | 55+ GLSL files in `shaders/` (vertex, fragment, compute) |
-| **Input** | `app_input.c`, `camera_input.c`, `postprocess_input.c`, `app_binding.c` |
+| **Input** | `app_input.c` (`AppInputContext`), `camera_input.c`, `postprocess_input.c` (`PostProcessInputContext`), `app_binding.c` |
 | **Profiling** | `gpu_profiler.c`, `perf_timer.c`, `tracy_manager.c`, `effect_benchmark.c` |
 | **Tests** | 59 test files in `tests/` (Unity framework, visual regression, benchmarks) |
 

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -19,7 +19,7 @@ Gère l'affichage de la superposition d'informations, du clavier interactif et d
 
 ### `app_input` — Gestion des entrées
 
-Traite les événements clavier et souris via les callbacks GLFW.
+Traite les événements clavier et souris via les callbacks GLFW. Utilise `AppInputContext` (bundle de pointeurs ciblés) pour se découpler de l'objet God `App`, suivant le même pattern que `PostProcessInputContext`.
 
 **Responsabilités :**
 - Dispatch des commandes depuis les frappes clavier

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ The monolithic `app.c` has been split into several specialized modules to improv
 | :--- | :--- |
 | `app.c` / `app.h` | Orchestrator: Initialization, main loop, high-level render pass management. |
 | `app_ui.c` / `app_ui.h` | UI Rendering: Overlays, help screens, debug text, histograms, and loading spinners. |
-| `app_input.c` / `app_input.h` | Input Handling: Keyboard callbacks, mouse/scroll events, and post-process feature toggles. |
+| `app_input.c` / `app_input.h` | Input Handling: Keyboard callbacks, mouse/scroll events, and post-process feature toggles. Uses `AppInputContext` (focused pointer bundle) to decouple from the `App` God Object, following the same pattern as `PostProcessInputContext`. |
 | `app_env.c` / `app_env.h` | Environment & IBL: HDR file scanning, asynchronous loading, and the IBL state machine. |
 | `app_scene.c` / `app_scene.h` | Scene Rendering: Billboard groups, instanced groups, and procedural geometry updates. |
 

--- a/docs/keyboard_system.fr.md
+++ b/docs/keyboard_system.fr.md
@@ -39,7 +39,7 @@ typedef struct {
 
 ### La capture « Dry-Run »
 
-Lorsque la superposition d'aide est visible (`app->show_help == true`), le `key_callback` dans `app_input.c` entre en mode **Dry-Run** :
+Lorsque la superposition d'aide est visible (`ctx->overlay->show_help != HELP_MODE_OFF`), le `key_callback` dans `app_input.c` entre en mode **Dry-Run** :
 
 - Il intercepte les appuis de touches.
 - Il met à jour `app->help_pressed_key` et `app->help_pressed_mods`.

--- a/docs/keyboard_system.md
+++ b/docs/keyboard_system.md
@@ -39,7 +39,7 @@ typedef struct {
 
 ### The "Dry-Run" Capture
 
-When the help overlay is visible (`app->show_help == true`), the `key_callback` in `app_input.c` enters a **Dry-Run** mode:
+When the help overlay is visible (`ctx->overlay->show_help != HELP_MODE_OFF`), the `key_callback` in `app_input.c` enters a **Dry-Run** mode:
 
 - It intercepts key presses.
 - It updates `app->help_pressed_key` and `app->help_pressed_mods`.

--- a/include/action_notifier.h
+++ b/include/action_notifier.h
@@ -27,7 +27,7 @@
  * @struct ActionNotification
  * @brief Represents a single active notification.
  */
-typedef struct {
+typedef struct ActionNotification {
 	char text[MAX_ACTION_TEXT_LENGTH];
 	float lifetime;     /**< Current time active (seconds). */
 	float max_lifetime; /**< Total time to display (seconds). */
@@ -38,7 +38,7 @@ typedef struct {
  * @struct ActionNotifier
  * @brief Manager for action notifications.
  */
-typedef struct {
+typedef struct ActionNotifier {
 	ActionNotification notes[MAX_ACTION_NOTIFICATIONS];
 } ActionNotifier;
 

--- a/include/app.h
+++ b/include/app.h
@@ -111,8 +111,6 @@ void app_run(App* app);
  */
 void app_update(App* app);
 
-#include "app_input.h"
-
 enum { TRACY_SCREENSHOT_WIDTH = 320, TRACY_SCREENSHOT_HEIGHT = 180 };
 
 #endif /* APP_H */

--- a/include/app_input.h
+++ b/include/app_input.h
@@ -5,14 +5,67 @@
  * This module manages all high-level input logic, bridging GLFW raw events
  * to application-specific actions like post-processing toggles, environment
  * map switching, and camera movement.
+ *
+ * Input handlers receive an AppInputContext (focused pointer bundle) instead
+ * of the full App struct, following the same pattern as PostProcessInputContext
+ * and camera_input.
  */
 
 #ifndef APP_INPUT_H
 #define APP_INPUT_H
 
-typedef struct App App;
-typedef struct Camera Camera;
 #include "gl_common.h"
+
+/* Forward declarations — avoids pulling heavy headers into app_input.h */
+typedef struct Camera Camera;
+typedef struct Scene Scene;
+typedef struct PostProcess PostProcess;
+typedef struct EnvManager EnvManager;
+typedef struct ActionNotifier ActionNotifier;
+typedef struct AppUIOverlay AppUIOverlay;
+typedef struct GPUProfilerUI GPUProfilerUI;
+typedef struct EffectBenchmark EffectBenchmark;
+typedef struct PerfModeContext PerfModeContext;
+typedef struct GamepadState GamepadState;
+typedef struct AsyncLoader AsyncLoader;
+
+/**
+ * @struct AppInputContext
+ * @brief Focused context for application-level input handling.
+ *
+ * Decouples input logic from the App God Object by exposing only the
+ * fields that input handlers actually need. Constructed once per frame
+ * (or per callback) from App fields in app.c.
+ */
+typedef struct {
+	GLFWwindow* window;
+	Camera* camera;
+	Scene* scene;
+	PostProcess* postprocess;
+	EnvManager* env_mgr;
+	ActionNotifier* notifier;
+	AppUIOverlay* overlay;
+	GPUProfilerUI* timeline_ui;
+	EffectBenchmark* effect_bench;
+	PerfModeContext* perf_context;
+	GamepadState* gamepad;
+	AsyncLoader* async_loader;
+
+	/* Mutable scalar state (pointers so mutations propagate to App) */
+	int* width;
+	int* height;
+	int* camera_enabled;
+	int* is_fullscreen;
+	int* saved_x;
+	int* saved_y;
+	int* saved_width;
+	int* saved_height;
+	int* resize_pending;
+	int* pending_width;
+	int* pending_height;
+	int* perf_mode_active;
+	int* log_gpu_metrics;
+} AppInputContext;
 
 /**
  * @brief Primary GLFW key callback.
@@ -60,35 +113,35 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height);
  * @brief Dispatches application-level logic for key inputs.
  *
  * Handles system-wide shortcuts (ESC to exit, Space to pause, etc.).
- * @param app Pointer to the application state.
+ * @param ctx Pointer to the input context.
  * @param key Locked key code.
  * @param mods Active modifiers.
  */
-void handle_app_input(App* app, int key, int mods);
+void handle_app_input(AppInputContext* ctx, int key, int mods);
 
 /* --- Internal Logic Bridge Functions --- */
 
 /**
  * @brief Handles input for cycling environment maps.
- * @param app Pointer to the application state.
+ * @param ctx Pointer to the input context.
  * @param action GLFW action (Press/Release).
  * @param mods Modifiers.
  * @param key Directional key.
  */
-void app_handle_env_input(App* app, int action, int mods, int key);
+void app_handle_env_input(AppInputContext* ctx, int action, int mods, int key);
 
 /**
  * @brief Toggles the application window between Windowed and Fullscreen.
- * @param app Pointer to the application state.
+ * @param ctx Pointer to the input context.
  * @param window GLFW window handle.
  */
-void app_toggle_fullscreen(App* app, GLFWwindow* window);
+void app_toggle_fullscreen(AppInputContext* ctx, GLFWwindow* window);
 
 /**
  * @brief Captures the current framebuffer and saves it as a PNG file.
- * @param app Pointer to the application state.
+ * @param ctx Pointer to the input context.
  * @param filename Output file path (should end in .png).
  */
-void app_save_png_frame(App* app, const char* filename);
+void app_save_png_frame(AppInputContext* ctx, const char* filename);
 
 #endif /* APP_INPUT_H */

--- a/include/app_ui.h
+++ b/include/app_ui.h
@@ -300,7 +300,7 @@ enum {
 	    sizeof(GAMEPAD_LAYOUT) / sizeof(GAMEPAD_LAYOUT[0])
 };
 
-typedef struct {
+typedef struct AppUIOverlay {
 	UIContext ui;
 	KeyboardLayoutConfig kbd_config;
 

--- a/include/effect_benchmark.h
+++ b/include/effect_benchmark.h
@@ -49,7 +49,7 @@ typedef enum {
  * @struct EffectBenchResult
  * @brief Timing result for a single effect.
  */
-typedef struct {
+typedef struct EffectBenchResult {
 	const char* name;        /**< Human-readable effect name. */
 	unsigned int effect_bit; /**< PostProcessEffect bitmask value. */
 	float mean_ms;           /**< Mean composite time with effect OFF. */
@@ -61,7 +61,7 @@ typedef struct {
  * @struct EffectBenchmark
  * @brief State for the automated benchmark sweep.
  */
-typedef struct {
+typedef struct EffectBenchmark {
 	BenchPhase phase;
 	PostProcess* postprocess;
 	GPUProfiler* profiler;

--- a/include/gpu_profiler_ui.h
+++ b/include/gpu_profiler_ui.h
@@ -9,7 +9,7 @@
  * @struct GPUProfilerUI
  * @brief Manages the visual state and animations for the GPU timeline.
  */
-typedef struct {
+typedef struct GPUProfilerUI {
 	GPUProfiler display_profiler; /**< Snapshot of profiler data for UI. */
 	float box_height;      /**< Current target height of background. */
 	float prev_box_height; /**< Previous height for LERP. */

--- a/include/perf_mode.h
+++ b/include/perf_mode.h
@@ -49,7 +49,7 @@ typedef enum {
  * @struct PerfModeContext
  * @brief State container for performance mode.
  */
-typedef struct {
+typedef struct PerfModeContext {
 	PerfModeState state;               /**< Current activity state. */
 	PerfModeBackend backend;           /**< Selected backend. */
 	int original_policy;               /**< Saved scheduler policy. */

--- a/src/app.c
+++ b/src/app.c
@@ -256,13 +256,24 @@ void app_run(App* app)
 			if (app->camera_enabled) {
 				gamepad_input_poll(&app->gamepad, &gp_actions);
 			}
-			if (gp_actions.env_next) {
-				app_handle_env_input(app, GLFW_PRESS, 0,
-				                     GLFW_KEY_PAGE_UP);
-			}
-			if (gp_actions.env_prev) {
-				app_handle_env_input(app, GLFW_PRESS, 0,
-				                     GLFW_KEY_PAGE_DOWN);
+			if (gp_actions.env_next || gp_actions.env_prev) {
+				AppInputContext env_ctx = {
+				    .window = app->window,
+				    .scene = &app->scene,
+				    .env_mgr = &app->env_mgr,
+				    .notifier = &app->notifier,
+				    .async_loader = app->async_loader,
+				};
+				if (gp_actions.env_next) {
+					app_handle_env_input(&env_ctx,
+					                     GLFW_PRESS, 0,
+					                     GLFW_KEY_PAGE_UP);
+				}
+				if (gp_actions.env_prev) {
+					app_handle_env_input(
+					    &env_ctx, GLFW_PRESS, 0,
+					    GLFW_KEY_PAGE_DOWN);
+				}
 			}
 			if (gp_actions.camera_reset) {
 				camera_init(

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -23,6 +23,43 @@
 #include <stdlib.h>
 #include <string.h>
 
+/**
+ * @brief Constructs an AppInputContext from the full App state.
+ *
+ * Used by GLFW callbacks to bridge between the GLFW user-pointer (App*)
+ * and the decoupled input API (AppInputContext*).
+ */
+static inline AppInputContext app_input_ctx_from_app(App* app)
+{
+	return (AppInputContext){
+	    .window = app->window,
+	    .camera = &app->camera,
+	    .scene = &app->scene,
+	    .postprocess = &app->postprocess,
+	    .env_mgr = &app->env_mgr,
+	    .notifier = &app->notifier,
+	    .overlay = &app->overlay,
+	    .timeline_ui = &app->timeline_ui,
+	    .effect_bench = &app->effect_bench,
+	    .perf_context = &app->perf_context,
+	    .gamepad = &app->gamepad,
+	    .async_loader = app->async_loader,
+	    .width = &app->width,
+	    .height = &app->height,
+	    .camera_enabled = &app->camera_enabled,
+	    .is_fullscreen = &app->is_fullscreen,
+	    .saved_x = &app->saved_x,
+	    .saved_y = &app->saved_y,
+	    .saved_width = &app->saved_width,
+	    .saved_height = &app->saved_height,
+	    .resize_pending = &app->resize_pending,
+	    .pending_width = &app->pending_width,
+	    .pending_height = &app->pending_height,
+	    .perf_mode_active = &app->perf_mode_active,
+	    .log_gpu_metrics = &app->log_gpu_metrics,
+	};
+}
+
 enum { PBR_DEBUG_MODE_COUNT = 10 };
 
 /* Notification constants */
@@ -43,8 +80,10 @@ static const float GRAVITY_INV_FACTOR = 0.5F;
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
 	App* app = (App*)glfwGetWindowUserPointer(window);
-	app->width = width;
-	app->height = height;
+	AppInputContext ctx_storage = app_input_ctx_from_app(app);
+	AppInputContext* ctx = &ctx_storage;
+	*ctx->width = width;
+	*ctx->height = height;
 	glViewport(0, 0, width, height);
 
 	/* Defer heavy GPU work (FBO/texture recreation) to the next frame.
@@ -52,15 +91,15 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 	 * glfwSetWindowMonitor() during a fullscreen toggle. Doing GPU resource
 	 * destruction/creation here deadlocks on NVIDIA when the driver is
 	 * mid-mode-switch. */
-	app->pending_width = width;
-	app->pending_height = height;
-	app->resize_pending = 1;
+	*ctx->pending_width = width;
+	*ctx->pending_height = height;
+	*ctx->resize_pending = 1;
 }
 
-static void handle_pbr_debug_mode(App* app)
+static void handle_pbr_debug_mode(AppInputContext* ctx)
 {
-	app->scene.pbr_debug_mode =
-	    (app->scene.pbr_debug_mode + 1) % PBR_DEBUG_MODE_COUNT;
+	ctx->scene->pbr_debug_mode =
+	    (ctx->scene->pbr_debug_mode + 1) % PBR_DEBUG_MODE_COUNT;
 	const char* modeNames[] = {"Final PBR",
 	                           "Albedo",
 	                           "Normal",
@@ -72,55 +111,57 @@ static void handle_pbr_debug_mode(App* app)
 	                           "BRDF LUT",
 	                           "1-Bounce GI (Probes)"};
 	LOG_INFO("suckless-ogl.app", "PBR Debug Mode: %s",
-	         modeNames[app->scene.pbr_debug_mode]);
+	         modeNames[ctx->scene->pbr_debug_mode]);
 
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "Debug: %s",
-	                    modeNames[app->scene.pbr_debug_mode]);
-	action_notifier_push(&app->notifier, buf, NOTIF_DUR_LONG);
+	                    modeNames[ctx->scene->pbr_debug_mode]);
+	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_LONG);
 }
 
-static void handle_aa_mode_input(App* app)
+static void handle_aa_mode_input(AppInputContext* ctx)
 {
-	app->scene.aa_mode = (app->scene.aa_mode + 1) % AA_MODE_COUNT;
-	const char* mode_name = aa_mode_to_string(app->scene.aa_mode);
+	ctx->scene->aa_mode = (ctx->scene->aa_mode + 1) % AA_MODE_COUNT;
+	const char* mode_name = aa_mode_to_string(ctx->scene->aa_mode);
 	LOG_INFO("suckless-ogl.app", "Specular AA Mode: %s", mode_name);
 
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "AA Mode: %s", mode_name);
-	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_NORMAL);
 }
 
-void app_handle_env_input(App* app, int action, int mods, int key)
+void app_handle_env_input(AppInputContext* ctx, int action, int mods, int key)
 {
 	if (action != GLFW_PRESS && action != GLFW_REPEAT) {
 		return;
 	}
 	if (key == GLFW_KEY_PAGE_UP) {
 		if (check_flag(mods, GLFW_MOD_SHIFT)) {
-			app->scene.env_lod += LOD_STEP;
-			if (app->scene.env_lod > MAX_ENV_LOD) {
-				app->scene.env_lod = MAX_ENV_LOD;
+			ctx->scene->env_lod += LOD_STEP;
+			if (ctx->scene->env_lod > MAX_ENV_LOD) {
+				ctx->scene->env_lod = MAX_ENV_LOD;
 			}
 			LOG_INFO("suckless-ogl.app", "Env LOD: %.1F",
-			         app->scene.env_lod);
+			         ctx->scene->env_lod);
 			char lod_buf[NOTIF_BUF_SIZE];
 			(void)safe_snprintf(lod_buf, sizeof(lod_buf),
 			                    "Env LOD: %.1F",
-			                    app->scene.env_lod);
-			action_notifier_push(&app->notifier, lod_buf,
+			                    ctx->scene->env_lod);
+			action_notifier_push(ctx->notifier, lod_buf,
 			                     NOTIF_DUR_SHORT);
-		} else if (app->scene.hdr_count > 1) {
-			app->scene.current_hdr_index =
-			    (app->scene.current_hdr_index + 1) %
-			    app->scene.hdr_count;
+		} else if (ctx->scene->hdr_count > 1) {
+			ctx->scene->current_hdr_index =
+			    (ctx->scene->current_hdr_index + 1) %
+			    ctx->scene->hdr_count;
 			env_manager_trigger_transition(
-			    &app->env_mgr, app->async_loader,
-			    app->scene.hdr_files[app->scene.current_hdr_index]);
+			    ctx->env_mgr, ctx->async_loader,
+			    ctx->scene
+			        ->hdr_files[ctx->scene->current_hdr_index]);
 
 			char buf[NOTIF_BUF_SIZE];
 			const char* filename =
-			    app->scene.hdr_files[app->scene.current_hdr_index];
+			    ctx->scene
+			        ->hdr_files[ctx->scene->current_hdr_index];
 			/* Try to strip path if possible for cleaner display */
 			const char* last_slash = strrchr(filename, '/');
 			if (last_slash) {
@@ -128,230 +169,232 @@ void app_handle_env_input(App* app, int action, int mods, int key)
 			}
 			(void)safe_snprintf(buf, sizeof(buf), "HDR: %s",
 			                    filename);
-			action_notifier_push(&app->notifier, buf,
+			action_notifier_push(ctx->notifier, buf,
 			                     NOTIF_DUR_LONG);
 		}
 	} else if (key == GLFW_KEY_PAGE_DOWN) {
 		if (check_flag(mods, GLFW_MOD_SHIFT)) {
-			app->scene.env_lod -= LOD_STEP;
-			if (app->scene.env_lod < MIN_ENV_LOD) {
-				app->scene.env_lod = MIN_ENV_LOD;
+			ctx->scene->env_lod -= LOD_STEP;
+			if (ctx->scene->env_lod < MIN_ENV_LOD) {
+				ctx->scene->env_lod = MIN_ENV_LOD;
 			}
 			LOG_INFO("suckless-ogl.app", "Env LOD: %.1F",
-			         app->scene.env_lod);
+			         ctx->scene->env_lod);
 			char lod_buf[NOTIF_BUF_SIZE];
 			(void)safe_snprintf(lod_buf, sizeof(lod_buf),
 			                    "Env LOD: %.1F",
-			                    app->scene.env_lod);
-			action_notifier_push(&app->notifier, lod_buf,
+			                    ctx->scene->env_lod);
+			action_notifier_push(ctx->notifier, lod_buf,
 			                     NOTIF_DUR_SHORT);
-		} else if (app->scene.hdr_count > 1) {
-			app->scene.current_hdr_index--;
-			if (app->scene.current_hdr_index < 0) {
-				app->scene.current_hdr_index =
-				    app->scene.hdr_count - 1;
+		} else if (ctx->scene->hdr_count > 1) {
+			ctx->scene->current_hdr_index--;
+			if (ctx->scene->current_hdr_index < 0) {
+				ctx->scene->current_hdr_index =
+				    ctx->scene->hdr_count - 1;
 			}
 			env_manager_trigger_transition(
-			    &app->env_mgr, app->async_loader,
-			    app->scene.hdr_files[app->scene.current_hdr_index]);
+			    ctx->env_mgr, ctx->async_loader,
+			    ctx->scene
+			        ->hdr_files[ctx->scene->current_hdr_index]);
 
 			char buf[NOTIF_BUF_SIZE];
 			const char* filename =
-			    app->scene.hdr_files[app->scene.current_hdr_index];
+			    ctx->scene
+			        ->hdr_files[ctx->scene->current_hdr_index];
 			const char* last_slash = strrchr(filename, '/');
 			if (last_slash) {
 				filename = last_slash + 1;
 			}
 			(void)safe_snprintf(buf, sizeof(buf), "HDR: %s",
 			                    filename);
-			action_notifier_push(&app->notifier, buf,
+			action_notifier_push(ctx->notifier, buf,
 			                     NOTIF_DUR_LONG);
 		}
 	}
 }
 
-static void handle_overlay_input(App* app)
+static void handle_overlay_input(AppInputContext* ctx)
 {
 	static const char* mode_names[] = {
 	    "Off", "FPS + Position", "FPS + Position + Envmap",
 	    "FPS + Position + Envmap + Exposure"};
 	static const int mode_count =
 	    sizeof(mode_names) / sizeof(mode_names[0]);
-	app->overlay.text_overlay_mode =
-	    (app->overlay.text_overlay_mode + 1) % mode_count;
+	ctx->overlay->text_overlay_mode =
+	    (ctx->overlay->text_overlay_mode + 1) % mode_count;
 	LOG_INFO("suckless-ogl.app", "Text Overlay: %s",
-	         mode_names[app->overlay.text_overlay_mode]);
+	         mode_names[ctx->overlay->text_overlay_mode]);
 
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "Overlay: %s",
-	                    mode_names[app->overlay.text_overlay_mode]);
-	action_notifier_push(&app->notifier, buf, NOTIF_DUR_LONG);
+	                    mode_names[ctx->overlay->text_overlay_mode]);
+	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_LONG);
 }
 
-static void handle_subdiv_input(App* app, int key)
+static void handle_subdiv_input(AppInputContext* ctx, int key)
 {
 	int changed = 0;
-	if (key == GLFW_KEY_UP && app->scene.subdivisions < MAX_SUBDIV) {
-		app->scene.subdivisions++;
+	if (key == GLFW_KEY_UP && ctx->scene->subdivisions < MAX_SUBDIV) {
+		ctx->scene->subdivisions++;
 		changed = 1;
 	} else if (key == GLFW_KEY_DOWN &&
-	           app->scene.subdivisions > MIN_SUBDIV) {
-		app->scene.subdivisions--;
+	           ctx->scene->subdivisions > MIN_SUBDIV) {
+		ctx->scene->subdivisions--;
 		changed = 1;
 	}
 
 	if (changed) {
 		char buf[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(buf, sizeof(buf), "Subdiv: %d",
-		                    app->scene.subdivisions);
-		action_notifier_push(&app->notifier, buf, NOTIF_DUR_SHORT);
+		                    ctx->scene->subdivisions);
+		action_notifier_push(ctx->notifier, buf, NOTIF_DUR_SHORT);
 	}
 }
 
-static void handle_camera_toggle(App* app)
+static void handle_camera_toggle(AppInputContext* ctx)
 {
-	app->camera_enabled = !app->camera_enabled;
-	if (app->camera_enabled) {
-		glfwSetInputMode(app->window, GLFW_CURSOR,
+	*ctx->camera_enabled = !*ctx->camera_enabled;
+	if (*ctx->camera_enabled) {
+		glfwSetInputMode(ctx->window, GLFW_CURSOR,
 		                 GLFW_CURSOR_DISABLED);
-		app->camera.first_mouse = 1;
+		ctx->camera->first_mouse = 1;
 	} else {
-		glfwSetInputMode(app->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+		glfwSetInputMode(ctx->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 	}
 	LOG_INFO("suckless-ogl.app", "Camera control: %s",
-	         app->camera_enabled ? "ENABLED" : "DISABLED");
-	action_notifier_push(&app->notifier,
-	                     app->camera_enabled ? "Camera: ON" : "Camera: OFF",
-	                     NOTIF_DUR_NORMAL);
+	         *ctx->camera_enabled ? "ENABLED" : "DISABLED");
+	action_notifier_push(
+	    ctx->notifier, *ctx->camera_enabled ? "Camera: ON" : "Camera: OFF",
+	    NOTIF_DUR_NORMAL);
 }
 
-static void handle_f3_input(App* app, int mods)
+static void handle_f3_input(AppInputContext* ctx, int mods)
 {
 	if (check_flag(mods, GLFW_MOD_SHIFT)) {
 		/* Toggle Position */
-		gpu_profiler_ui_toggle_position(&app->timeline_ui);
+		gpu_profiler_ui_toggle_position(ctx->timeline_ui);
 
 		const char* pos_str =
-		    (app->timeline_ui.position == 0) ? "TOP" : "BOTTOM";
+		    (ctx->timeline_ui->position == 0) ? "TOP" : "BOTTOM";
 		LOG_INFO("suckless-ogl.app", "Timeline Position: %s", pos_str);
 
 		char msg[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(msg, sizeof(msg), "Timeline: %s", pos_str);
-		action_notifier_push(&app->notifier, msg, NOTIF_DUR_NORMAL);
+		action_notifier_push(ctx->notifier, msg, NOTIF_DUR_NORMAL);
 	} else {
 		/* Toggle Visibility */
-		gpu_profiler_ui_toggle_visibility(&app->timeline_ui);
+		gpu_profiler_ui_toggle_visibility(ctx->timeline_ui);
 		LOG_INFO("suckless-ogl.app", "GPU Timeline: %s",
-		         app->timeline_ui.visible ? "ON" : "OFF");
+		         ctx->timeline_ui->visible ? "ON" : "OFF");
 		const char* status = "Timeline: OFF";
-		if (app->timeline_ui.visible) {
+		if (ctx->timeline_ui->visible) {
 			status = "Timeline: ON";
 		}
-		action_notifier_push(&app->notifier, status, NOTIF_DUR_NORMAL);
+		action_notifier_push(ctx->notifier, status, NOTIF_DUR_NORMAL);
 	}
 }
 
-static void handle_f9_input(App* app)
+static void handle_f9_input(AppInputContext* ctx)
 {
 	PROFILE_ZONE(f9_zone, "Input: F9 (Performance Mode)");
-	if (app->perf_mode_active != 0) {
-		perf_mode_request_end(&app->perf_context);
-		app->perf_mode_active = 0;
-		action_notifier_push(&app->notifier, "Perf Mode: OFF",
+	if (*ctx->perf_mode_active != 0) {
+		perf_mode_request_end(ctx->perf_context);
+		*ctx->perf_mode_active = 0;
+		action_notifier_push(ctx->notifier, "Perf Mode: OFF",
 		                     NOTIF_DUR_LONG);
 	} else {
-		app->perf_mode_active =
-		    (perf_mode_request_start(&app->perf_context) == 0) ? 1 : 0;
+		*ctx->perf_mode_active =
+		    (perf_mode_request_start(ctx->perf_context) == 0) ? 1 : 0;
 		char buf[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(
 		    buf, sizeof(buf), "Perf Mode: ON (%s)",
-		    perf_mode_get_state_string(&app->perf_context));
-		action_notifier_push(&app->notifier, buf, NOTIF_DUR_LONG);
+		    perf_mode_get_state_string(ctx->perf_context));
+		action_notifier_push(ctx->notifier, buf, NOTIF_DUR_LONG);
 	}
 	LOG_INFO("suckless-ogl.app", "Performance Mode: %s (%s)",
-	         (app->perf_mode_active != 0) ? "ON" : "OFF",
-	         perf_mode_get_state_string(&app->perf_context));
+	         (*ctx->perf_mode_active != 0) ? "ON" : "OFF",
+	         perf_mode_get_state_string(ctx->perf_context));
 	PROFILE_ZONE_END(f9_zone);
 }
 
 static const char* const HELP_MODE_NAMES[] = {"Help: OFF", "Help: Keyboard",
                                               "Help: Gamepad"};
 
-static void app_toggle_help(App* app)
+static void app_toggle_help(AppInputContext* ctx)
 {
-	HelpMode prev = app->overlay.show_help;
-	app->overlay.show_help = (HelpMode)(((int)prev + 1) % HELP_MODE_COUNT);
+	HelpMode prev = ctx->overlay->show_help;
+	ctx->overlay->show_help = (HelpMode)(((int)prev + 1) % HELP_MODE_COUNT);
 
 	/* Skip gamepad page when no controller is connected. */
-	if (app->overlay.show_help == HELP_MODE_GAMEPAD &&
-	    !app->gamepad.connected) {
-		app->overlay.show_help =
-		    (HelpMode)(((int)app->overlay.show_help + 1) %
+	if (ctx->overlay->show_help == HELP_MODE_GAMEPAD &&
+	    !ctx->gamepad->connected) {
+		ctx->overlay->show_help =
+		    (HelpMode)(((int)ctx->overlay->show_help + 1) %
 		               HELP_MODE_COUNT);
 	}
-	HelpMode next = app->overlay.show_help;
+	HelpMode next = ctx->overlay->show_help;
 
 	if (prev == HELP_MODE_OFF && next != HELP_MODE_OFF) {
 		/* Opening overlay: if camera is active, disable it. */
-		if (app->camera_enabled) {
-			handle_camera_toggle(app);
-			app->overlay.help_captured_camera = 1;
+		if (*ctx->camera_enabled) {
+			handle_camera_toggle(ctx);
+			ctx->overlay->help_captured_camera = 1;
 		} else {
-			app->overlay.help_captured_camera = 0;
+			ctx->overlay->help_captured_camera = 0;
 		}
 	} else if (next == HELP_MODE_OFF && prev != HELP_MODE_OFF) {
 		/* Closing overlay: re-enable camera if we disabled it. */
-		if (app->overlay.help_captured_camera) {
-			handle_camera_toggle(app);
-			app->overlay.help_captured_camera = 0;
+		if (ctx->overlay->help_captured_camera) {
+			handle_camera_toggle(ctx);
+			ctx->overlay->help_captured_camera = 0;
 		}
 	}
-	action_notifier_push(&app->notifier, HELP_MODE_NAMES[(int)next],
+	action_notifier_push(ctx->notifier, HELP_MODE_NAMES[(int)next],
 	                     NOTIF_DUR_NORMAL);
 }
 
-static void app_close_help(App* app)
+static void app_close_help(AppInputContext* ctx)
 {
-	if (app->overlay.show_help == HELP_MODE_OFF) {
+	if (ctx->overlay->show_help == HELP_MODE_OFF) {
 		return;
 	}
-	app->overlay.show_help = HELP_MODE_OFF;
-	if (app->overlay.help_captured_camera) {
-		handle_camera_toggle(app);
-		app->overlay.help_captured_camera = 0;
+	ctx->overlay->show_help = HELP_MODE_OFF;
+	if (ctx->overlay->help_captured_camera) {
+		handle_camera_toggle(ctx);
+		ctx->overlay->help_captured_camera = 0;
 	}
-	action_notifier_push(&app->notifier, HELP_MODE_NAMES[0],
+	action_notifier_push(ctx->notifier, HELP_MODE_NAMES[0],
 	                     NOTIF_DUR_NORMAL);
 }
 
-static bool handle_f_key_input(App* app, int key, int mods)
+static bool handle_f_key_input(AppInputContext* ctx, int key, int mods)
 {
 	switch (key) {
 		case GLFW_KEY_F1:
-			handle_overlay_input(app);
+			handle_overlay_input(ctx);
 			return true;
 		case GLFW_KEY_F2:
-			app_toggle_help(app);
+			app_toggle_help(ctx);
 			return true;
 		case GLFW_KEY_F3:
-			handle_f3_input(app, mods);
+			handle_f3_input(ctx, mods);
 			return true;
 		case GLFW_KEY_F4:
-			app->log_gpu_metrics =
-			    (app->log_gpu_metrics != 0) ? 0 : 1;
+			*ctx->log_gpu_metrics =
+			    (*ctx->log_gpu_metrics != 0) ? 0 : 1;
 			LOG_INFO("suckless-ogl.app", "Log GPU Metrics: %s",
-			         (app->log_gpu_metrics != 0) ? "ON" : "OFF");
-			action_notifier_push(&app->notifier,
-			                     (app->log_gpu_metrics != 0)
+			         (*ctx->log_gpu_metrics != 0) ? "ON" : "OFF");
+			action_notifier_push(ctx->notifier,
+			                     (*ctx->log_gpu_metrics != 0)
 			                         ? "Log Metrics: ON"
 			                         : "Log Metrics: OFF",
 			                     NOTIF_DUR_NORMAL);
 			return true;
 		case GLFW_KEY_F5:
-			handle_pbr_debug_mode(app);
+			handle_pbr_debug_mode(ctx);
 			return true;
 		case GLFW_KEY_F9:
-			handle_f9_input(app);
+			handle_f9_input(ctx);
 			return true;
 		case GLFW_KEY_F12: {
 			if (!check_flag(mods, GLFW_MOD_SHIFT)) {
@@ -364,11 +407,11 @@ static bool handle_f_key_input(App* app, int key, int mods)
 			(void)strftime(filename, sizeof(filename),
 			               "screenshot_%Y%m%d_%H%M%S.png",
 			               time_info);
-			app_save_png_frame(app, filename);
+			app_save_png_frame(ctx, filename);
 			char msg[NOTIF_BUF_SIZE];
 			(void)safe_snprintf(msg, sizeof(msg),
 			                    "Screenshot saved: %s", filename);
-			action_notifier_push(&app->notifier, msg,
+			action_notifier_push(ctx->notifier, msg,
 			                     NOTIF_DUR_LONG);
 			return true;
 		}
@@ -377,80 +420,80 @@ static bool handle_f_key_input(App* app, int key, int mods)
 	}
 }
 
-static void handle_y_key_input(App* app, int mods)
+static void handle_y_key_input(AppInputContext* ctx, int mods)
 {
 	if ((unsigned int)mods & (unsigned int)GLFW_MOD_SHIFT) {
-		app->scene.show_probe_grid = !app->scene.show_probe_grid;
+		ctx->scene->show_probe_grid = !ctx->scene->show_probe_grid;
 		LOG_INFO("suckless-ogl.app", "Probe Grid Debug: %s",
-		         app->scene.show_probe_grid ? "ON" : "OFF");
+		         ctx->scene->show_probe_grid ? "ON" : "OFF");
 		action_notifier_push(
-		    &app->notifier,
-		    app->scene.show_probe_grid ? "Probes: ON" : "Probes: OFF",
+		    ctx->notifier,
+		    ctx->scene->show_probe_grid ? "Probes: ON" : "Probes: OFF",
 		    NOTIF_DUR_NORMAL);
 	} else {
-		app->scene.gi_mode = (app->scene.gi_mode + 1) % GI_MODE_COUNT;
+		ctx->scene->gi_mode = (ctx->scene->gi_mode + 1) % GI_MODE_COUNT;
 		const char* mode_names[] = {"OFF", "3D Texture", "SSBO"};
 		LOG_INFO("suckless-ogl.app", "GI Mode: %s",
-		         mode_names[app->scene.gi_mode]);
+		         mode_names[ctx->scene->gi_mode]);
 
 		char buf[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(buf, sizeof(buf), "GI: %s",
-		                    mode_names[app->scene.gi_mode]);
-		action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+		                    mode_names[ctx->scene->gi_mode]);
+		action_notifier_push(ctx->notifier, buf, NOTIF_DUR_NORMAL);
 	}
 }
 
-static void handle_system_key_input(App* app, int key, int mods)
+static void handle_system_key_input(AppInputContext* ctx, int key, int mods)
 {
 	switch (key) {
 		case GLFW_KEY_P:
-			app_save_png_frame(app, "capture_frame.png");
-			action_notifier_push(&app->notifier, "Frame Captured",
+			app_save_png_frame(ctx, "capture_frame.png");
+			action_notifier_push(ctx->notifier, "Frame Captured",
 			                     NOTIF_DUR_LONG);
 			break;
 		case GLFW_KEY_Z:
-			app->scene.wireframe = !app->scene.wireframe;
-			action_notifier_push(&app->notifier,
-			                     app->scene.wireframe
+			ctx->scene->wireframe = !ctx->scene->wireframe;
+			action_notifier_push(ctx->notifier,
+			                     ctx->scene->wireframe
 			                         ? "Wireframe: ON"
 			                         : "Wireframe: OFF",
 			                     NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_UP:
 		case GLFW_KEY_DOWN:
-			handle_subdiv_input(app, key);
+			handle_subdiv_input(ctx, key);
 			break;
 		case GLFW_KEY_C:
-			handle_camera_toggle(app);
+			handle_camera_toggle(ctx);
 			break;
 		case GLFW_KEY_SPACE:
-			camera_init(&app->camera, DEFAULT_CAMERA_DISTANCE,
+			camera_init(ctx->camera, DEFAULT_CAMERA_DISTANCE,
 			            DEFAULT_CAMERA_YAW, DEFAULT_CAMERA_PITCH);
-			app->scene.env_lod = DEFAULT_ENV_LOD;
+			ctx->scene->env_lod = DEFAULT_ENV_LOD;
 			LOG_INFO("suckless-ogl.app", "Camera and LOD reset");
-			action_notifier_push(&app->notifier,
+			action_notifier_push(ctx->notifier,
 			                     "Camera & LOD Reset",
 			                     NOTIF_DUR_LONG);
 			break;
 		case GLFW_KEY_PAGE_UP:
 		case GLFW_KEY_PAGE_DOWN:
-			app_handle_env_input(app, GLFW_PRESS, mods, key);
+			app_handle_env_input(ctx, GLFW_PRESS, mods, key);
 			break;
 		case GLFW_KEY_F:
-			app_toggle_fullscreen(app, app->window);
+			app_toggle_fullscreen(ctx, ctx->window);
 			break;
 		default:
 			break;
 	}
 }
 
-static bool handle_g_key_input(App* app, int mods)
+static bool handle_g_key_input(AppInputContext* ctx, int mods)
 {
 	/* Ctrl+Shift+G: toggle time reversal */
 	const int ctrl_shift =
 	    (int)((unsigned)GLFW_MOD_SHIFT | (unsigned)GLFW_MOD_CONTROL);
 	if (((unsigned)mods & (unsigned)ctrl_shift) == (unsigned)ctrl_shift) {
-		NBodySim* sim = &app->scene.nbody_sim;
+		NBodySim* sim = &ctx->scene->nbody_sim;
 		sim->target_time_scale = -sim->target_time_scale;
 		const char* dir =
 		    (sim->target_time_scale < 0.0F) ? "REVERSE" : "FORWARD";
@@ -459,25 +502,25 @@ static bool handle_g_key_input(App* app, int mods)
 		char buf[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(buf, sizeof(buf), "Time: %s (%.1fx)", dir,
 		                    (double)fabsf(sim->target_time_scale));
-		action_notifier_push(&app->notifier, buf, NOTIF_DUR_LONG);
+		action_notifier_push(ctx->notifier, buf, NOTIF_DUR_LONG);
 		return true;
 	}
 	if (!check_flag(mods, GLFW_MOD_SHIFT)) {
 		return false;
 	}
-	scene_toggle_nbody(&app->scene);
+	scene_toggle_nbody(ctx->scene);
 	LOG_INFO("suckless-ogl.app", "N-Body mode: %s",
-	         app->scene.nbody_mode ? "ON" : "OFF");
-	action_notifier_push(&app->notifier,
-	                     app->scene.nbody_mode ? "N-Body Gravity: ON"
-	                                           : "N-Body Gravity: OFF",
+	         ctx->scene->nbody_mode ? "ON" : "OFF");
+	action_notifier_push(ctx->notifier,
+	                     ctx->scene->nbody_mode ? "N-Body Gravity: ON"
+	                                            : "N-Body Gravity: OFF",
 	                     NOTIF_DUR_LONG);
 	return true;
 }
 
-static void handle_sim_speed_input(App* app, bool speed_up)
+static void handle_sim_speed_input(AppInputContext* ctx, bool speed_up)
 {
-	NBodySim* sim = &app->scene.nbody_sim;
+	NBodySim* sim = &ctx->scene->nbody_sim;
 	float mag = fabsf(sim->target_time_scale);
 	float sign = (sim->target_time_scale < 0.0F) ? -1.0F : 1.0F;
 	if (speed_up) {
@@ -495,12 +538,12 @@ static void handle_sim_speed_input(App* app, bool speed_up)
 	sim->time_scale = sim->target_time_scale;
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "Sim Speed: %.1fx", (double)mag);
-	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_NORMAL);
 }
 
-static void handle_gravity_input(App* app, bool increase)
+static void handle_gravity_input(AppInputContext* ctx, bool increase)
 {
-	NBodySim* sim = &app->scene.nbody_sim;
+	NBodySim* sim = &ctx->scene->nbody_sim;
 	if (increase) {
 		if (sim->gravity == 0.0F) {
 			sim->gravity = GRAVITY_MIN_POSITIVE;
@@ -527,26 +570,27 @@ static void handle_gravity_input(App* app, bool increase)
 		(void)safe_snprintf(buf, sizeof(buf), "Gravity: G=%.3f",
 		                    (double)sim->gravity);
 	}
-	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_NORMAL);
 }
 
-static void handle_sim_or_gravity_input(App* app, int mods, bool increase)
+static void handle_sim_or_gravity_input(AppInputContext* ctx, int mods,
+                                        bool increase)
 {
 	if (check_flag(mods, GLFW_MOD_SHIFT)) {
-		handle_gravity_input(app, increase);
+		handle_gravity_input(ctx, increase);
 	} else {
-		handle_sim_speed_input(app, increase);
+		handle_sim_speed_input(ctx, increase);
 	}
 }
 
-static void handle_o_key_input(App* app)
+static void handle_o_key_input(AppInputContext* ctx)
 {
-	app->scene.sorting_mode =
-	    (app->scene.sorting_mode + 1) % SORTING_MODE_COUNT;
+	ctx->scene->sorting_mode =
+	    (ctx->scene->sorting_mode + 1) % SORTING_MODE_COUNT;
 	const char* mode_name = "Unknown";
 	const char* notif_name = "Sort: Unknown";
 
-	switch (app->scene.sorting_mode) {
+	switch (ctx->scene->sorting_mode) {
 		case SORTING_MODE_CPU_QSORT:
 			mode_name = "CPU (qsort)";
 			notif_name = "Sort: CPU (qsort)";
@@ -564,24 +608,24 @@ static void handle_o_key_input(App* app)
 	}
 
 	LOG_INFO("suckless-ogl.app", "Sphere Sorting: %s", mode_name);
-	action_notifier_push(&app->notifier, notif_name, NOTIF_DUR_NORMAL);
+	action_notifier_push(ctx->notifier, notif_name, NOTIF_DUR_NORMAL);
 }
 
 static const char* const NEON_PARAM_NAMES[] = {"Intensity", "Core", "Width"};
 
-static void handle_neon_cycle(App* app)
+static void handle_neon_cycle(AppInputContext* ctx)
 {
-	TrailNeonParams* neon = &app->scene.trail_renderer.neon;
+	TrailNeonParams* neon = &ctx->scene->trail_renderer.neon;
 	neon->active = (neon->active + 1) % TRAIL_NEON_PARAM_COUNT;
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "Neon: %s selected",
 	                    NEON_PARAM_NAMES[neon->active]);
-	action_notifier_push(&app->notifier, buf, NOTIF_DUR_NORMAL);
+	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_NORMAL);
 }
 
-static void handle_neon_adjust(App* app, int increase)
+static void handle_neon_adjust(AppInputContext* ctx, int increase)
 {
-	TrailNeonParams* neon = &app->scene.trail_renderer.neon;
+	TrailNeonParams* neon = &ctx->scene->trail_renderer.neon;
 	float sign = (increase != 0) ? 1.0F : -1.0F;
 	const char* name = NEON_PARAM_NAMES[neon->active];
 	float val = 0.0F;
@@ -615,28 +659,28 @@ static void handle_neon_adjust(App* app, int increase)
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "Neon %s: %.2f", name,
 	                    (double)val);
-	action_notifier_push(&app->notifier, buf, NOTIF_DUR_SHORT);
+	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_SHORT);
 }
 
-static int handle_neon_input(App* app, int key, int mods)
+static int handle_neon_input(AppInputContext* ctx, int key, int mods)
 {
 	if (key != GLFW_KEY_I) {
 		return 0;
 	}
 	if (check_flag(mods, GLFW_MOD_SHIFT)) {
-		handle_neon_adjust(app, 1);
+		handle_neon_adjust(ctx, 1);
 	} else if (check_flag(mods, GLFW_MOD_CONTROL)) {
-		handle_neon_adjust(app, 0);
+		handle_neon_adjust(ctx, 0);
 	} else {
-		handle_neon_cycle(app);
+		handle_neon_cycle(ctx);
 	}
 	return 1;
 }
 
-void handle_app_input(App* app, int key, int mods)
+void handle_app_input(AppInputContext* ctx, int key, int mods)
 {
 	if (key >= GLFW_KEY_F1 && key <= GLFW_KEY_F12) {
-		if (handle_f_key_input(app, key, mods)) {
+		if (handle_f_key_input(ctx, key, mods)) {
 			return;
 		}
 	}
@@ -651,32 +695,33 @@ void handle_app_input(App* app, int key, int mods)
 		case GLFW_KEY_PAGE_UP:
 		case GLFW_KEY_PAGE_DOWN:
 		case GLFW_KEY_F:
-			handle_system_key_input(app, key, mods);
+			handle_system_key_input(ctx, key, mods);
 			break;
 		case GLFW_KEY_Y:
-			handle_y_key_input(app, mods);
+			handle_y_key_input(ctx, mods);
 			break;
 		case GLFW_KEY_L:
-			app->scene.billboard_mode = !app->scene.billboard_mode;
+			ctx->scene->billboard_mode =
+			    !ctx->scene->billboard_mode;
 			// app_update_instancing_mode(app) was empty and
 			// removed.
 			LOG_INFO("suckless-ogl.app", "Billboard Mode: %s",
-			         app->scene.billboard_mode ? "ON" : "OFF");
-			action_notifier_push(&app->notifier,
-			                     app->scene.billboard_mode
+			         ctx->scene->billboard_mode ? "ON" : "OFF");
+			action_notifier_push(ctx->notifier,
+			                     ctx->scene->billboard_mode
 			                         ? "Billboards: ON"
 			                         : "Billboards: OFF",
 			                     NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_O:
-			handle_o_key_input(app);
+			handle_o_key_input(ctx);
 			break;
 		case GLFW_KEY_T:
-			app->env_mgr.env_transition_mode =
-			    (app->env_mgr.env_transition_mode + 1) % 2;
+			ctx->env_mgr->env_transition_mode =
+			    (ctx->env_mgr->env_transition_mode + 1) % 2;
 			LOG_INFO("suckless-ogl.app",
 			         "Environment Transition Mode: %s",
-			         app->env_mgr.env_transition_mode ==
+			         ctx->env_mgr->env_transition_mode ==
 			                 ENV_TRANSITION_CROSSFADE
 			             ? "CROSSFADE"
 			             : "BLACK_SCREEN");
@@ -684,59 +729,59 @@ void handle_app_input(App* app, int key, int mods)
 			(void)safe_snprintf(transition_buf,
 			                    sizeof(transition_buf),
 			                    "Transition: %s",
-			                    app->env_mgr.env_transition_mode ==
+			                    ctx->env_mgr->env_transition_mode ==
 			                            ENV_TRANSITION_CROSSFADE
 			                        ? "CROSSFADE"
 			                        : "BLACK_SCREEN");
-			action_notifier_push(&app->notifier, transition_buf,
+			action_notifier_push(ctx->notifier, transition_buf,
 			                     NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_N:
 			if (check_flag(mods, GLFW_MOD_SHIFT)) {
-				handle_aa_mode_input(app);
+				handle_aa_mode_input(ctx);
 			} else {
-				app->scene.specular_aa_enabled =
-				    !app->scene.specular_aa_enabled;
+				ctx->scene->specular_aa_enabled =
+				    !ctx->scene->specular_aa_enabled;
 				action_notifier_push(
-				    &app->notifier,
-				    app->scene.specular_aa_enabled
+				    ctx->notifier,
+				    ctx->scene->specular_aa_enabled
 				        ? "Specular AA: ON"
 				        : "Specular AA: OFF",
 				    NOTIF_DUR_SHORT);
 			}
 			break;
 		case GLFW_KEY_K:
-			app->scene.show_envmap = !app->scene.show_envmap;
+			ctx->scene->show_envmap = !ctx->scene->show_envmap;
 			LOG_INFO("suckless-ogl.app", "Envmap: %s",
-			         app->scene.show_envmap ? "ON" : "OFF");
-			action_notifier_push(&app->notifier,
-			                     app->scene.show_envmap
+			         ctx->scene->show_envmap ? "ON" : "OFF");
+			action_notifier_push(ctx->notifier,
+			                     ctx->scene->show_envmap
 			                         ? "Skybox: ON"
 			                         : "Skybox: OFF",
 			                     NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_G:
-			if (handle_g_key_input(app, mods)) {
+			if (handle_g_key_input(ctx, mods)) {
 				return;
 			}
 			break;
 		case GLFW_KEY_PERIOD:
-			handle_sim_or_gravity_input(app, mods, true);
+			handle_sim_or_gravity_input(ctx, mods, true);
 			break;
 		case GLFW_KEY_COMMA:
-			handle_sim_or_gravity_input(app, mods, false);
+			handle_sim_or_gravity_input(ctx, mods, false);
 			break;
 		case GLFW_KEY_I:
-			handle_neon_input(app, key, mods);
+			handle_neon_input(ctx, key, mods);
 			break;
 		default:
 			break;
 	}
 
-	PostProcessInputContext pp_ctx = {.postprocess = &app->postprocess,
-	                                  .notifier = &app->notifier,
-	                                  .effect_bench = &app->effect_bench,
-	                                  .window = app->window};
+	PostProcessInputContext pp_ctx = {.postprocess = ctx->postprocess,
+	                                  .notifier = ctx->notifier,
+	                                  .effect_bench = ctx->effect_bench,
+	                                  .window = ctx->window};
 	postprocess_input_handle_key(&pp_ctx, key, mods);
 }
 
@@ -776,35 +821,37 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action,
 	          "Key: %d - Scancode: %d - Name: %s - Action: %d - Mods: %d",
 	          key, scancode, key_name ? key_name : "NULL", action, mods);
 	App* app = (App*)glfwGetWindowUserPointer(window);
+	AppInputContext ctx_storage = app_input_ctx_from_app(app);
+	AppInputContext* ctx = &ctx_storage;
 	if (action == GLFW_PRESS) {
 		if (key == GLFW_KEY_ESCAPE) {
-			if (app->overlay.show_help != HELP_MODE_OFF) {
-				app_close_help(app);
+			if (ctx->overlay->show_help != HELP_MODE_OFF) {
+				app_close_help(ctx);
 			} else {
 				glfwSetWindowShouldClose(window, GLFW_TRUE);
 			}
-		} else if (app->overlay.show_help != HELP_MODE_OFF) {
+		} else if (ctx->overlay->show_help != HELP_MODE_OFF) {
 			/* Dry-run mode: intercept keys except for Close/Toggle
 			 * keys */
 			if (key == GLFW_KEY_F2) {
-				handle_app_input(app, key, mods);
+				handle_app_input(ctx, key, mods);
 			} else {
-				app->overlay.help_pressed_key = key;
-				app->overlay.help_pressed_mods = mods;
-				app->overlay.help_press_timer =
+				ctx->overlay->help_pressed_key = key;
+				ctx->overlay->help_pressed_mods = mods;
+				ctx->overlay->help_press_timer =
 				    (double)HELP_PRESS_DURATION; /* Highlight
 				                                    duration */
 			}
 		} else {
-			handle_app_input(app, key, mods);
+			handle_app_input(ctx, key, mods);
 		}
 	}
-	if (app->overlay.show_help == HELP_MODE_OFF) {
-		camera_input_handle_key(&app->camera, key, action);
+	if (ctx->overlay->show_help == HELP_MODE_OFF) {
+		camera_input_handle_key(ctx->camera, key, action);
 	}
 }
 
-void app_toggle_fullscreen(App* app, GLFWwindow* window)
+void app_toggle_fullscreen(AppInputContext* ctx, GLFWwindow* window)
 {
 	static const int REFRESH_RATE_WINDOWED = 0;
 
@@ -814,28 +861,27 @@ void app_toggle_fullscreen(App* app, GLFWwindow* window)
 	 * pending fences/swaps, the NVIDIA driver can deadlock. */
 	glFinish();
 
-	if (app->is_fullscreen == 0) {
+	if (*ctx->is_fullscreen == 0) {
 		GLFWmonitor* monitor = glfwGetPrimaryMonitor();
 		const GLFWvidmode* mode = glfwGetVideoMode(monitor);
-		glfwGetWindowPos(window, &app->saved_x, &app->saved_y);
-		glfwGetWindowSize(window, &app->saved_width,
-		                  &app->saved_height);
+		glfwGetWindowPos(window, ctx->saved_x, ctx->saved_y);
+		glfwGetWindowSize(window, ctx->saved_width, ctx->saved_height);
 		glfwSetWindowMonitor(window, monitor, 0, 0, mode->width,
 		                     mode->height, mode->refreshRate);
-		app->is_fullscreen = 1;
+		*ctx->is_fullscreen = 1;
 		LOG_INFO("suckless-ogl.app", "Switched to fullscreen (%dx%d)",
 		         mode->width, mode->height);
 	} else {
-		glfwSetWindowMonitor(window, NULL, app->saved_x, app->saved_y,
-		                     app->saved_width, app->saved_height,
+		glfwSetWindowMonitor(window, NULL, *ctx->saved_x, *ctx->saved_y,
+		                     *ctx->saved_width, *ctx->saved_height,
 		                     REFRESH_RATE_WINDOWED);
-		app->is_fullscreen = 0;
+		*ctx->is_fullscreen = 0;
 		LOG_INFO("suckless-ogl.app", "Switched to windowed");
 	}
 	glfwFocusWindow(window);
 
 	/* Force Wine/OS to re-capture the cursor after monitor switch */
-	if (app->camera_enabled) {
+	if (*ctx->camera_enabled) {
 		glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 
 		int width = 0;
@@ -845,33 +891,38 @@ void app_toggle_fullscreen(App* app, GLFWwindow* window)
 		                 (double)(height / 2));
 
 		glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-		app->camera.first_mouse = 1;
+		ctx->camera->first_mouse = 1;
 	}
 }
 
 void mouse_callback(GLFWwindow* window, double xpos, double ypos)
 {
 	App* app = (App*)glfwGetWindowUserPointer(window);
+	AppInputContext ctx_storage = app_input_ctx_from_app(app);
+	AppInputContext* ctx = &ctx_storage;
 
-	app_ui_handle_mouse(&app->overlay, xpos, ypos, app->width, app->height);
+	app_ui_handle_mouse(ctx->overlay, xpos, ypos, *ctx->width,
+	                    *ctx->height);
 
-	if (!app->camera_enabled) {
+	if (!*ctx->camera_enabled) {
 		return;
 	}
-	camera_input_handle_mouse(&app->camera, xpos, ypos);
+	camera_input_handle_mouse(ctx->camera, xpos, ypos);
 }
 
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset)
 {
 	(void)xoffset;
 	App* app = (App*)glfwGetWindowUserPointer(window);
-	camera_input_handle_scroll(&app->camera, yoffset);
+	AppInputContext ctx_storage = app_input_ctx_from_app(app);
+	AppInputContext* ctx = &ctx_storage;
+	camera_input_handle_scroll(ctx->camera, yoffset);
 }
 
-void app_save_png_frame(App* app, const char* filename)
+void app_save_png_frame(AppInputContext* ctx, const char* filename)
 {
-	int width = app->width;
-	int height = app->height;
+	int width = *ctx->width;
+	int height = *ctx->height;
 	int channels = 3;
 	size_t size = (size_t)width * (size_t)height * (size_t)channels;
 	unsigned char* pixels = malloc(size);

--- a/tests/test_app_input.c
+++ b/tests/test_app_input.c
@@ -10,6 +10,37 @@
 
 static App* test_app = NULL;
 
+static AppInputContext test_ctx_from_app(App* app)
+{
+	return (AppInputContext){
+	    .window = app->window,
+	    .camera = &app->camera,
+	    .scene = &app->scene,
+	    .postprocess = &app->postprocess,
+	    .env_mgr = &app->env_mgr,
+	    .notifier = &app->notifier,
+	    .overlay = &app->overlay,
+	    .timeline_ui = &app->timeline_ui,
+	    .effect_bench = &app->effect_bench,
+	    .perf_context = &app->perf_context,
+	    .gamepad = &app->gamepad,
+	    .async_loader = app->async_loader,
+	    .width = &app->width,
+	    .height = &app->height,
+	    .camera_enabled = &app->camera_enabled,
+	    .is_fullscreen = &app->is_fullscreen,
+	    .saved_x = &app->saved_x,
+	    .saved_y = &app->saved_y,
+	    .saved_width = &app->saved_width,
+	    .saved_height = &app->saved_height,
+	    .resize_pending = &app->resize_pending,
+	    .pending_width = &app->pending_width,
+	    .pending_height = &app->pending_height,
+	    .perf_mode_active = &app->perf_mode_active,
+	    .log_gpu_metrics = &app->log_gpu_metrics,
+	};
+}
+
 void setUp(void)
 {
 	if (!glfwInit()) {
@@ -76,47 +107,48 @@ void test_framebuffer_size_callback(void)
  */
 void test_handle_app_input_exhaustive(void)
 {
+	AppInputContext ctx = test_ctx_from_app(test_app);
 	/* Base toggles */
 	int val_before = test_app->overlay.text_overlay_mode;
-	handle_app_input(test_app, GLFW_KEY_F1, 0);
+	handle_app_input(&ctx, GLFW_KEY_F1, 0);
 	TEST_ASSERT_EQUAL(1, test_app->overlay.text_overlay_mode);
-	handle_app_input(test_app, GLFW_KEY_F2, 0);
+	handle_app_input(&ctx, GLFW_KEY_F2, 0);
 	TEST_ASSERT_EQUAL(HELP_MODE_KEYBOARD, test_app->overlay.show_help);
-	handle_app_input(test_app, GLFW_KEY_F3, 0);
+	handle_app_input(&ctx, GLFW_KEY_F3, 0);
 	TEST_ASSERT_TRUE(test_app->timeline_ui.visible);
-	handle_app_input(test_app, GLFW_KEY_F4, 0);
+	handle_app_input(&ctx, GLFW_KEY_F4, 0);
 	TEST_ASSERT_TRUE(test_app->log_gpu_metrics);
-	handle_app_input(test_app, GLFW_KEY_Z, 0);
+	handle_app_input(&ctx, GLFW_KEY_Z, 0);
 	TEST_ASSERT_TRUE(test_app->scene.wireframe);
-	handle_app_input(test_app, GLFW_KEY_C, 0);
+	handle_app_input(&ctx, GLFW_KEY_C, 0);
 	TEST_ASSERT_TRUE(test_app->camera_enabled);
-	handle_app_input(test_app, GLFW_KEY_L, 0);
+	handle_app_input(&ctx, GLFW_KEY_L, 0);
 	TEST_ASSERT_TRUE(test_app->scene.billboard_mode);
-	handle_app_input(test_app, GLFW_KEY_K, 0);
+	handle_app_input(&ctx, GLFW_KEY_K, 0);
 	TEST_ASSERT_TRUE(test_app->scene.show_envmap);
 
 	/* PBR Debug Modes (cycle) */
 	int initial_debug = test_app->scene.pbr_debug_mode;
-	handle_app_input(test_app, GLFW_KEY_F5, 0);
+	handle_app_input(&ctx, GLFW_KEY_F5, 0);
 	TEST_ASSERT_EQUAL((initial_debug + 1) % 9,
 	                  test_app->scene.pbr_debug_mode);
 
 	/* Banding Styles (cycle) */
 	/* First press enables banding and sets idx to 0 (Linear) */
-	handle_app_input(test_app, GLFW_KEY_7, 0);
+	handle_app_input(&ctx, GLFW_KEY_7, 0);
 	TEST_ASSERT_EQUAL(BANDING_MODE_LINEAR,
 	                  test_app->postprocess.banding.mode);
 	/* Enable banding manually to test cycle */
 	postprocess_enable(&test_app->postprocess, POSTFX_BANDING);
-	handle_app_input(test_app, GLFW_KEY_7, 0);
+	handle_app_input(&ctx, GLFW_KEY_7, 0);
 	TEST_ASSERT_EQUAL(BANDING_MODE_DITHERED,
 	                  test_app->postprocess.banding.mode);
-	handle_app_input(test_app, GLFW_KEY_7, 0);
+	handle_app_input(&ctx, GLFW_KEY_7, 0);
 	TEST_ASSERT_EQUAL(BANDING_MODE_PERCEPTUAL,
 	                  test_app->postprocess.banding.mode);
 
 	/* Benchmark */
-	handle_app_input(test_app, GLFW_KEY_8, 0);
+	handle_app_input(&ctx, GLFW_KEY_8, 0);
 	/* Benchmark might need more mocking if it calls GL, but let's check
 	 * flag if it exists */
 }
@@ -131,83 +163,84 @@ void test_handle_app_input_exhaustive(void)
  */
 void test_handle_postprocess_input_exhaustive(void)
 {
+	AppInputContext ctx = test_ctx_from_app(test_app);
 	/* Basic toggles */
-	handle_app_input(test_app, GLFW_KEY_V, 0);
+	handle_app_input(&ctx, GLFW_KEY_V, 0);
 	TEST_ASSERT_TRUE(
 	    postprocess_is_enabled(&test_app->postprocess, POSTFX_VIGNETTE));
-	handle_app_input(test_app, GLFW_KEY_G, 0);
+	handle_app_input(&ctx, GLFW_KEY_G, 0);
 	TEST_ASSERT_TRUE(
 	    postprocess_is_enabled(&test_app->postprocess, POSTFX_GRAIN));
-	handle_app_input(test_app, GLFW_KEY_B, 0);
+	handle_app_input(&ctx, GLFW_KEY_B, 0);
 	TEST_ASSERT_TRUE(
 	    postprocess_is_enabled(&test_app->postprocess, POSTFX_BLOOM));
-	handle_app_input(test_app, GLFW_KEY_M, 0);
+	handle_app_input(&ctx, GLFW_KEY_M, 0);
 	TEST_ASSERT_TRUE(
 	    postprocess_is_enabled(&test_app->postprocess, POSTFX_MOTION_BLUR));
 
 	/* Reset */
-	handle_app_input(test_app, GLFW_KEY_0, 0);
+	handle_app_input(&ctx, GLFW_KEY_0, 0);
 	/* Check some default values */
 
 	/* Exposure */
 	float exp_before = test_app->postprocess.exposure.exposure;
-	handle_app_input(test_app, GLFW_KEY_KP_ADD, 0);
+	handle_app_input(&ctx, GLFW_KEY_KP_ADD, 0);
 	TEST_ASSERT_TRUE(test_app->postprocess.exposure.exposure > exp_before);
 
 	/* Complex toggles (SHIFT) */
 	/* Motion Blur Debug Cycle */
-	handle_app_input(test_app, GLFW_KEY_M, GLFW_MOD_SHIFT);
+	handle_app_input(&ctx, GLFW_KEY_M, GLFW_MOD_SHIFT);
 	TEST_ASSERT_TRUE(postprocess_is_enabled(&test_app->postprocess,
 	                                        POSTFX_MOTION_BLUR_DEBUG));
-	handle_app_input(test_app, GLFW_KEY_M, GLFW_MOD_SHIFT);
+	handle_app_input(&ctx, GLFW_KEY_M, GLFW_MOD_SHIFT);
 	TEST_ASSERT_FALSE(postprocess_is_enabled(&test_app->postprocess,
 	                                         POSTFX_MOTION_BLUR_DEBUG));
 	TEST_ASSERT_TRUE(postprocess_is_enabled(&test_app->postprocess,
 	                                        POSTFX_VECTOR_FIELD_DEBUG));
-	handle_app_input(test_app, GLFW_KEY_M, GLFW_MOD_SHIFT);
+	handle_app_input(&ctx, GLFW_KEY_M, GLFW_MOD_SHIFT);
 	TEST_ASSERT_FALSE(postprocess_is_enabled(&test_app->postprocess,
 	                                         POSTFX_VECTOR_FIELD_DEBUG));
 
 	/* FXAA Toggle and Debug */
-	handle_app_input(test_app, GLFW_KEY_X, 0);
+	handle_app_input(&ctx, GLFW_KEY_X, 0);
 	TEST_ASSERT_TRUE(
 	    postprocess_is_enabled(&test_app->postprocess, POSTFX_FXAA));
-	handle_app_input(test_app, GLFW_KEY_X, GLFW_MOD_SHIFT);
+	handle_app_input(&ctx, GLFW_KEY_X, GLFW_MOD_SHIFT);
 	TEST_ASSERT_TRUE(
 	    postprocess_is_enabled(&test_app->postprocess, POSTFX_FXAA_DEBUG));
 
 	/* DOF Debug */
-	handle_app_input(test_app, GLFW_KEY_H, GLFW_MOD_SHIFT);
+	handle_app_input(&ctx, GLFW_KEY_H, GLFW_MOD_SHIFT);
 	TEST_ASSERT_TRUE(
 	    postprocess_is_enabled(&test_app->postprocess, POSTFX_DOF_DEBUG));
 
 	/* Auto Exposure Debug */
-	handle_app_input(test_app, GLFW_KEY_J, GLFW_MOD_SHIFT);
+	handle_app_input(&ctx, GLFW_KEY_J, GLFW_MOD_SHIFT);
 	TEST_ASSERT_TRUE(postprocess_is_enabled(&test_app->postprocess,
 	                                        POSTFX_EXPOSURE_DEBUG));
 
 	/* Stencil Debug */
-	handle_app_input(test_app, GLFW_KEY_F6, 0);
+	handle_app_input(&ctx, GLFW_KEY_F6, 0);
 	TEST_ASSERT_TRUE(postprocess_is_enabled(&test_app->postprocess,
 	                                        POSTFX_STENCIL_DEBUG));
 
 	/* Presets 2-6 */
-	handle_app_input(test_app, GLFW_KEY_2, 0);
-	handle_app_input(test_app, GLFW_KEY_3, 0);
-	handle_app_input(test_app, GLFW_KEY_4, 0);
-	handle_app_input(test_app, GLFW_KEY_5, 0);
-	handle_app_input(test_app, GLFW_KEY_6, 0);
+	handle_app_input(&ctx, GLFW_KEY_2, 0);
+	handle_app_input(&ctx, GLFW_KEY_3, 0);
+	handle_app_input(&ctx, GLFW_KEY_4, 0);
+	handle_app_input(&ctx, GLFW_KEY_5, 0);
+	handle_app_input(&ctx, GLFW_KEY_6, 0);
 
 	/* Banding Style Cycle (trigger multiple times) */
-	handle_app_input(test_app, GLFW_KEY_7, 0);
-	handle_app_input(test_app, GLFW_KEY_7, 0);
+	handle_app_input(&ctx, GLFW_KEY_7, 0);
+	handle_app_input(&ctx, GLFW_KEY_7, 0);
 
 	/* Benchmark (multiple times for 'already running' branch) */
-	handle_app_input(test_app, GLFW_KEY_8, 0);
-	handle_app_input(test_app, GLFW_KEY_8, 0);
+	handle_app_input(&ctx, GLFW_KEY_8, 0);
+	handle_app_input(&ctx, GLFW_KEY_8, 0);
 
 	/* Reload (just logs) */
-	handle_app_input(test_app, GLFW_KEY_R, 0);
+	handle_app_input(&ctx, GLFW_KEY_R, 0);
 }
 
 /**
@@ -278,10 +311,11 @@ void test_key_callback_dispatch(void)
  */
 void test_subdiv_input(void)
 {
+	AppInputContext ctx = test_ctx_from_app(test_app);
 	test_app->scene.subdivisions = 2;
-	handle_app_input(test_app, GLFW_KEY_UP, 0);
+	handle_app_input(&ctx, GLFW_KEY_UP, 0);
 	TEST_ASSERT_EQUAL(3, test_app->scene.subdivisions);
-	handle_app_input(test_app, GLFW_KEY_DOWN, 0);
+	handle_app_input(&ctx, GLFW_KEY_DOWN, 0);
 	TEST_ASSERT_EQUAL(2, test_app->scene.subdivisions);
 }
 
@@ -294,15 +328,16 @@ void test_subdiv_input(void)
  */
 void test_misc_system_input(void)
 {
+	AppInputContext ctx = test_ctx_from_app(test_app);
 	/* Fullscreen toggle */
-	handle_app_input(test_app, GLFW_KEY_F, 0);
+	handle_app_input(&ctx, GLFW_KEY_F, 0);
 
 	/* Screenshot */
-	handle_app_input(test_app, GLFW_KEY_P, 0);
+	handle_app_input(&ctx, GLFW_KEY_P, 0);
 	remove("capture_frame.png");
 
 	/* Reset */
-	handle_app_input(test_app, GLFW_KEY_SPACE, 0);
+	handle_app_input(&ctx, GLFW_KEY_SPACE, 0);
 }
 
 /**
@@ -314,10 +349,11 @@ void test_misc_system_input(void)
  */
 void test_env_input_exhaustive(void)
 {
+	AppInputContext ctx = test_ctx_from_app(test_app);
 	/* Test PageUp/Down for envmap switching */
-	app_handle_env_input(test_app, GLFW_RELEASE, 0, GLFW_KEY_PAGE_UP);
-	app_handle_env_input(test_app, GLFW_PRESS, 0, GLFW_KEY_PAGE_UP);
-	app_handle_env_input(test_app, GLFW_PRESS, 0, GLFW_KEY_PAGE_DOWN);
+	app_handle_env_input(&ctx, GLFW_RELEASE, 0, GLFW_KEY_PAGE_UP);
+	app_handle_env_input(&ctx, GLFW_PRESS, 0, GLFW_KEY_PAGE_UP);
+	app_handle_env_input(&ctx, GLFW_PRESS, 0, GLFW_KEY_PAGE_DOWN);
 }
 
 int main(void)


### PR DESCRIPTION
## Summary

Introduces `AppInputContext` — a focused pointer-bundle struct that decouples
`app_input.c` from the `App` God Object, following the same pattern as
`PostProcessInputContext` and `camera_input`.

## Changes

### Core refactoring
- **`include/app_input.h`**: Define `AppInputContext` (13 pointer fields + 13 mutable scalar pointers)
- **`src/app_input.c`**: All functions take `AppInputContext*` instead of `App*`; GLFW callbacks bridge via `app_input_ctx_from_app()`
- **`include/app.h`**: Remove `#include "app_input.h"` (breaks the dependency)
- **`src/app.c`**: Construct local `AppInputContext` for gamepad env dispatch

### Prerequisite: named struct tags
- 5 headers upgraded from anonymous `typedef struct { } Foo;` to named `typedef struct Foo { } Foo;`:
  `action_notifier.h`, `app_ui.h`, `gpu_profiler_ui.h`, `effect_benchmark.h`, `perf_mode.h`

### Tests
- `tests/test_app_input.c`: Uses `test_ctx_from_app()` helper — 63/63 tests pass

### Documentation
- `docs/architecture.md` / `.fr.md`: Note AppInputContext pattern
- `docs/keyboard_system.md` / `.fr.md`: Update dry-run condition reference
- `.github/copilot-instructions.md`: Add AppInputContext to Input subsystem table

## Architecture Grade

**C+ → A-** (context-struct pattern, consistent with camera_input and postprocess_input)

## Validation

- `just format` ✅
- `just lint` ✅ (0 warnings)
- `just test-all` ✅ (63/63)
- Manual functional validation: F2 overlay, all keybindings ISO

Closes #204