### PR TITLE
refactor(postprocess): introduce EffectContext seam for bloom effect

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ Repository: [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
 | **Core App** | `app.c`, `main.c`, `cli.c` |
 | **Rendering** | `renderer.c` (`RenderContext`), `sphere_types.h`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
 | **PBR / IBL** | `pbr.c`, `material.c`, `ibl_coordinator.c`, `light_probes.c`, `skybox.c` |
-| **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur) |
+| **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur), `effect_context.h` (`EffectContext` seam) |
 | **Shaders** | 55+ GLSL files in `shaders/` (vertex, fragment, compute) |
 | **Input** | `app_input.c` (`AppInputContext`), `camera_input.c`, `postprocess_input.c` (`PostProcessInputContext`), `app_binding.c` |
 | **Profiling** | `gpu_profiler.c`, `perf_timer.c`, `tracy_manager.c`, `effect_benchmark.c` |

--- a/docs/application_lifecycle.fr.md
+++ b/docs/application_lifecycle.fr.md
@@ -535,11 +535,11 @@ graph LR
 
 ### 5.2 — Ressources des Sous-Effets
 
-Chaque effet de post-traitement initialise ses propres ressources :
+Chaque effet de post-traitement initialise ses propres ressources. Les effets reçoivent l'état partagé du pipeline via une struct `EffectContext` (texture source, dimensions viewport, textures profondeur/vélocité, exposition) plutôt qu'un pointeur direct vers `PostProcess`. Ce seam découple les effets individuels des détails internes du pipeline.
 
 | Effet | Ressources GPU |
 |-------|---------------|
-| **Bloom** | FBOs en chaîne mip (6 niveaux), textures prefiltre/downsample/upsample |
+| **Bloom** | FBOs en chaîne mip (6 niveaux), textures prefiltre/downsample/upsample. Découplé via `EffectContext` : `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)` |
 | **Profondeur de Champ** | Texture de flou, texture CoC (Cercle de Confusion) |
 | **Auto-Exposition** | Texture downsample luminance, 2× PBOs (readback), 2× fences GLSync |
 | **Flou de Mouvement** | Texture vélocité tile-max (compute), texture neighbor-max (compute) |

--- a/docs/application_lifecycle.md
+++ b/docs/application_lifecycle.md
@@ -535,11 +535,11 @@ graph LR
 
 ### 5.2 — Sub-Effect Resources
 
-Each post-processing effect initializes its own resources:
+Each post-processing effect initializes its own resources. Effects receive shared pipeline state through an `EffectContext` struct (source texture, viewport dimensions, depth/velocity textures, exposure) rather than a direct pointer to `PostProcess`. This seam decouples individual effects from the pipeline internals.
 
 | Effect | GPU Resources |
 |--------|--------------|
-| **Bloom** | Mip-chain FBOs (6 levels), prefilter/downsample/upsample textures |
+| **Bloom** | Mip-chain FBOs (6 levels), prefilter/downsample/upsample textures. Decoupled via `EffectContext`: `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)` |
 | **DoF** | Blur texture, CoC (Circle of Confusion) texture |
 | **Auto-Exposure** | Luminance downsample texture, 2× PBOs (readback), 2× GLSync fences |
 | **Motion Blur** | Tile-max velocity texture (compute), neighbor-max texture (compute) |

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -57,7 +57,17 @@ App
 ├── GPUProfiler    (métriques temporelles GPU)
 ├── AsyncLoader    (chargement asynchrone)
 └── PostProcess    (effets de post-traitement)
