### PR TITLE
refactor(scene): extract SceneSimulation sub-struct (Phase 2 of #201)

### DIFF
--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -60,14 +60,15 @@ App
     └── EffectContext  (seam vers les effets individuels)
 ```
 
-### Décomposition de Scene (SceneVisuals)
+### Décomposition de Scene (SceneVisuals, SceneSimulation)
 
 La structure `Scene` est progressivement décomposée en sous-structs par domaine :
 
 - **`SceneVisuals`** (`include/scene.h`) : regroupe les effets visuels — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Accès via `scene->visuals.skybox`, etc.
-- Les phases suivantes extrairont `SceneSimulation` (N-body, tri) et `SceneLighting` (IBL, probes, matériaux).
+- **`SceneSimulation`** (`include/scene.h`) : regroupe l'état N-body — `NBodySim`, `nbody_mode`. Accès via `scene->simulation.nbody_sim`, etc.
+- La phase suivante extraira `SceneLighting` (IBL, probes, matériaux).
 
-Cela réduit le nombre de champs directs de `Scene` et localise les changements d'effets visuels.
+Cela réduit le nombre de champs directs de `Scene` et localise les changements par domaine.
 
 ### Découplage des effets (EffectContext)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,14 +100,15 @@ To avoid cyclic dependencies:
 - Module headers are included at the **end** of `app.h` to ensure they can see the full `App` definition if necessary (though they primarily use pointers).
 - Specialized source files (`.c`) include `app.h` and the required renderer headers directly.
 
-### Scene Decomposition (SceneVisuals)
+### Scene Decomposition (SceneVisuals, SceneSimulation)
 
 The `Scene` struct is being decomposed into domain-aligned sub-structs:
 
 - **`SceneVisuals`** (`include/scene.h`): Groups visual effects — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Access via `scene->visuals.skybox`, etc.
-- Future phases will extract `SceneSimulation` (N-body, sorting) and `SceneLighting` (IBL, probes, materials).
+- **`SceneSimulation`** (`include/scene.h`): Groups N-body state — `NBodySim`, `nbody_mode`. Access via `scene->simulation.nbody_sim`, etc.
+- Future phase will extract `SceneLighting` (IBL, probes, materials).
 
-This reduces `Scene`'s direct field count and localizes visual-effect changes.
+This reduces `Scene`'s direct field count and localizes domain-specific changes.
 
 ### Effect Decoupling (EffectContext)
 

--- a/include/scene.h
+++ b/include/scene.h
@@ -145,6 +145,15 @@ typedef struct SceneVisuals {
 } SceneVisuals;
 
 /**
+ * @struct SceneSimulation
+ * @brief N-body simulation state grouped to reduce Scene fan-out.
+ */
+typedef struct SceneSimulation {
+	NBodySim nbody_sim; /**< N-body gravitational simulation. */
+	int nbody_mode;     /**< Toggle: 0=grid, 1=N-body. */
+} SceneSimulation;
+
+/**
  * @struct Scene
  * @brief Encapsulates all 3D scene data, geometry, and rendering state.
  */
@@ -231,8 +240,7 @@ typedef struct Scene {
 	AAMode aa_mode;           /**< AA Mode: Screen-space or Curvature. */
 
 	/* --- N-Body Simulation --- */
-	NBodySim nbody_sim; /**< N-body gravitational simulation. */
-	int nbody_mode;     /**< Toggle: 0=grid, 1=N-body. */
+	SceneSimulation simulation; /**< N-body simulation sub-system. */
 
 	/* --- Uniform Caches --- */
 	BillboardUniforms billboard_uniforms; /**< Cached locations. */

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -493,7 +493,7 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 	const int ctrl_shift =
 	    (int)((unsigned)GLFW_MOD_SHIFT | (unsigned)GLFW_MOD_CONTROL);
 	if (((unsigned)mods & (unsigned)ctrl_shift) == (unsigned)ctrl_shift) {
-		NBodySim* sim = &ctx->scene->nbody_sim;
+		NBodySim* sim = &ctx->scene->simulation.nbody_sim;
 		sim->target_time_scale = -sim->target_time_scale;
 		const char* dir =
 		    (sim->target_time_scale < 0.0F) ? "REVERSE" : "FORWARD";
@@ -510,17 +510,18 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 	}
 	scene_toggle_nbody(ctx->scene);
 	LOG_INFO("suckless-ogl.app", "N-Body mode: %s",
-	         ctx->scene->nbody_mode ? "ON" : "OFF");
+	         ctx->scene->simulation.nbody_mode ? "ON" : "OFF");
 	action_notifier_push(ctx->notifier,
-	                     ctx->scene->nbody_mode ? "N-Body Gravity: ON"
-	                                            : "N-Body Gravity: OFF",
+	                     ctx->scene->simulation.nbody_mode
+	                         ? "N-Body Gravity: ON"
+	                         : "N-Body Gravity: OFF",
 	                     NOTIF_DUR_LONG);
 	return true;
 }
 
 static void handle_sim_speed_input(AppInputContext* ctx, bool speed_up)
 {
-	NBodySim* sim = &ctx->scene->nbody_sim;
+	NBodySim* sim = &ctx->scene->simulation.nbody_sim;
 	float mag = fabsf(sim->target_time_scale);
 	float sign = (sim->target_time_scale < 0.0F) ? -1.0F : 1.0F;
 	if (speed_up) {
@@ -543,7 +544,7 @@ static void handle_sim_speed_input(AppInputContext* ctx, bool speed_up)
 
 static void handle_gravity_input(AppInputContext* ctx, bool increase)
 {
-	NBodySim* sim = &ctx->scene->nbody_sim;
+	NBodySim* sim = &ctx->scene->simulation.nbody_sim;
 	if (increase) {
 		if (sim->gravity == 0.0F) {
 			sim->gravity = GRAVITY_MIN_POSITIVE;

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -1175,11 +1175,12 @@ static void draw_exposure_overlay(const App* app, UILayout* layout)
 
 static void draw_nbody_overlay(const App* app, UILayout* layout)
 {
-	if (app->overlay.text_overlay_mode < 1 || !app->scene.nbody_mode) {
+	if (app->overlay.text_overlay_mode < 1 ||
+	    !app->scene.simulation.nbody_mode) {
 		return;
 	}
 
-	const NBodySim* sim = &app->scene.nbody_sim;
+	const NBodySim* sim = &app->scene.simulation.nbody_sim;
 	char text[NBODY_TEXT_BUFFER_SIZE];
 
 	/* Kinetic energy + time direction */

--- a/src/scene.c
+++ b/src/scene.c
@@ -1015,7 +1015,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 	/* --- N-Body orbital trails (rendered after spheres, into HDR FBO) ---
 	 */
-	if (scene->nbody_mode) {
+	if (scene->simulation.nbody_mode) {
 		GPU_STAGE_PROFILER(profiler, "NBody Trails",
 		                   GPU_PROFILER_NBODY_COLOR);
 		gl_debug_push_group("NBody_Trails");
@@ -1034,8 +1034,8 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			}
 			shockwave_draw(&scene->visuals.shockwave_renderer, view,
 			               proj, camera_pos,
-			               scene->nbody_sim.sim_time, width,
-			               height);
+			               scene->simulation.nbody_sim.sim_time,
+			               width, height);
 			if (scene->wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 			}
@@ -1054,23 +1054,23 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 void scene_toggle_nbody(Scene* scene)
 {
-	scene->nbody_mode = !scene->nbody_mode;
+	scene->simulation.nbody_mode = !scene->simulation.nbody_mode;
 
-	if (scene->nbody_mode) {
+	if (scene->simulation.nbody_mode) {
 		/* Initialize simulation and trails */
-		nbody_init_preset(&scene->nbody_sim);
+		nbody_init_preset(&scene->simulation.nbody_sim);
 
-		int count = nbody_get_count(&scene->nbody_sim);
+		int count = nbody_get_count(&scene->simulation.nbody_sim);
 		if (!trail_renderer_init(&scene->visuals.trail_renderer,
 		                         count)) {
-			scene->nbody_mode = 0;
+			scene->simulation.nbody_mode = 0;
 			return;
 		}
 
 		if (!shockwave_renderer_init(
 		        &scene->visuals.shockwave_renderer)) {
 			trail_renderer_cleanup(&scene->visuals.trail_renderer);
-			scene->nbody_mode = 0;
+			scene->simulation.nbody_mode = 0;
 			return;
 		}
 
@@ -1078,12 +1078,12 @@ void scene_toggle_nbody(Scene* scene)
 		for (int i = 0; i < count; i++) {
 			trail_renderer_set_color(
 			    &scene->visuals.trail_renderer, i,
-			    scene->nbody_sim.bodies[i].albedo);
+			    scene->simulation.nbody_sim.bodies[i].albedo);
 		}
 
 		/* Write initial SphereInstance data and upload to GPU */
 		SphereInstance instances[NBODY_MAX_BODIES];
-		nbody_write_instances(&scene->nbody_sim, instances);
+		nbody_write_instances(&scene->simulation.nbody_sim, instances);
 		instanced_group_update(&scene->instanced_group, instances,
 		                       count);
 
@@ -1117,46 +1117,47 @@ void scene_toggle_nbody(Scene* scene)
 
 void scene_nbody_update(Scene* scene, float delta_time)
 {
-	if (!scene->nbody_mode) {
+	if (!scene->simulation.nbody_mode) {
 		return;
 	}
 
 	/* Smooth time-scale transition (decelerate → pause → reverse) */
-	nbody_update_time_scale(&scene->nbody_sim, delta_time);
+	nbody_update_time_scale(&scene->simulation.nbody_sim, delta_time);
 
 	/* Advance physics (Velocity Verlet, O(N²) gravity) */
 	{
 		PROFILE_ZONE(verlet_ctx, "NBody Verlet");
-		nbody_step(&scene->nbody_sim, delta_time);
+		nbody_step(&scene->simulation.nbody_sim, delta_time);
 		PROFILE_ZONE_END(verlet_ctx);
 	}
 
 	/* Forward confinement impacts to shockwave VFX */
-	for (int i = 1; i < scene->nbody_sim.body_count; i++) {
-		const NBodyImpact* imp = &scene->nbody_sim.impacts[i];
+	for (int i = 1; i < scene->simulation.nbody_sim.body_count; i++) {
+		const NBodyImpact* imp =
+		    &scene->simulation.nbody_sim.impacts[i];
 		if (imp->active) {
 			shockwave_emit(&scene->visuals.shockwave_renderer,
 			               imp->position, imp->color, imp->velocity,
-			               scene->nbody_sim.sim_time);
+			               scene->simulation.nbody_sim.sim_time);
 		}
 	}
 	shockwave_update(&scene->visuals.shockwave_renderer,
-	                 scene->nbody_sim.sim_time);
+	                 scene->simulation.nbody_sim.sim_time);
 
 	/* Record trail positions into ring buffers */
 	{
 		PROFILE_ZONE(trail_ctx, "NBody Trail Sample");
 		trail_renderer_record(&scene->visuals.trail_renderer,
-		                      &scene->nbody_sim, delta_time);
+		                      &scene->simulation.nbody_sim, delta_time);
 		PROFILE_ZONE_END(trail_ctx);
 	}
 
 	/* Build SphereInstance data and upload to GPU */
-	int count = nbody_get_count(&scene->nbody_sim);
+	int count = nbody_get_count(&scene->simulation.nbody_sim);
 	SphereInstance instances[NBODY_MAX_BODIES];
 	{
 		PROFILE_ZONE(inst_ctx, "NBody Instance Build");
-		nbody_write_instances(&scene->nbody_sim, instances);
+		nbody_write_instances(&scene->simulation.nbody_sim, instances);
 		PROFILE_ZONE_END(inst_ctx);
 	}
 	{


### PR DESCRIPTION
## Summary

Phase 2 of #201: extract `SceneSimulation` sub-struct from the `Scene` God Object.

### Changes

- **`include/scene.h`**: New `SceneSimulation` struct grouping `NBodySim` and `nbody_mode`. `Scene` now holds `SceneSimulation simulation` instead of 2 separate fields.
- **`src/scene.c`** (20 sites), **`src/app_input.c`** (5 sites), **`src/app_ui.c`** (2 sites): All access sites updated (`scene->nbody_sim` → `scene->simulation.nbody_sim`, etc.)
- **`docs/architecture.md`** + **`docs/architecture.fr.md`**: Updated Scene Decomposition section to include SceneSimulation.

### Acceptance Criteria (Phase 2)

- [x] SceneSimulation groups nbody_sim + nbody_mode
- [x] Zero behavioral change (pure refactor)
- [x] `just format && just lint && just test-all` passes (63/63 tests)
- [x] Documentation updated (EN + FR)

Partial fix for #201 — Phase 3 (SceneLighting) will follow.