### PR TITLE
refactor(rendering): introduce RenderContext struct for renderer_draw_frame

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ Repository: [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
 | Subsystem | Key Files |
 |-----------|-----------|
 | **Core App** | `app.c`, `main.c`, `cli.c` |
-| **Rendering** | `renderer.c`, `sphere_types.h`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
+| **Rendering** | `renderer.c` (`RenderContext`), `sphere_types.h`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
 | **PBR / IBL** | `pbr.c`, `material.c`, `ibl_coordinator.c`, `light_probes.c`, `skybox.c` |
 | **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur) |
 | **Shaders** | 55+ GLSL files in `shaders/` (vertex, fragment, compute) |

--- a/docs/application_lifecycle.fr.md
+++ b/docs/application_lifecycle.fr.md
@@ -770,7 +770,7 @@ Cela assure une physique déterministe indépendamment du frame rate, tandis que
 
 ## Chapitre 9 — Rendu d'une Frame
 
-`renderer_draw_frame()` ([src/renderer.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/renderer.c)) orchestre le pipeline de rendu complet pour chaque frame.
+`renderer_draw_frame(const RenderContext* ctx)` ([src/renderer.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/renderer.c)) orchestre le pipeline de rendu complet pour chaque frame. Elle reçoit une seule struct `RenderContext` contenant tout l'état par frame (scène, caméra, postprocess, profiler, dimensions, etc.) au lieu de paramètres individuels, découplant le renderer de l'objet God `App`.
 
 ### 9.1 — Architecture Haut Niveau d'une Frame
 
@@ -1204,7 +1204,7 @@ Voici une estimation de la consommation VRAM en régime stationnaire :
 | `src/app.c` | `app_init()`, `app_run()`, `app_cleanup()` |
 | `src/window.c` | Création contexte GLFW + OpenGL |
 | `src/scene.c` | État scène, géométrie, instancing, passes de rendu |
-| `src/renderer.c` | Orchestration frame (`renderer_draw_frame`) |
+| `src/renderer.c` | Orchestration frame (`renderer_draw_frame`, `RenderContext`) |
 | `src/skybox.c` | Rendu environnement équirectangulaire |
 | `src/postprocess.c` | Pipeline post-traitement complet (7 étapes) |
 | `src/icosphere.c` | Génération mesh icosphère récursive |

--- a/docs/application_lifecycle.md
+++ b/docs/application_lifecycle.md
@@ -770,7 +770,7 @@ This ensures deterministic physics regardless of frame rate, while rotation stay
 
 ## Chapter 9 — Rendering a Frame
 
-`renderer_draw_frame()` ([src/renderer.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/renderer.c)) orchestrates the full rendering pipeline for each frame.
+`renderer_draw_frame(const RenderContext* ctx)` ([src/renderer.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/renderer.c)) orchestrates the full rendering pipeline for each frame. It receives a single `RenderContext` struct containing all per-frame state (scene, camera, postprocess, profiler, dimensions, etc.) instead of individual parameters, decoupling the renderer from the `App` God Object.
 
 ### 9.1 — High-Level Frame Architecture
 
@@ -1204,7 +1204,7 @@ Here's an estimate of VRAM consumption at steady state:
 | `src/app.c` | `app_init()`, `app_run()`, `app_cleanup()` |
 | `src/window.c` | GLFW + OpenGL context creation |
 | `src/scene.c` | Scene state, geometry, instancing, render passes |
-| `src/renderer.c` | Frame orchestration (`renderer_draw_frame`) |
+| `src/renderer.c` | Frame orchestration (`renderer_draw_frame`, `RenderContext`) |
 | `src/skybox.c` | Equirectangular environment rendering |
 | `src/postprocess.c` | Full post-processing pipeline (7 stages) |
 | `src/icosphere.c` | Recursive icosphere mesh generation |

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -12,20 +12,37 @@
 #include "ui.h"
 #include <stdint.h>
 
