### PR TITLE
refactor(scene): extract SceneVisuals sub-struct (Phase 1 of #201)

### DIFF
--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -60,6 +60,15 @@ App
     └── EffectContext  (seam vers les effets individuels)
 ```
 
+### Décomposition de Scene (SceneVisuals)
+
+La structure `Scene` est progressivement décomposée en sous-structs par domaine :
+
+- **`SceneVisuals`** (`include/scene.h`) : regroupe les effets visuels — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Accès via `scene->visuals.skybox`, etc.
+- Les phases suivantes extrairont `SceneSimulation` (N-body, tri) et `SceneLighting` (IBL, probes, matériaux).
+
+Cela réduit le nombre de champs directs de `Scene` et localise les changements d'effets visuels.
+
 ### Découplage des effets (EffectContext)
 
 Les effets de post-traitement (bloom, DoF, auto-exposition, flou de mouvement, LUT, LUT viz) sont progressivement découplés de l'objet God `PostProcess` via un seam `EffectContext` :

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,15 @@ To avoid cyclic dependencies:
 - Module headers are included at the **end** of `app.h` to ensure they can see the full `App` definition if necessary (though they primarily use pointers).
 - Specialized source files (`.c`) include `app.h` and the required renderer headers directly.
 
+### Scene Decomposition (SceneVisuals)
+
+The `Scene` struct is being decomposed into domain-aligned sub-structs:
+
+- **`SceneVisuals`** (`include/scene.h`): Groups visual effects — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Access via `scene->visuals.skybox`, etc.
+- Future phases will extract `SceneSimulation` (N-body, sorting) and `SceneLighting` (IBL, probes, materials).
+
+This reduces `Scene`'s direct field count and localizes visual-effect changes.
+
 ### Effect Decoupling (EffectContext)
 
 Post-processing effects (bloom, DoF, auto-exposure, motion blur, LUT, LUT viz) are progressively decoupled from the `PostProcess` God Object via an `EffectContext` seam:

--- a/include/scene.h
+++ b/include/scene.h
@@ -135,6 +135,16 @@ typedef struct {
 } BillboardUniforms;
 
 /**
+ * @struct SceneVisuals
+ * @brief Visual effects grouped into a sub-struct to reduce Scene fan-out.
+ */
+typedef struct SceneVisuals {
+	Skybox skybox;                        /**< Environment renderer. */
+	TrailRenderer trail_renderer;         /**< Orbital trail renderer. */
+	ShockwaveRenderer shockwave_renderer; /**< Confinement impact VFX. */
+} SceneVisuals;
+
+/**
  * @struct Scene
  * @brief Encapsulates all 3D scene data, geometry, and rendering state.
  */
@@ -155,7 +165,7 @@ typedef struct Scene {
 	int billboard_instance_count; /**< Active billboard count. */
 #endif
 
-	Skybox skybox; /**< Environment renderer (Shaders owned by Scene). */
+	SceneVisuals visuals;      /**< Visual effects sub-system. */
 	MaterialLib* material_lib; /**< Loaded material presets. */
 	char** hdr_files;          /**< List of found HDR files in assets. */
 	int hdr_count;             /**< Number of available environment maps. */
@@ -221,10 +231,8 @@ typedef struct Scene {
 	AAMode aa_mode;           /**< AA Mode: Screen-space or Curvature. */
 
 	/* --- N-Body Simulation --- */
-	NBodySim nbody_sim;           /**< N-body gravitational simulation. */
-	TrailRenderer trail_renderer; /**< Orbital trail renderer. */
-	ShockwaveRenderer shockwave_renderer; /**< Confinement impact VFX. */
-	int nbody_mode;                       /**< Toggle: 0=grid, 1=N-body. */
+	NBodySim nbody_sim; /**< N-body gravitational simulation. */
+	int nbody_mode;     /**< Toggle: 0=grid, 1=N-body. */
 
 	/* --- Uniform Caches --- */
 	BillboardUniforms billboard_uniforms; /**< Cached locations. */

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -615,7 +615,7 @@ static const char* const NEON_PARAM_NAMES[] = {"Intensity", "Core", "Width"};
 
 static void handle_neon_cycle(AppInputContext* ctx)
 {
-	TrailNeonParams* neon = &ctx->scene->trail_renderer.neon;
+	TrailNeonParams* neon = &ctx->scene->visuals.trail_renderer.neon;
 	neon->active = (neon->active + 1) % TRAIL_NEON_PARAM_COUNT;
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "Neon: %s selected",
@@ -625,7 +625,7 @@ static void handle_neon_cycle(AppInputContext* ctx)
 
 static void handle_neon_adjust(AppInputContext* ctx, int increase)
 {
-	TrailNeonParams* neon = &ctx->scene->trail_renderer.neon;
+	TrailNeonParams* neon = &ctx->scene->visuals.trail_renderer.neon;
 	float sign = (increase != 0) ? 1.0F : -1.0F;
 	const char* name = NEON_PARAM_NAMES[neon->active];
 	float val = 0.0F;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -46,7 +46,7 @@ void renderer_draw_frame(const RenderContext* ctx)
 
 	/* Provide scene FBO color handle so the shockwave grab pass can use
 	 * glCopyImageSubData (texture-to-texture DMA, no framebuffer read). */
-	ctx->scene->shockwave_renderer.scene_color_tex =
+	ctx->scene->visuals.shockwave_renderer.scene_color_tex =
 	    ctx->postprocess->scene_color_tex;
 
 	{

--- a/src/scene.c
+++ b/src/scene.c
@@ -425,7 +425,7 @@ int scene_init(Scene* scene)
 	render_utils_create_quad_vbo(&scene->quad_vbo);
 	render_utils_create_wire_cube_vbo(&scene->wire_cube_vbo);
 	render_utils_create_wire_quad_vbo(&scene->wire_quad_vbo);
-	skybox_init(&scene->skybox, scene->skybox_shader);
+	skybox_init(&scene->visuals.skybox, scene->skybox_shader);
 	icosphere_init(&scene->geometry);
 
 	glGenVertexArrays(1, &scene->icosphere_vao);
@@ -540,7 +540,7 @@ void scene_cleanup(Scene* scene)
 	}
 
 	icosphere_free(&scene->geometry);
-	skybox_cleanup(&scene->skybox);
+	skybox_cleanup(&scene->visuals.skybox);
 #ifdef USE_TRANSPARENT_BILLBOARDS
 	if (scene->billboard_instances) {
 		platform_aligned_free(scene->billboard_instances);
@@ -550,8 +550,8 @@ void scene_cleanup(Scene* scene)
 #endif
 	instanced_group_cleanup(&scene->instanced_group);
 	billboard_group_cleanup(&scene->billboard_group);
-	trail_renderer_cleanup(&scene->trail_renderer);
-	shockwave_renderer_cleanup(&scene->shockwave_renderer);
+	trail_renderer_cleanup(&scene->visuals.trail_renderer);
+	shockwave_renderer_cleanup(&scene->visuals.shockwave_renderer);
 #ifdef USE_SSBO_RENDERING
 	ssbo_group_cleanup(&scene->ssbo_group);
 #endif
@@ -858,7 +858,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 		gl_debug_push_group("Skybox_Pass");
 		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 		glDisable(GL_DEPTH_TEST);
-		skybox_render(&scene->skybox, scene->skybox_shader,
+		skybox_render(&scene->visuals.skybox, scene->skybox_shader,
 		              scene->hdr_texture, scene->dummy_black_tex,
 		              inv_view_proj, scene->env_lod);
 		glEnable(GL_DEPTH_TEST);
@@ -1019,7 +1019,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 		GPU_STAGE_PROFILER(profiler, "NBody Trails",
 		                   GPU_PROFILER_NBODY_COLOR);
 		gl_debug_push_group("NBody_Trails");
-		trail_renderer_draw(&scene->trail_renderer, view, proj,
+		trail_renderer_draw(&scene->visuals.trail_renderer, view, proj,
 		                    camera_pos);
 		gl_debug_pop_group();
 
@@ -1032,9 +1032,10 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			if (scene->wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 			}
-			shockwave_draw(&scene->shockwave_renderer, view, proj,
-			               camera_pos, scene->nbody_sim.sim_time,
-			               width, height);
+			shockwave_draw(&scene->visuals.shockwave_renderer, view,
+			               proj, camera_pos,
+			               scene->nbody_sim.sim_time, width,
+			               height);
 			if (scene->wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 			}
@@ -1060,13 +1061,15 @@ void scene_toggle_nbody(Scene* scene)
 		nbody_init_preset(&scene->nbody_sim);
 
 		int count = nbody_get_count(&scene->nbody_sim);
-		if (!trail_renderer_init(&scene->trail_renderer, count)) {
+		if (!trail_renderer_init(&scene->visuals.trail_renderer,
+		                         count)) {
 			scene->nbody_mode = 0;
 			return;
 		}
 
-		if (!shockwave_renderer_init(&scene->shockwave_renderer)) {
-			trail_renderer_cleanup(&scene->trail_renderer);
+		if (!shockwave_renderer_init(
+		        &scene->visuals.shockwave_renderer)) {
+			trail_renderer_cleanup(&scene->visuals.trail_renderer);
 			scene->nbody_mode = 0;
 			return;
 		}
@@ -1074,7 +1077,7 @@ void scene_toggle_nbody(Scene* scene)
 		/* Set trail colors from body albedos (HDR-scaled) */
 		for (int i = 0; i < count; i++) {
 			trail_renderer_set_color(
-			    &scene->trail_renderer, i,
+			    &scene->visuals.trail_renderer, i,
 			    scene->nbody_sim.bodies[i].albedo);
 		}
 
@@ -1097,8 +1100,8 @@ void scene_toggle_nbody(Scene* scene)
 	} else {
 		/* Restore original material grid — clean up before re-init
 		 * to avoid leaking GPU buffers and CPU allocations */
-		trail_renderer_cleanup(&scene->trail_renderer);
-		shockwave_renderer_cleanup(&scene->shockwave_renderer);
+		trail_renderer_cleanup(&scene->visuals.trail_renderer);
+		shockwave_renderer_cleanup(&scene->visuals.shockwave_renderer);
 #ifdef USE_TRANSPARENT_BILLBOARDS
 		if (scene->billboard_instances) {
 			platform_aligned_free(scene->billboard_instances);
@@ -1132,18 +1135,19 @@ void scene_nbody_update(Scene* scene, float delta_time)
 	for (int i = 1; i < scene->nbody_sim.body_count; i++) {
 		const NBodyImpact* imp = &scene->nbody_sim.impacts[i];
 		if (imp->active) {
-			shockwave_emit(&scene->shockwave_renderer,
+			shockwave_emit(&scene->visuals.shockwave_renderer,
 			               imp->position, imp->color, imp->velocity,
 			               scene->nbody_sim.sim_time);
 		}
 	}
-	shockwave_update(&scene->shockwave_renderer, scene->nbody_sim.sim_time);
+	shockwave_update(&scene->visuals.shockwave_renderer,
+	                 scene->nbody_sim.sim_time);
 
 	/* Record trail positions into ring buffers */
 	{
 		PROFILE_ZONE(trail_ctx, "NBody Trail Sample");
-		trail_renderer_record(&scene->trail_renderer, &scene->nbody_sim,
-		                      delta_time);
+		trail_renderer_record(&scene->visuals.trail_renderer,
+		                      &scene->nbody_sim, delta_time);
 		PROFILE_ZONE_END(trail_ctx);
 	}
 


### PR DESCRIPTION
## Summary

Phase 1 of #201: extract `SceneVisuals` sub-struct from the `Scene` God Object.

### Changes

- **`include/scene.h`**: New `SceneVisuals` struct grouping `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. `Scene` now holds `SceneVisuals visuals` instead of 3 separate fields.
- **`src/scene.c`**, **`src/app_input.c`**, **`src/renderer.c`**: All access sites updated (`scene->skybox` → `scene->visuals.skybox`, etc.)
- **`docs/architecture.md`** + **`docs/architecture.fr.md`**: Document SceneVisuals decomposition pattern.

### Acceptance Criteria (Phase 1)

- [x] SceneVisuals groups skybox + trail_renderer + shockwave_renderer
- [x] Zero behavioral change (pure refactor)
- [x] `just format && just lint && just test-all` passes (63/63 tests)
- [x] Documentation updated (EN + FR)

Partial fix for #201 — Phases 2 (SceneSimulation) and 3 (SceneLighting) will follow.