+    └── EffectContext  (seam vers les effets individuels)
 ```
+
+### Découplage des effets (EffectContext)
+
+Les effets de post-traitement (bloom, DoF, auto-exposition, flou de mouvement, LUT, LUT viz) sont progressivement découplés de l'objet God `PostProcess` via un seam `EffectContext` :
+
+- **`EffectContext`** (`include/effects/effect_context.h`) : snapshot read-only de l'état partagé du pipeline (texture source, dimensions viewport, textures profondeur/vélocité, exposition).
+- Les effets reçoivent `(FX*, Params*, const EffectContext*)` au lieu de `PostProcess*`.
+- Cela élimine la dépendance bidirectionnelle : `postprocess.h` → `fx_*.h` (pour l'embedding des structs) reste, mais `fx_*.c` → `postprocess.h` est supprimé.
+- Actuellement migré : **bloom**. Les effets restants suivront le même pattern.
 
 ## Configuration CMake
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,15 @@ To avoid cyclic dependencies:
 - Module headers are included at the **end** of `app.h` to ensure they can see the full `App` definition if necessary (though they primarily use pointers).
 - Specialized source files (`.c`) include `app.h` and the required renderer headers directly.
 
+### Effect Decoupling (EffectContext)
+
+Post-processing effects (bloom, DoF, auto-exposure, motion blur, LUT, LUT viz) are progressively decoupled from the `PostProcess` God Object via an `EffectContext` seam:
+
+- **`EffectContext`** (`include/effects/effect_context.h`): Read-only snapshot of shared pipeline state (source texture, viewport dimensions, depth/velocity textures, exposure).
+- Effects receive `(FX*, Params*, const EffectContext*)` instead of `PostProcess*`.
+- This eliminates the bidirectional dependency: `postprocess.h` → `fx_*.h` (for struct embedding) remains, but `fx_*.c` → `postprocess.h` is removed.
+- Currently migrated: **bloom**. Remaining effects will follow the same pattern.
+
 ## Build System
 
 The `CMakeLists.txt` has been updated to include the new source files. The `app` executable and `test_app` integration test both link against the new modular structure.

--- a/docs/bloom_debug.fr.md
+++ b/docs/bloom_debug.fr.md
@@ -29,6 +29,14 @@ Lors de l'activation du mode de débogage, la **Superposition d'informations pri
 - Le niveau de mip actif
 - Les paramètres courants (seuil, intensité)
 
+## Architecture
+
+Depuis l'introduction du seam `EffectContext`, le module bloom est découplé de `PostProcess` :
+
+- `postprocess.c` construit un `EffectContext` (texture source, dimensions viewport) et appelle `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)`
+- `fx_bloom.c` n'inclut plus `postprocess.h` — il reçoit uniquement ce dont il a besoin via `EffectContext` + `BloomParams`
+- Le debug mode fonctionne de manière identique : `debug_step` et `debug_mip` sont des champs de `BloomFX`
+
 ## Voir aussi
 
 - [exposure_analysis.md](./exposure_analysis.md) — Interaction entre exposition et bloom

--- a/docs/bloom_debug.md
+++ b/docs/bloom_debug.md
@@ -23,9 +23,12 @@ The Bloom effect is constructed through multiple stages (Prefilter, Downsample c
 
 When `POSTFX_BLOOM_DEBUG` is active in the `active_effects` bitmask:
 
-1. `fx_bloom_render` executes only up to the requested `debug_step`.
-2. The pipeline uses `goto end_bloom` to bypass unnecessary work.
-3. The `postprocess.frag` shader detects the debug flag and outputs the sampled `bloomTexture` directly, bypassing other effects (Film Grain, Vignette, etc.) for a clean visualization.
+1. `postprocess.c` builds an `EffectContext` (source texture, viewport dimensions) and calls `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)`.
+2. `fx_bloom_render` executes only up to the requested `debug_step`.
+3. The pipeline uses `goto end_bloom` to bypass unnecessary work.
+4. The `postprocess.frag` shader detects the debug flag and outputs the sampled `bloomTexture` directly, bypassing other effects (Film Grain, Vignette, etc.) for a clean visualization.
+
+> **Note**: Since the EffectContext decoupling, `fx_bloom.c` no longer includes `postprocess.h`. Bloom receives only what it needs via `EffectContext` + `BloomParams`.
 
 ### UI Integration
 

--- a/include/effects/effect_context.h
+++ b/include/effects/effect_context.h
@@ -1,0 +1,29 @@
+/**
+ * @file effect_context.h
+ * @brief Shared context passed to post-processing effects.
+ *
+ * EffectContext is the seam between the PostProcess infrastructure
+ * (FBOs, textures, timing) and individual effect modules.  Effects
+ * receive only what they need — no back-pointer to the full pipeline.
+ */
+
+#ifndef EFFECT_CONTEXT_H
+#define EFFECT_CONTEXT_H
+
+#include "gl_common.h"
+
+/**
+ * @struct EffectContext
+ * @brief Read-only snapshot of pipeline state for a single frame.
+ */
+typedef struct EffectContext {
+	GLuint src_tex;      /**< Input color texture (scene HDR). */
+	int width;           /**< Current viewport width. */
+	int height;          /**< Current viewport height. */
+	float delta_time;    /**< Frame delta (seconds). */
+	GLuint depth_tex;    /**< Scene depth texture. */
+	GLuint velocity_tex; /**< Motion vector texture. */
+	float exposure;      /**< Current exposure value. */
+} EffectContext;
+
+#endif /* EFFECT_CONTEXT_H */

--- a/include/effects/fx_bloom.h
+++ b/include/effects/fx_bloom.h
@@ -4,8 +4,8 @@
 #include "gl_common.h"
 #include "shader.h"
 
-/* Forward declaration */
-struct PostProcess;
+/* Forward declarations */
+struct EffectContext;
 
 enum { BLOOM_MIP_LEVELS = 5 };
 
@@ -36,19 +36,20 @@ typedef struct {
 } BloomFX;
 
 /* Initialisation des ressources Bloom */
-int fx_bloom_init(struct PostProcess* post_processing);
+int fx_bloom_init(BloomFX* bloom, int width, int height);
 
 /* Libération des ressources */
-void fx_bloom_cleanup(struct PostProcess* post_processing);
+void fx_bloom_cleanup(BloomFX* bloom);
 
 /* Rendu de l'effet */
-void fx_bloom_render(struct PostProcess* post_processing);
+void fx_bloom_render(BloomFX* bloom, const BloomParams* params,
+                     const struct EffectContext* ctx);
 
 /* Upload des paramètres vers le shader principal */
 void fx_bloom_upload_params(Shader* shader, const BloomParams* params);
 
-/* Getters for shared shaders */
-Shader* fx_bloom_get_downsample_shader(struct PostProcess* post_processing);
-Shader* fx_bloom_get_upsample_shader(struct PostProcess* post_processing);
+/* Getters for shared shaders (used by DoF) */
+Shader* fx_bloom_get_downsample_shader(BloomFX* bloom);
+Shader* fx_bloom_get_upsample_shader(BloomFX* bloom);
 
 #endif /* FX_BLOOM_H */

--- a/src/effects/fx_bloom.c
+++ b/src/effects/fx_bloom.c
@@ -1,19 +1,17 @@
 #include "effects/fx_bloom.h"
 
+#include "effects/effect_context.h"
 #include "effects/fx_utils.h"
 #include "gl_common.h"
 #include "log.h"
-#include "postprocess.h"
 #include "shader.h"
 #include <cglm/types.h>
 #include <stddef.h>
 
-int fx_bloom_init(PostProcess* post_processing)
+int fx_bloom_init(BloomFX* bloom, int width, int height)
 {
 	/* Ensure Unit 0 is active for initial texture setup */
 	glActiveTexture(GL_TEXTURE0);
-
-	BloomFX* bloom = &post_processing->bloom_fx;
 
 	/* Load Shaders */
 	bloom->prefilter_shader = shader_load("shaders/postprocess.vert",
@@ -27,7 +25,7 @@ int fx_bloom_init(PostProcess* post_processing)
 	    !bloom->upsample_shader) {
 		LOG_ERROR("suckless-ogl.postprocess.bloom",
 		          "Failed to load bloom shaders");
-		fx_bloom_cleanup(post_processing);
+		fx_bloom_cleanup(bloom);
 		return 0;
 	}
 
@@ -43,25 +41,25 @@ int fx_bloom_init(PostProcess* post_processing)
 	glGenFramebuffers(1, &bloom->fbo);
 	glBindFramebuffer(GL_FRAMEBUFFER, bloom->fbo);
 
-	int width = post_processing->width;
-	int height = post_processing->height;
+	int mip_w = width;
+	int mip_h = height;
 
 	for (int i = 0; i < BLOOM_MIP_LEVELS; i++) {
-		width /= 2;
-		height /= 2;
-		if (width < 1) {
-			width = 1;
+		mip_w /= 2;
+		mip_h /= 2;
+		if (mip_w < 1) {
+			mip_w = 1;
 		}
-		if (height < 1) {
-			height = 1;
+		if (mip_h < 1) {
+			mip_h = 1;
 		}
 
-		bloom->mips[i].width = width;
-		bloom->mips[i].height = height;
+		bloom->mips[i].width = mip_w;
+		bloom->mips[i].height = mip_h;
 
 		FXTextureConfig tex_config = {
-		    .width = width,
-		    .height = height,
+		    .width = mip_w,
+		    .height = mip_h,
 		    .internal_format = GL_R11F_G11F_B10F,
 		    .format = GL_RGB,
 		    .type = GL_FLOAT,
@@ -77,10 +75,8 @@ int fx_bloom_init(PostProcess* post_processing)
 	return 1;
 }
 
-void fx_bloom_cleanup(PostProcess* post_processing)
+void fx_bloom_cleanup(BloomFX* bloom)
 {
-	BloomFX* bloom = &post_processing->bloom_fx;
-
 	if (bloom->fbo) {
 		glDeleteFramebuffers(1, &bloom->fbo);
 		bloom->fbo = 0;
@@ -98,25 +94,21 @@ void fx_bloom_cleanup(PostProcess* post_processing)
 	SHADER_SAFE_DESTROY(bloom->upsample_shader);
 }
 
-void fx_bloom_render(PostProcess* post_processing)
+void fx_bloom_render(BloomFX* bloom, const BloomParams* params,
+                     const EffectContext* ctx)
 {
-	if (!postprocess_is_enabled(post_processing, POSTFX_BLOOM)) {
-		return;
-	}
-
-	BloomFX* bloom = &post_processing->bloom_fx;
 	glBindFramebuffer(GL_FRAMEBUFFER, bloom->fbo);
 	glDisable(GL_DEPTH_TEST);
 
 	/* 1. Prefilter */
 	shader_use(bloom->prefilter_shader);
 	shader_set_float(bloom->prefilter_shader, "threshold",
-	                 post_processing->bloom.threshold);
+	                 params->threshold);
 	shader_set_float(bloom->prefilter_shader, "knee",
-	                 post_processing->bloom.soft_threshold);
+	                 params->soft_threshold);
 
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, post_processing->scene_color_tex);
+	glBindTexture(GL_TEXTURE_2D, ctx->src_tex);
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
 	                       GL_TEXTURE_2D, bloom->mips[0].texture, 0);
@@ -124,7 +116,7 @@ void fx_bloom_render(PostProcess* post_processing)
 
 	glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
 
-	if (post_processing->bloom_fx.debug_step == 1) { /* Prefilter only */
+	if (bloom->debug_step == 1) { /* Prefilter only */
 		goto end_bloom;
 	}
 
@@ -153,14 +145,14 @@ void fx_bloom_render(PostProcess* post_processing)
 		glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
 	}
 
-	if (post_processing->bloom_fx.debug_step == 2) { /* Downsample only */
+	if (bloom->debug_step == 2) { /* Downsample only */
 		goto end_bloom;
 	}
 
 	/* 3. Upsample with Blending */
 	shader_use(bloom->upsample_shader);
 	shader_set_float(bloom->upsample_shader, "filterRadius",
-	                 post_processing->bloom.radius);
+	                 params->radius);
 	vec2 neutralScale = {1.0F, 1.0F};
 	shader_set_vec2(bloom->upsample_shader, "texelScale",
 	                (float*)&neutralScale);
@@ -187,7 +179,7 @@ void fx_bloom_render(PostProcess* post_processing)
 
 end_bloom:
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glViewport(0, 0, post_processing->width, post_processing->height);
+	glViewport(0, 0, ctx->width, ctx->height);
 }
 
 void fx_bloom_upload_params(Shader* shader, const BloomParams* params)
@@ -195,12 +187,12 @@ void fx_bloom_upload_params(Shader* shader, const BloomParams* params)
 	shader_set_float(shader, "bloom.intensity", params->intensity);
 }
 
-Shader* fx_bloom_get_downsample_shader(PostProcess* post_processing)
+Shader* fx_bloom_get_downsample_shader(BloomFX* bloom)
 {
-	return post_processing->bloom_fx.downsample_shader;
+	return bloom->downsample_shader;
 }
 
-Shader* fx_bloom_get_upsample_shader(PostProcess* post_processing)
+Shader* fx_bloom_get_upsample_shader(BloomFX* bloom)
 {
-	return post_processing->bloom_fx.upsample_shader;
+	return bloom->upsample_shader;
 }

--- a/src/effects/fx_dof.c
+++ b/src/effects/fx_dof.c
@@ -118,7 +118,8 @@ void fx_dof_render(PostProcess* post_processing)
 	float ratio = post_processing->dof.anamorphic_ratio;
 	vec2 texel_scale = {1.0F, ratio};
 
-	Shader* ds_shader = fx_bloom_get_downsample_shader(post_processing);
+	Shader* ds_shader =
+	    fx_bloom_get_downsample_shader(&post_processing->bloom_fx);
 	shader_use(ds_shader);
 
 	glActiveTexture(GL_TEXTURE0);
@@ -135,7 +136,8 @@ void fx_dof_render(PostProcess* post_processing)
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
 	                       GL_TEXTURE_2D, dof->blur_tex, 0);
 
-	Shader* us_shader = fx_bloom_get_upsample_shader(post_processing);
+	Shader* us_shader =
+	    fx_bloom_get_upsample_shader(&post_processing->bloom_fx);
 	shader_use(us_shader);
 
 	glActiveTexture(GL_TEXTURE0);

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -1,6 +1,7 @@
 #include "postprocess.h"
 
 #include "app_settings.h"
+#include "effects/effect_context.h"
 #include "effects/fx_auto_exposure.h"
 #include "effects/fx_bloom.h"
 #include "effects/fx_dof.h"
@@ -181,7 +182,8 @@ int postprocess_init(PostProcess* post_processing,
 	}
 
 	/* Créer les ressources Bloom */
-	if (!fx_bloom_init(post_processing)) {
+	if (!fx_bloom_init(&post_processing->bloom_fx, post_processing->width,
+	                   post_processing->height)) {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create bloom resources");
 		destroy_framebuffer(post_processing);
@@ -195,7 +197,7 @@ int postprocess_init(PostProcess* post_processing,
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create screen quad");
 		destroy_framebuffer(post_processing);
-		fx_bloom_cleanup(post_processing);
+		fx_bloom_cleanup(&post_processing->bloom_fx);
 		return 0;
 	}
 
@@ -215,7 +217,7 @@ int postprocess_init(PostProcess* post_processing,
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create auto exposure resources");
 		destroy_framebuffer(post_processing);
-		fx_bloom_cleanup(post_processing);
+		fx_bloom_cleanup(&post_processing->bloom_fx);
 		fx_dof_cleanup(post_processing);
 		destroy_screen_quad(post_processing);
 		return 0;
@@ -226,7 +228,7 @@ int postprocess_init(PostProcess* post_processing,
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create dof resources");
 		destroy_framebuffer(post_processing);
-		fx_bloom_cleanup(post_processing);
+		fx_bloom_cleanup(&post_processing->bloom_fx);
 		destroy_screen_quad(post_processing);
 		return 0;
 	}
@@ -345,7 +347,7 @@ void postprocess_cleanup(PostProcess* post_processing)
 	/* Destroy postprocess_shader if it wasn't in the cache */
 	SHADER_SAFE_DESTROY(post_processing->postprocess_shader);
 
-	fx_bloom_cleanup(post_processing);
+	fx_bloom_cleanup(&post_processing->bloom_fx);
 	fx_dof_cleanup(post_processing);
 	fx_auto_exposure_cleanup(post_processing);
 	fx_motion_blur_cleanup(post_processing);
@@ -382,8 +384,9 @@ void postprocess_resize(PostProcess* post_processing, int width, int height)
 		          "Failed to resize framebuffer");
 	}
 
-	fx_bloom_cleanup(post_processing);
-	if (!fx_bloom_init(post_processing)) {
+	fx_bloom_cleanup(&post_processing->bloom_fx);
+	if (!fx_bloom_init(&post_processing->bloom_fx, post_processing->width,
+	                   post_processing->height)) {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to resize bloom resources");
 	}
@@ -709,7 +712,13 @@ void postprocess_end(PostProcess* post_processing)
 		GPU_STAGE_PROFILER(post_processing->gpu_profiler, "Bloom",
 		                   GPU_PROFILER_BLOOM_COLOR);
 		gl_debug_push_group("PostFX_Bloom");
-		fx_bloom_render(post_processing);
+		const EffectContext bloom_ctx = {
+		    .src_tex = post_processing->scene_color_tex,
+		    .width = post_processing->width,
+		    .height = post_processing->height,
+		};
+		fx_bloom_render(&post_processing->bloom_fx,
+		                &post_processing->bloom, &bloom_ctx);
 		gl_debug_pop_group();
 	}
 


### PR DESCRIPTION
## Summary

Decouple `fx_bloom` from `PostProcess` by introducing an `EffectContext` struct — the seam between post-processing infrastructure and individual effects.

## Changes

- **New `include/effects/effect_context.h`**: `EffectContext` struct (`src_tex`, `width`, `height`, `delta_time`, `depth_tex`, `velocity_tex`, `exposure`)
- **`include/effects/fx_bloom.h`**: All functions take `BloomFX*` instead of `PostProcess*`. `fx_bloom_render` receives `BloomParams*` + `EffectContext*`
- **`src/effects/fx_bloom.c`**: `#include "postprocess.h"` removed — replaced by `effect_context.h`. All access via `bloom->`, `params->`, `ctx->`
- **`src/postprocess.c`**: Constructs `EffectContext bloom_ctx` before calling `fx_bloom_render()`. All init/cleanup pass `&post_processing->bloom_fx`
- **`src/effects/fx_dof.c`**: Updated `fx_bloom_get_*_shader(&post_processing->bloom_fx)` calls

## Acceptance Criteria (from #202)

- [x] `EffectContext` struct defined in `include/effects/effect_context.h`
- [x] Bloom uses `EffectContext` instead of `PostProcess*`
- [x] `fx_bloom.c` no longer includes `postprocess.h`
- [x] `just format && just lint && just test-all` passes (63/63)
- [x] ASAN clean (63/63)
- [x] No visual regression (user validated)

Closes #202