-/* Forward declare App UI function */
-struct App;
-void app_render_ui(const struct App* app);
+/**
+ * @brief Callback type for rendering the UI overlay.
+ * Decouples the renderer from the App struct.
+ */
+typedef void (*RenderUIFn)(void* user_data);
+
+/**
+ * @brief All state needed by renderer_draw_frame for a single frame.
+ * Populated by the caller (App or test harness) once per frame.
+ */
+typedef struct RenderContext {
+	Scene* scene;
+	PostProcess* postprocess;
+	Camera* camera;
+	GPUProfiler* profiler;
+	GPUProfilerUI* profiler_ui;
+	EnvManager* env_mgr;
+	ActionNotifier* notifier;
+	EffectBenchmark* effect_bench;
+	int width;
+	int height;
+	double delta_time;
+	uint64_t frame_count;
+	int log_gpu_metrics;
+	RenderUIFn render_ui;
+	void* render_ui_data;
+} RenderContext;
 
 /**
  * @brief Orchestrates the entire frame render (scene, postprocess, ui).
- * Decouples the rendering logic from the main App lifecycle and window state.
  */
-void renderer_draw_frame(struct App* app_ref, Scene* scene,
-                         PostProcess* postprocess, Camera* camera,
-                         GPUProfiler* profiler, GPUProfilerUI* timeline_ui,
-                         EnvManager* env_mgr, ActionNotifier* notifier,
-                         EffectBenchmark* effect_bench, int width, int height,
-                         double delta_time, uint64_t frame_count,
-                         int log_gpu_metrics);
+void renderer_draw_frame(const RenderContext* ctx);
 
 #endif /* RENDERER_H */

--- a/src/app.c
+++ b/src/app.c
@@ -187,6 +187,11 @@ void app_cleanup(App* app)
 	tracy_manager_cleanup(&app->tracy_mgr);
 }
 
