### PR TITLE
refactor(scene): extract SceneLighting sub-struct (Phase 3 of #201)

### DIFF
--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -60,13 +60,13 @@ App
     └── EffectContext  (seam vers les effets individuels)
 ```
 
-### Décomposition de Scene (SceneVisuals, SceneSimulation)
+### Décomposition de Scene (SceneVisuals, SceneSimulation, SceneLighting)
 
 La structure `Scene` est progressivement décomposée en sous-structs par domaine :
 
 - **`SceneVisuals`** (`include/scene.h`) : regroupe les effets visuels — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Accès via `scene->visuals.skybox`, etc.
 - **`SceneSimulation`** (`include/scene.h`) : regroupe l'état N-body — `NBodySim`, `nbody_mode`. Accès via `scene->simulation.nbody_sim`, etc.
-- La phase suivante extraira `SceneLighting` (IBL, probes, matériaux).
+- **`SceneLighting`** (`include/scene.h`) : regroupe IBL, probes et matériaux — `IBLCoordinator`, `LightProbeGrid`, `MaterialLib*`. Accès via `scene->lighting.ibl_coord`, etc.
 
 Cela réduit le nombre de champs directs de `Scene` et localise les changements par domaine.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,13 +100,13 @@ To avoid cyclic dependencies:
 - Module headers are included at the **end** of `app.h` to ensure they can see the full `App` definition if necessary (though they primarily use pointers).
 - Specialized source files (`.c`) include `app.h` and the required renderer headers directly.
 
-### Scene Decomposition (SceneVisuals, SceneSimulation)
+### Scene Decomposition (SceneVisuals, SceneSimulation, SceneLighting)
 
 The `Scene` struct is being decomposed into domain-aligned sub-structs:
 
 - **`SceneVisuals`** (`include/scene.h`): Groups visual effects — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Access via `scene->visuals.skybox`, etc.
 - **`SceneSimulation`** (`include/scene.h`): Groups N-body state — `NBodySim`, `nbody_mode`. Access via `scene->simulation.nbody_sim`, etc.
-- Future phase will extract `SceneLighting` (IBL, probes, materials).
+- **`SceneLighting`** (`include/scene.h`): Groups IBL, probes, and materials — `IBLCoordinator`, `LightProbeGrid`, `MaterialLib*`. Access via `scene->lighting.ibl_coord`, etc.
 
 This reduces `Scene`'s direct field count and localizes domain-specific changes.
 

--- a/include/scene.h
+++ b/include/scene.h
@@ -154,6 +154,16 @@ typedef struct SceneSimulation {
 } SceneSimulation;
 
 /**
+ * @struct SceneLighting
+ * @brief IBL, probes, and materials grouped to reduce Scene fan-out.
+ */
+typedef struct SceneLighting {
+	MaterialLib* material_lib; /**< Loaded material presets. */
+	IBLCoordinator ibl_coord;  /**< IBL state machine. */
+	LightProbeGrid probe_grid; /**< Global Illumination spatial grid. */
+} SceneLighting;
+
+/**
  * @struct Scene
  * @brief Encapsulates all 3D scene data, geometry, and rendering state.
  */
@@ -174,14 +184,11 @@ typedef struct Scene {
 	int billboard_instance_count; /**< Active billboard count. */
 #endif
 
-	SceneVisuals visuals;      /**< Visual effects sub-system. */
-	MaterialLib* material_lib; /**< Loaded material presets. */
-	char** hdr_files;          /**< List of found HDR files in assets. */
-	int hdr_count;             /**< Number of available environment maps. */
-	int current_hdr_index;     /**< Index of active HDR in file list. */
-	IBLCoordinator ibl_coord;  /**< IBL state machine (Compute shaders owned
-	                              by Scene). */
-	LightProbeGrid probe_grid; /**< Global Illumination spatial grid. */
+	SceneVisuals visuals;   /**< Visual effects sub-system. */
+	SceneLighting lighting; /**< IBL, probes, and materials. */
+	char** hdr_files;       /**< List of found HDR files in assets. */
+	int hdr_count;          /**< Number of available environment maps. */
+	int current_hdr_index;  /**< Index of active HDR in file list. */
 
 	/* --- Shaders --- */
 	Shader* pbr_instanced_shader; /**< Shared PBR shader for opaque geo. */

--- a/src/app.c
+++ b/src/app.c
@@ -412,9 +412,9 @@ void app_update(App* app)
 	}
 
 	if (app->env_mgr.env_map_loading_step > 0) {
-		env_manager_process_loading_step(&app->env_mgr,
-		                                 &app->scene.recycled_hdr_tex,
-		                                 &app->scene.ibl_coord);
+		env_manager_process_loading_step(
+		    &app->env_mgr, &app->scene.recycled_hdr_tex,
+		    &app->scene.lighting.ibl_coord);
 	}
 
 	env_manager_update_ibl(&app->env_mgr, &app->scene, &app->postprocess,

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -1234,7 +1234,7 @@ static void draw_nbody_overlay(const App* app, UILayout* layout)
 
 static void draw_loading_indicator(const App* app)
 {
-	if (app->scene.ibl_coord.state == IBL_STATE_IDLE &&
+	if (app->scene.lighting.ibl_coord.state == IBL_STATE_IDLE &&
 	    !app->env_mgr.env_map_loading) {
 		return;
 	}

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -185,8 +185,8 @@ static void handle_ibl_done_wait_state(EnvManager* mgr, Scene* scene,
 	GLuint irr_tex = 0;
 	float threshold = 0.0F;
 
-	if (ibl_coordinator_get_results(&scene->ibl_coord, &hdr_tex, &spec_tex,
-	                                &irr_tex, &threshold)) {
+	if (ibl_coordinator_get_results(&scene->lighting.ibl_coord, &hdr_tex,
+	                                &spec_tex, &irr_tex, &threshold)) {
 		finalize_ibl_swap(scene, postproc, hdr_tex, spec_tex, irr_tex,
 		                  threshold, frame_count);
 		mgr->transition_state = TRANSITION_FADE_IN;
@@ -211,8 +211,8 @@ static void handle_ibl_done_loading_state(EnvManager* mgr, Scene* scene,
 		GLuint irr_tex = 0;
 		float threshold = 0.0F;
 
-		if (ibl_coordinator_get_results(&scene->ibl_coord, &hdr_tex,
-		                                &spec_tex, &irr_tex,
+		if (ibl_coordinator_get_results(&scene->lighting.ibl_coord,
+		                                &hdr_tex, &spec_tex, &irr_tex,
 		                                &threshold)) {
 			capture_snapshot(scene, width, height);
 			finalize_ibl_swap(scene, postproc, hdr_tex, spec_tex,
@@ -227,7 +227,8 @@ void env_manager_update_ibl(EnvManager* mgr, Scene* scene,
                             PostProcess* postproc, uint64_t frame_count,
                             int width, int height)
 {
-	IBLState state = ibl_coordinator_update(&scene->ibl_coord, frame_count);
+	IBLState state =
+	    ibl_coordinator_update(&scene->lighting.ibl_coord, frame_count);
 
 	if (state == IBL_STATE_DONE) {
 		if (mgr->transition_state == TRANSITION_WAIT_IBL) {
@@ -263,9 +264,9 @@ void env_manager_update_transition(EnvManager* mgr, Scene* scene,
 			GLuint spec_tex = 0;
 			GLuint irr_tex = 0;
 			float threshold = 0.0F;
-			if (ibl_coordinator_get_results(&scene->ibl_coord,
-			                                &hdr_tex, &spec_tex,
-			                                &irr_tex, &threshold)) {
+			if (ibl_coordinator_get_results(
+			        &scene->lighting.ibl_coord, &hdr_tex, &spec_tex,
+			        &irr_tex, &threshold)) {
 				finalize_ibl_swap(scene, postproc, hdr_tex,
 				                  spec_tex, irr_tex, threshold,
 				                  frame_count);

--- a/src/scene.c
+++ b/src/scene.c
@@ -90,8 +90,8 @@ static void scene_scan_hdr_files(Scene* scene)
 
 static void scene_init_instancing(Scene* scene)
 {
-	const int total_count =
-	    MIN(scene->material_lib->count, DEFAULT_COLS * DEFAULT_COLS);
+	const int total_count = MIN(scene->lighting.material_lib->count,
+	                            DEFAULT_COLS * DEFAULT_COLS);
 	const int cols = DEFAULT_COLS;
 	const int rows = (total_count + cols - 1) / cols;
 	const float spacing = DEFAULT_SPACING;
@@ -118,7 +118,7 @@ static void scene_init_instancing(Scene* scene)
 		vec3 position = {pos_x, pos_y, 0.0F};
 		// NOLINTNEXTLINE(misc-include-cleaner)
 		glm_translate(data[i].model, position);
-		PBRMaterial* mat = &scene->material_lib->materials[i];
+		PBRMaterial* mat = &scene->lighting.material_lib->materials[i];
 		glm_vec3_copy(mat->albedo, data[i].albedo);
 		data[i].metallic = mat->metallic;
 		data[i].roughness = mat->roughness;
@@ -151,15 +151,15 @@ static void scene_init_instancing(Scene* scene)
 	                        scene->wire_quad_vbo, scene->wire_cube_vbo);
 
 	/* Initialize Light Probe Grid with Scene Data */
-	light_probe_grid_set_scene(&scene->probe_grid, data, total_count,
-	                           sizeof(SphereInstance));
+	light_probe_grid_set_scene(&scene->lighting.probe_grid, data,
+	                           total_count, sizeof(SphereInstance));
 
 	/* Initialize Light Probe Grid Bounding Box with Scene Data */
-	light_probe_grid_compute_aabb(&scene->probe_grid, data, total_count,
-	                              sizeof(SphereInstance),
+	light_probe_grid_compute_aabb(&scene->lighting.probe_grid, data,
+	                              total_count, sizeof(SphereInstance),
 	                              DEFAULT_SPACING * HALF_OFFSET_MULTIPLIER);
 	/* Trigger initial async calculation */
-	light_probe_grid_update_async(&scene->probe_grid);
+	light_probe_grid_update_async(&scene->lighting.probe_grid);
 
 	free(data);
 }
@@ -167,8 +167,8 @@ static void scene_init_instancing(Scene* scene)
 #ifdef USE_SSBO_RENDERING
 static void scene_init_ssbo(Scene* scene)
 {
-	const int total_count =
-	    MIN(scene->material_lib->count, DEFAULT_COLS * DEFAULT_COLS);
+	const int total_count = MIN(scene->lighting.material_lib->count,
+	                            DEFAULT_COLS * DEFAULT_COLS);
 	const int cols = DEFAULT_COLS;
 	const int rows = (total_count + cols - 1) / cols;
 	const float spacing = DEFAULT_SPACING;
@@ -194,7 +194,7 @@ static void scene_init_ssbo(Scene* scene)
 		                      (grid_h * HALF_OFFSET_MULTIPLIER));
 		vec3 position = {pos_x, pos_y, 0.0F};
 		glm_translate(data[i].model, position);
-		PBRMaterial* mat = &scene->material_lib->materials[i];
+		PBRMaterial* mat = &scene->lighting.material_lib->materials[i];
 		glm_vec3_copy(mat->albedo, data[i].albedo);
 		data[i].metallic = mat->metallic;
 		data[i].roughness = mat->roughness;
@@ -208,14 +208,14 @@ static void scene_init_ssbo(Scene* scene)
 	                     scene->icosphere_nbo, scene->icosphere_ebo);
 
 	/* Initialize Light Probe Grid with Scene Data (SSBO Mode) */
-	light_probe_grid_set_scene(&scene->probe_grid, data, total_count,
-	                           sizeof(SphereInstanceSSBO));
+	light_probe_grid_set_scene(&scene->lighting.probe_grid, data,
+	                           total_count, sizeof(SphereInstanceSSBO));
 
 	/* Initialize Light Probe Grid Bounding Box with Scene Data */
-	light_probe_grid_compute_aabb(&scene->probe_grid, data, total_count,
-	                              sizeof(SphereInstanceSSBO),
+	light_probe_grid_compute_aabb(&scene->lighting.probe_grid, data,
+	                              total_count, sizeof(SphereInstanceSSBO),
 	                              DEFAULT_SPACING * HALF_OFFSET_MULTIPLIER);
-	light_probe_grid_update_async(&scene->probe_grid);
+	light_probe_grid_update_async(&scene->lighting.probe_grid);
 
 	free(data);
 }
@@ -337,7 +337,7 @@ static int scene_init_compute_resources(Scene* scene)
 		return 0;
 	}
 
-	ibl_coordinator_init(&scene->ibl_coord, scene->spmap_program,
+	ibl_coordinator_init(&scene->lighting.ibl_coord, scene->spmap_program,
 	                     scene->irmap_program, scene->lum_pass1_program,
 	                     scene->lum_pass2_program);
 	return 1;
@@ -433,7 +433,7 @@ int scene_init(Scene* scene)
 	glGenBuffers(1, &scene->icosphere_nbo);
 	glGenBuffers(1, &scene->icosphere_ebo);
 
-	scene->material_lib =
+	scene->lighting.material_lib =
 	    material_load_presets("assets/materials/pbr_materials.json");
 
 	if (!scene_init_compute_resources(scene)) {
@@ -442,14 +442,14 @@ int scene_init(Scene* scene)
 
 	/* Initialize Probe Grid: dense grid covering the full sphere extent. */
 	{
-		int sphere_count = scene->material_lib->count;
+		int sphere_count = scene->lighting.material_lib->count;
 		if (sphere_count > (DEFAULT_COLS * DEFAULT_COLS)) {
 			sphere_count = DEFAULT_COLS * DEFAULT_COLS;
 		}
 		const int pcols = DEFAULT_COLS;
 		const int prows = (sphere_count + pcols - 1) / pcols;
-		light_probe_grid_init(&scene->probe_grid, (2 * pcols) + 1,
-		                      (2 * prows) + 1, 3);
+		light_probe_grid_init(&scene->lighting.probe_grid,
+		                      (2 * pcols) + 1, (2 * prows) + 1, 3);
 	}
 
 	Shader* inst_shader = NULL;
@@ -556,16 +556,16 @@ void scene_cleanup(Scene* scene)
 	ssbo_group_cleanup(&scene->ssbo_group);
 #endif
 
-	if (scene->material_lib) {
-		material_free_lib(scene->material_lib);
-		scene->material_lib = NULL;
+	if (scene->lighting.material_lib) {
+		material_free_lib(scene->lighting.material_lib);
+		scene->lighting.material_lib = NULL;
 	}
 
 	scene_cleanup_shaders(scene);
 	scene_cleanup_gpu_resources(scene);
 
-	ibl_coordinator_cleanup(&scene->ibl_coord);
-	light_probe_grid_cleanup(&scene->probe_grid);
+	ibl_coordinator_cleanup(&scene->lighting.ibl_coord);
+	light_probe_grid_cleanup(&scene->lighting.probe_grid);
 
 	if (scene->hdr_files) {
 		for (int i = 0; i < scene->hdr_count; i++) {
@@ -622,7 +622,7 @@ void scene_update_gpu_buffers(Scene* scene)
 static void scene_bind_probe_textures(Scene* scene)
 {
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
-		GLuint tex = scene->probe_grid.sh_textures[i];
+		GLuint tex = scene->lighting.probe_grid.sh_textures[i];
 		if (tex != scene->bound_sh_textures[i]) {
 			glActiveTexture(
 			    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_SH_START + i));
@@ -631,10 +631,10 @@ static void scene_bind_probe_textures(Scene* scene)
 		}
 	}
 
-	if (scene->probe_grid.ssbo != scene->bound_probe_ssbo) {
+	if (scene->lighting.probe_grid.ssbo != scene->bound_probe_ssbo) {
 		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3,
-		                 scene->probe_grid.ssbo);
-		scene->bound_probe_ssbo = scene->probe_grid.ssbo;
+		                 scene->lighting.probe_grid.ssbo);
+		scene->bound_probe_ssbo = scene->lighting.probe_grid.ssbo;
 	}
 }
 
@@ -677,13 +677,15 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		ubo.debug_mode = scene->pbr_debug_mode;
 		ubo.screen_size[0] = (float)width;
 		ubo.screen_size[1] = (float)height;
-		glm_vec3_copy(scene->probe_grid.aabb_min, ubo.probe_grid_min);
+		glm_vec3_copy(scene->lighting.probe_grid.aabb_min,
+		              ubo.probe_grid_min);
 		ubo.gi_mode = (int32_t)scene->gi_mode;
-		glm_vec3_copy(scene->probe_grid.aabb_max, ubo.probe_grid_max);
+		glm_vec3_copy(scene->lighting.probe_grid.aabb_max,
+		              ubo.probe_grid_max);
 		ubo.specular_aa_enabled = scene->specular_aa_enabled;
-		ubo.probe_grid_dim[0] = scene->probe_grid.grid_dim[0];
-		ubo.probe_grid_dim[1] = scene->probe_grid.grid_dim[1];
-		ubo.probe_grid_dim[2] = scene->probe_grid.grid_dim[2];
+		ubo.probe_grid_dim[0] = scene->lighting.probe_grid.grid_dim[0];
+		ubo.probe_grid_dim[1] = scene->lighting.probe_grid.grid_dim[1];
+		ubo.probe_grid_dim[2] = scene->lighting.probe_grid.grid_dim[2];
 		ubo.aa_mode = scene->aa_mode;
 
 		if (scene->billboard_ubo_ptr) {
@@ -797,15 +799,15 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 
 	/* Probe Grid spatial bounds and GI Toggle */
 	shader_set_vec3_loc(scene->instanced_uniforms.probe_grid_min,
-	                    scene->probe_grid.aabb_min);
+	                    scene->lighting.probe_grid.aabb_min);
 	shader_set_vec3_loc(scene->instanced_uniforms.probe_grid_max,
-	                    scene->probe_grid.aabb_max);
+	                    scene->lighting.probe_grid.aabb_max);
 
 	if (scene->instanced_uniforms.probe_grid_dim != -1) {
 		glUniform3i(scene->instanced_uniforms.probe_grid_dim,
-		            scene->probe_grid.grid_dim[0],
-		            scene->probe_grid.grid_dim[1],
-		            scene->probe_grid.grid_dim[2]);
+		            scene->lighting.probe_grid.grid_dim[0],
+		            scene->lighting.probe_grid.grid_dim[1],
+		            scene->lighting.probe_grid.grid_dim[2]);
 	}
 	shader_set_int_loc(scene->instanced_uniforms.gi_mode,
 	                   (int)scene->gi_mode);
@@ -841,7 +843,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 	if (scene->gi_mode != GI_MODE_OFF || scene->show_probe_grid) {
 		PROFILE_ZONE(gi_sync_ctx,
 		             "GI Light Probe Grid Sync (buffer upload)");
-		light_probe_grid_sync(&scene->probe_grid);
+		light_probe_grid_sync(&scene->lighting.probe_grid);
 		/* Sync clobbers 3D texture bindings on the current unit
 		 * via glBindTexture(GL_TEXTURE_3D, 0) — invalidate cache
 		 * so scene_bind_probe_textures() will re-bind. */
@@ -1044,7 +1046,8 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 	}
 
 	if (scene->show_probe_grid) {
-		light_probe_grid_render_debug(&scene->probe_grid, view, proj);
+		light_probe_grid_render_debug(&scene->lighting.probe_grid, view,
+		                              proj);
 	}
 }
 

--- a/tests/test_env_transition.c
+++ b/tests/test_env_transition.c
@@ -61,7 +61,7 @@ void test_transition_initial_state(void)
 {
 	g_test_app->env_mgr.transition_state = TRANSITION_WAIT_IBL;
 	g_test_app->env_mgr.transition_alpha = 1.0F;
-	g_test_app->scene.ibl_coord.state = IBL_STATE_DONE;
+	g_test_app->scene.lighting.ibl_coord.state = IBL_STATE_DONE;
 
 	/* Simulate state machine processing */
 	env_manager_update_ibl(
@@ -80,7 +80,7 @@ void test_transition_crossfade_flow(void)
 {
 	g_test_app->env_mgr.env_transition_mode = ENV_TRANSITION_CROSSFADE;
 	g_test_app->env_mgr.transition_state = TRANSITION_LOADING;
-	g_test_app->scene.ibl_coord.state = IBL_STATE_DONE;
+	g_test_app->scene.lighting.ibl_coord.state = IBL_STATE_DONE;
 
 	/* Simulate state machine processing */
 	env_manager_update_ibl(
@@ -103,7 +103,7 @@ void test_transition_black_screen_flow(void)
 {
 	g_test_app->env_mgr.env_transition_mode = ENV_TRANSITION_BLACK_SCREEN;
 	g_test_app->env_mgr.transition_state = TRANSITION_LOADING;
-	g_test_app->scene.ibl_coord.state = IBL_STATE_DONE;
+	g_test_app->scene.lighting.ibl_coord.state = IBL_STATE_DONE;
 
 	/* Simulate state machine processing */
 	env_manager_update_ibl(


### PR DESCRIPTION
## Summary

Phase 3 of #201: extract `SceneLighting` sub-struct from the `Scene` God Object.

### Changes

- **`include/scene.h`**: New `SceneLighting` struct grouping `MaterialLib*`, `IBLCoordinator`, `LightProbeGrid`. `Scene` now holds `SceneLighting lighting` instead of 3 separate fields.
- **`src/scene.c`** (35 sites), **`src/env_manager.c`** (4 sites), **`tests/test_env_transition.c`** (3 sites), **`src/app.c`** (1 site), **`src/app_ui.c`** (1 site): All 44 access sites updated.
- **`docs/architecture.md`** + **`docs/architecture.fr.md`**: Updated Scene Decomposition section with all 3 phases.

### Acceptance Criteria (Phase 3)

- [x] SceneLighting groups material_lib + ibl_coord + probe_grid
- [x] Zero behavioral change (pure refactor)
- [x] `just format && just lint && just test-all` passes (63/63 tests)
- [x] Documentation updated (EN + FR)

### Scene Decomposition Summary (Issue #201)

| Phase | Sub-struct | Fields grouped | PR |
|-------|-----------|---------------|-----|
| 1 | SceneVisuals | Skybox, TrailRenderer, ShockwaveRenderer | #218 |
| 2 | SceneSimulation | NBodySim, nbody_mode | #219 |
| 3 | SceneLighting | MaterialLib*, IBLCoordinator, LightProbeGrid | This PR |

Closes #201