+static void app_render_ui_trampoline(void* user_data)
+{
+	app_render_ui((const App*)user_data);
+}
+
 void app_run(App* app)
 {
 	int last_subdiv = -1;
@@ -340,12 +345,24 @@ void app_run(App* app)
 
 		{
 			PROFILE_ZONE(render_ctx, "App Render");
-			renderer_draw_frame(
-			    app, &app->scene, &app->postprocess, &app->camera,
-			    &app->gpu_profiler, &app->timeline_ui,
-			    &app->env_mgr, &app->notifier, &app->effect_bench,
-			    app->width, app->height, app->delta_time,
-			    app->frame_count, app->log_gpu_metrics);
+			RenderContext rctx = {
+			    .scene = &app->scene,
+			    .postprocess = &app->postprocess,
+			    .camera = &app->camera,
+			    .profiler = &app->gpu_profiler,
+			    .profiler_ui = &app->timeline_ui,
+			    .env_mgr = &app->env_mgr,
+			    .notifier = &app->notifier,
+			    .effect_bench = &app->effect_bench,
+			    .width = app->width,
+			    .height = app->height,
+			    .delta_time = app->delta_time,
+			    .frame_count = app->frame_count,
+			    .log_gpu_metrics = app->log_gpu_metrics,
+			    .render_ui = app_render_ui_trampoline,
+			    .render_ui_data = app,
+			};
+			renderer_draw_frame(&rctx);
 			PROFILE_ZONE_END(render_ctx);
 		}
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,49 +1,43 @@
 #include "renderer.h"
 
-#include "app_ui.h"
 #include "gl_common.h"
 #include "gl_debug.h"
 #include "gpu_profiler.h"
 #include "profiler.h"
 #include <GLFW/glfw3.h>
 
-void renderer_draw_frame(struct App* app_ref, Scene* scene,
-                         PostProcess* postprocess, Camera* camera,
-                         GPUProfiler* profiler, GPUProfilerUI* timeline_ui,
-                         EnvManager* env_mgr, ActionNotifier* notifier,
-                         EffectBenchmark* effect_bench, int width, int height,
-                         double delta_time, uint64_t frame_count,
-                         int log_gpu_metrics)
+void renderer_draw_frame(const RenderContext* ctx)
 {
 	bool profiling_enabled =
-	    (timeline_ui->visible || log_gpu_metrics != 0 ||
-	     effect_benchmark_is_running(effect_bench)) != 0;
-	postprocess_update_readbacks(postprocess, frame_count);
+	    (ctx->profiler_ui->visible || ctx->log_gpu_metrics != 0 ||
+	     effect_benchmark_is_running(ctx->effect_bench)) != 0;
+	postprocess_update_readbacks(ctx->postprocess, ctx->frame_count);
 
 	PROFILE_FRAME_MARK;
 
 	/* Effect benchmark: read previous frame's profiler results */
-	if (effect_benchmark_update(effect_bench)) {
-		action_notifier_push(notifier, "FX Benchmark: Done (see log)",
+	if (effect_benchmark_update(ctx->effect_bench)) {
+		action_notifier_push(ctx->notifier,
+		                     "FX Benchmark: Done (see log)",
 		                     NOTIF_DUR_LONG);
 	}
 
 	gl_debug_push_group("Render_Frame");
 
-	postprocess_begin(postprocess);
+	postprocess_begin(ctx->postprocess);
 	glClearColor(0.0F, 0.0F, 0.0F, 1.0F);
 
 	mat4 view;
 	mat4 proj;
 	mat4 view_proj;
 	mat4 inv_view_proj;
-	vec3 camera_pos = {camera->position[0], camera->position[1],
-	                   camera->position[2]};
-	camera_get_view_matrix(camera, view);
-	if (height > 0) {
-		glm_perspective(glm_rad(camera->zoom),
-		                (float)width / (float)height, NEAR_PLANE,
-		                FAR_PLANE, proj);
+	vec3 camera_pos = {ctx->camera->position[0], ctx->camera->position[1],
+	                   ctx->camera->position[2]};
+	camera_get_view_matrix(ctx->camera, view);
+	if (ctx->height > 0) {
+		glm_perspective(glm_rad(ctx->camera->zoom),
+		                (float)ctx->width / (float)ctx->height,
+		                NEAR_PLANE, FAR_PLANE, proj);
 	} else {
 		glm_mat4_identity(proj);
 	}
@@ -52,35 +46,38 @@ void renderer_draw_frame(struct App* app_ref, Scene* scene,
 
 	/* Provide scene FBO color handle so the shockwave grab pass can use
 	 * glCopyImageSubData (texture-to-texture DMA, no framebuffer read). */
-	scene->shockwave_renderer.scene_color_tex =
-	    postprocess->scene_color_tex;
+	ctx->scene->shockwave_renderer.scene_color_tex =
+	    ctx->postprocess->scene_color_tex;
 
 	{
-		GPU_STAGE_PROFILER(profiler, "Scene Render",
+		GPU_STAGE_PROFILER(ctx->profiler, "Scene Render",
 		                   GPU_PROFILER_SCENE_COLOR);
 		gl_debug_push_group("Scene_Render");
-		scene_render(scene, profiler, view, proj, camera_pos,
-		             postprocess->motion_blur_fx.previous_view_proj,
-		             width, height);
+		scene_render(
+		    ctx->scene, ctx->profiler, view, proj, camera_pos,
+		    ctx->postprocess->motion_blur_fx.previous_view_proj,
+		    ctx->width, ctx->height);
 		gl_debug_pop_group();
 	}
 
 	gl_debug_push_group("Post_Processing");
-	postprocess_end(postprocess);
+	postprocess_end(ctx->postprocess);
 	gl_debug_pop_group();
 
-	postprocess_update_matrices(postprocess, view_proj);
+	postprocess_update_matrices(ctx->postprocess, view_proj);
 
 	{
-		GPU_STAGE_PROFILER(profiler, "UI Overlay",
+		GPU_STAGE_PROFILER(ctx->profiler, "UI Overlay",
 		                   GPU_PROFILER_UI_COLOR);
 
 		gl_debug_push_group("UI_Overlay");
 
 		/* Render Transition Overlay */
-		env_manager_render_overlay(env_mgr, scene);
+		env_manager_render_overlay(ctx->env_mgr, ctx->scene);
 
-		app_render_ui(app_ref);
+		if (ctx->render_ui) {
+			ctx->render_ui(ctx->render_ui_data);
+		}
 
 		gl_debug_pop_group();
 	}
@@ -89,6 +86,6 @@ void renderer_draw_frame(struct App* app_ref, Scene* scene,
 
 	// 4. Logique d'affichage et animations
 	double current_time = glfwGetTime();
-	gpu_profiler_ui_update(timeline_ui, profiler, delta_time, current_time,
-	                       (bool)log_gpu_metrics);
+	gpu_profiler_ui_update(ctx->profiler_ui, ctx->profiler, ctx->delta_time,
+	                       current_time, (bool)ctx->log_gpu_metrics);
 }

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -87,6 +87,32 @@ static TestState* get_test_state(void)
 #define g_ref_cache (get_test_state()->ref_cache)
 #define g_ref_cache_count (get_test_state()->ref_cache_count)
 
+static void test_render_ui_trampoline(void* user_data)
+{
+	app_render_ui((const App*)user_data);
+}
+
+static RenderContext test_render_ctx_from_app(App* app)
+{
+	return (RenderContext){
+	    .scene = &app->scene,
+	    .postprocess = &app->postprocess,
+	    .camera = &app->camera,
+	    .profiler = &app->gpu_profiler,
+	    .profiler_ui = &app->timeline_ui,
+	    .env_mgr = &app->env_mgr,
+	    .notifier = &app->notifier,
+	    .effect_bench = &app->effect_bench,
+	    .width = app->width,
+	    .height = app->height,
+	    .delta_time = app->delta_time,
+	    .frame_count = app->frame_count,
+	    .log_gpu_metrics = app->log_gpu_metrics,
+	    .render_ui = test_render_ui_trampoline,
+	    .render_ui_data = app,
+	};
+}
+
 static void preload_reference(const char* test_name)
 {
 	if (g_ref_cache_count >= MAX_CACHED_REFS) {
@@ -377,14 +403,11 @@ static void pipeline_run_test_loop(const char* test_tag,
 			}
 
 			app_update(&g_test_app);
-			renderer_draw_frame(
-			    &g_test_app, &g_test_app.scene,
-			    &g_test_app.postprocess, &g_test_app.camera,
-			    &g_test_app.gpu_profiler, &g_test_app.timeline_ui,
-			    &g_test_app.env_mgr, &g_test_app.notifier,
-			    &g_test_app.effect_bench, g_test_app.width,
-			    g_test_app.height, g_test_app.delta_time,
-			    g_test_app.frame_count, g_test_app.log_gpu_metrics);
+			{
+				RenderContext rctx =
+				    test_render_ctx_from_app(&g_test_app);
+				renderer_draw_frame(&rctx);
+			}
 
 			// Start async readback for Viewpoint I
 			glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -528,13 +551,11 @@ static void pre_render_auto_exposure(const ViewPoint* vpoint, void* data)
 	for (int frame = 0; frame < warmup_frames; frame++) {
 		g_test_app.frame_count++;
 		app_update(&g_test_app);
-		renderer_draw_frame(
-		    &g_test_app, &g_test_app.scene, &g_test_app.postprocess,
-		    &g_test_app.camera, &g_test_app.gpu_profiler,
-		    &g_test_app.timeline_ui, &g_test_app.env_mgr,
-		    &g_test_app.notifier, &g_test_app.effect_bench,
-		    g_test_app.width, g_test_app.height, g_test_app.delta_time,
-		    g_test_app.frame_count, g_test_app.log_gpu_metrics);
+		{
+			RenderContext rctx =
+			    test_render_ctx_from_app(&g_test_app);
+			renderer_draw_frame(&rctx);
+		}
 	}
 }
 
@@ -562,13 +583,10 @@ static void pre_render_motion_blur(const ViewPoint* vpoint, void* data)
 	camera_update_vectors(&g_test_app.camera);
 
 	app_update(&g_test_app);
-	renderer_draw_frame(&g_test_app, &g_test_app.scene,
-	                    &g_test_app.postprocess, &g_test_app.camera,
-	                    &g_test_app.gpu_profiler, &g_test_app.timeline_ui,
-	                    &g_test_app.env_mgr, &g_test_app.notifier,
-	                    &g_test_app.effect_bench, g_test_app.width,
-	                    g_test_app.height, g_test_app.delta_time,
-	                    g_test_app.frame_count, g_test_app.log_gpu_metrics);
+	{
+		RenderContext rctx = test_render_ctx_from_app(&g_test_app);
+		renderer_draw_frame(&rctx);
+	}
 
 	// Restore camera to exact baseline for the pipeline's capture render
 	g_test_app.camera.yaw = vpoint->yaw;
@@ -587,13 +605,11 @@ static void pre_render_sony_a7siii(const ViewPoint* vpoint, void* data)
 	const int warmup_frames = 128;
 	for (int frame = 0; frame < warmup_frames; frame++) {
 		app_update(&g_test_app);
-		renderer_draw_frame(
-		    &g_test_app, &g_test_app.scene, &g_test_app.postprocess,
-		    &g_test_app.camera, &g_test_app.gpu_profiler,
-		    &g_test_app.timeline_ui, &g_test_app.env_mgr,
-		    &g_test_app.notifier, &g_test_app.effect_bench,
-		    g_test_app.width, g_test_app.height, g_test_app.delta_time,
-		    g_test_app.frame_count, g_test_app.log_gpu_metrics);
+		{
+			RenderContext rctx =
+			    test_render_ctx_from_app(&g_test_app);
+			renderer_draw_frame(&rctx);
+		}
 	}
 }
 

--- a/tests/test_stencil_masking.c
+++ b/tests/test_stencil_masking.c
@@ -19,6 +19,32 @@ enum {
 static App g_test_app;
 static bool g_app_initialized = false;
 
+static void test_render_ui_trampoline(void* user_data)
+{
+	app_render_ui((const App*)user_data);
+}
+
+static RenderContext test_render_ctx_from_app(App* app)
+{
+	return (RenderContext){
+	    .scene = &app->scene,
+	    .postprocess = &app->postprocess,
+	    .camera = &app->camera,
+	    .profiler = &app->gpu_profiler,
+	    .profiler_ui = &app->timeline_ui,
+	    .env_mgr = &app->env_mgr,
+	    .notifier = &app->notifier,
+	    .effect_bench = &app->effect_bench,
+	    .width = app->width,
+	    .height = app->height,
+	    .delta_time = app->delta_time,
+	    .frame_count = app->frame_count,
+	    .log_gpu_metrics = app->log_gpu_metrics,
+	    .render_ui = test_render_ui_trampoline,
+	    .render_ui_data = app,
+	};
+}
+
 static const float TEST_CAMERA_Z = 50.0F;
 static const float TEST_CAMERA_YAW = -90.0F;
 static const float TEST_CAMERA_PITCH = 0.0F;
@@ -64,13 +90,10 @@ void test_stencil_depth_consistency(void)
 	}
 
 	/* 4. Render a frame */
-	renderer_draw_frame(&g_test_app, &g_test_app.scene,
-	                    &g_test_app.postprocess, &g_test_app.camera,
-	                    &g_test_app.gpu_profiler, &g_test_app.timeline_ui,
-	                    &g_test_app.env_mgr, &g_test_app.notifier,
-	                    &g_test_app.effect_bench, g_test_app.width,
-	                    g_test_app.height, g_test_app.delta_time,
-	                    g_test_app.frame_count, g_test_app.log_gpu_metrics);
+	{
+		RenderContext rctx = test_render_ctx_from_app(&g_test_app);
+		renderer_draw_frame(&rctx);
+	}
 
 	/* 5. Bind the scene FBO to read from it */
 	glBindFramebuffer(GL_FRAMEBUFFER, g_test_app.postprocess.scene_fbo);


### PR DESCRIPTION
## Summary

Replace the 14-parameter `renderer_draw_frame()` with a single `const RenderContext*` parameter.

## Changes

- **`include/renderer.h`**: Define `RenderContext` struct (15 fields) + `RenderUIFn` callback type + new signature
- **`src/renderer.c`**: All field access via `ctx->`, `#include "app_ui.h"` removed, UI via callback
- **`src/app.c`**: Trampoline `app_render_ui_trampoline()` + `RenderContext` construction from App
- **`tests/test_app.c`**: Helper `test_render_ctx_from_app()` + 5 call sites adapted
- **`tests/test_stencil_masking.c`**: Same helper + 1 call site adapted
- **Docs**: `application_lifecycle.md/fr.md`, `copilot-instructions.md` updated

## Acceptance Criteria (from #200)

- [x] `renderer_draw_frame` takes ≤3 parameters (1: `const RenderContext*`)
- [x] No `App*` AND decomposed `App` fields in the same signature
- [x] `just format && just lint && just test-all` passes (63/63)
- [x] ASAN clean

Closes #200