### PR TITLE
refactor(app): extract sub-struct headers + delegate init/cleanup (Phase 3 of #203)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,9 @@ set(SOURCES
     src/app_binding.c
     src/env_manager.c
     src/app_input.c
+    src/app_input_state.c
     src/app_metrics.c
+    src/app_profiling.c
     src/app_ui.c
     src/async_loader.c
     src/async_coordinator.c

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -74,10 +74,12 @@ Cela réduit le nombre de champs directs de `Scene` et localise les changements 
 
 La structure `App` est progressivement décomposée en sous-structs par domaine :
 
-- **`AppProfiling`** (`include/app.h`) : regroupe le profiling et les métriques — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Accès via `app->profiling.gpu_profiler`, etc.
-- **`AppInput`** (`include/app.h`) : regroupe la caméra, le gamepad, les raccourcis clavier et le lissage d'entrée — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Accès via `app->input.camera`, etc.
+- **`AppProfiling`** (`include/app_profiling.h`) : regroupe le profiling et les métriques — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Accès via `app->profiling.gpu_profiler`, etc. Init/cleanup délégués à `app_profiling_init()` / `app_profiling_cleanup()` dans `src/app_profiling.c`.
+- **`AppInput`** (`include/app_input_state.h`) : regroupe la caméra, le gamepad, les raccourcis clavier et le lissage d'entrée — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Accès via `app->input.camera`, etc. Init/cleanup délégués à `app_input_state_init()` / `app_input_state_cleanup()` dans `src/app_input_state.c`.
 
-Cela réduit le nombre de champs directs de `App` (13 champs → 2 sous-structs) et localise les changements par domaine.
+> **Note de nommage** : `app_input_state.h` héberge la définition de la sous-struct `AppInput`, tandis que le fichier existant `app_input.h` héberge le seam `AppInputContext` (bundle de pointeurs ciblés pour les handlers d'entrée, issue #204).
+
+Cela réduit le nombre de champs directs de `App` (13 champs → 2 sous-structs) et le nombre d'includes de `app.h` de 22 à 14 (sous la cible ≤15). Chaque header de sous-struct possède ses dépendances de type et ses fonctions de délégation, gardant `app.c` focalisé sur l'orchestration.
 
 ### Découplage des effets (EffectContext)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,10 +114,12 @@ This reduces `Scene`'s direct field count and localizes domain-specific changes.
 
 The `App` struct is being decomposed into domain-aligned sub-structs:
 
-- **`AppProfiling`** (`include/app.h`): Groups profiling and metrics — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Access via `app->profiling.gpu_profiler`, etc.
-- **`AppInput`** (`include/app.h`): Groups camera, gamepad, key-bindings, and input smoothing — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Access via `app->input.camera`, etc.
+- **`AppProfiling`** (`include/app_profiling.h`): Groups profiling and metrics — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Access via `app->profiling.gpu_profiler`, etc. Init/cleanup delegated to `app_profiling_init()` / `app_profiling_cleanup()` in `src/app_profiling.c`.
+- **`AppInput`** (`include/app_input_state.h`): Groups camera, gamepad, key-bindings, and input smoothing — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Access via `app->input.camera`, etc. Init/cleanup delegated to `app_input_state_init()` / `app_input_state_cleanup()` in `src/app_input_state.c`.
 
-This reduces `App`'s direct field count (13 fields → 2 sub-structs) and localizes domain-specific changes.
+> **Naming note**: `app_input_state.h` hosts the `AppInput` sub-struct definition, while the existing `app_input.h` hosts the `AppInputContext` seam (focused pointer bundle for input handlers, issue #204).
+
+This reduces `App`'s direct field count (13 fields → 2 sub-structs) and `app.h`'s include count from 22 to 14 (below the ≤15 target). Each sub-struct header owns its type dependencies and its delegation functions, keeping `app.c` focused on orchestration.
 
 ### Effect Decoupling (EffectContext)
 

--- a/include/app.h
+++ b/include/app.h
@@ -2,61 +2,22 @@
 #define APP_H
 
 #include "action_notifier.h"
-#include "adaptive_sampler.h"
-#include "app_binding.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
 #include "app_ui.h"
 #include "async/async_coordinator.h"
 #include "async_loader.h"
-#include "camera.h"
 #include "effect_benchmark.h"
 #include "env_manager.h"
-#include "fps.h"
-#include "gamepad_input.h"
 #include "gl_common.h"
-#include "gpu_profiler.h"
-#include "gpu_profiler_ui.h"
-#include "gpu_usage.h"
-#include "perf_mode.h"
 #include "postprocess.h"
 #include "scene.h"
-#include "tracy_manager.h"
 #include "ui.h"
 #include <cglm/cglm.h>
 
 #ifdef USE_SSBO_RENDERING
 #include "ssbo_rendering.h"
 #endif
-
-typedef struct AsyncLoader
-    AsyncLoader; /**< Forward declaration of AsyncLoader. */
-
-/**
- * @struct AppProfiling
- * @brief Profiling, metrics, and performance monitoring grouped together.
- */
-typedef struct AppProfiling {
-	FpsCounter fps_counter;       /**< Rolling average FPS manager. */
-	GPUProfiler gpu_profiler;     /**< GPU timer query profiler. */
-	GPUProfilerUI timeline_ui;    /**< GPU profiler timeline overlay. */
-	TracyManager tracy_mgr;       /**< Tracy instrumentation manager. */
-	GPUUsageMonitor gpu_usage;    /**< GPU utilization % via DRM fdinfo. */
-	PerfModeContext perf_context; /**< Performance mode state context. */
-	int perf_mode_active; /**< Performance/GameMode optimization active. */
-	int log_gpu_metrics;  /**< Toggle console logging of GPU stats. */
-} AppProfiling;
-
-/**
- * @struct AppInput
- * @brief Camera, gamepad, key-bindings, and input smoothing grouped together.
- */
-typedef struct AppInput {
-	Camera camera;        /**< View/Proj state. */
-	GamepadState gamepad; /**< Controller/gamepad input state. */
-	AppBindingRegistry
-	    binding_registry;        /**< Key-binding overlay registry. */
-	AdaptiveSampler fps_sampler; /**< Jitter compensation for input. */
-	int camera_enabled;          /**< Pause camera movement. */
-} AppInput;
 
 /**
  * @struct App

--- a/include/app_input_state.h
+++ b/include/app_input_state.h
@@ -1,0 +1,43 @@
+#ifndef APP_INPUT_STATE_H
+#define APP_INPUT_STATE_H
+
+/**
+ * @file app_input_state.h
+ * @brief Camera, gamepad, key-bindings, and input smoothing sub-struct.
+ *
+ * Extracted from app.h to reduce include fan-out.
+ * Named "app_input_state" to avoid collision with the existing
+ * app_input.h (AppInputContext seam, issue #204).
+ */
+
+#include "adaptive_sampler.h"
+#include "app_binding.h"
+#include "camera.h"
+#include "gamepad_input.h"
+
+/**
+ * @struct AppInput
+ * @brief Camera, gamepad, key-bindings, and input smoothing grouped together.
+ */
+typedef struct AppInput {
+	Camera camera;        /**< View/Proj state. */
+	GamepadState gamepad; /**< Controller/gamepad input state. */
+	AppBindingRegistry
+	    binding_registry;        /**< Key-binding overlay registry. */
+	AdaptiveSampler fps_sampler; /**< Jitter compensation for input. */
+	int camera_enabled;          /**< Pause camera movement. */
+} AppInput;
+
+/**
+ * @brief Initialize all input sub-systems to default state.
+ * @param input  Pointer to the input sub-struct.
+ */
+void app_input_state_init(AppInput* input);
+
+/**
+ * @brief Release all input resources.
+ * @param input  Pointer to the input sub-struct.
+ */
+void app_input_state_cleanup(AppInput* input);
+
+#endif /* APP_INPUT_STATE_H */

--- a/include/app_profiling.h
+++ b/include/app_profiling.h
@@ -1,0 +1,49 @@
+#ifndef APP_PROFILING_H
+#define APP_PROFILING_H
+
+/**
+ * @file app_profiling.h
+ * @brief Profiling, metrics, and performance monitoring sub-struct.
+ *
+ * Extracted from app.h to reduce include fan-out.
+ * All profiling-related types are grouped here so that app.h
+ * only needs a single `#include "app_profiling.h"`.
+ */
+
+#include "fps.h"
+#include "gpu_profiler.h"
+#include "gpu_profiler_ui.h"
+#include "gpu_usage.h"
+#include "perf_mode.h"
+#include "tracy_manager.h"
+
+/**
+ * @struct AppProfiling
+ * @brief Profiling, metrics, and performance monitoring grouped together.
+ */
+typedef struct AppProfiling {
+	FpsCounter fps_counter;       /**< Rolling average FPS manager. */
+	GPUProfiler gpu_profiler;     /**< GPU timer query profiler. */
+	GPUProfilerUI timeline_ui;    /**< GPU profiler timeline overlay. */
+	TracyManager tracy_mgr;       /**< Tracy instrumentation manager. */
+	GPUUsageMonitor gpu_usage;    /**< GPU utilization % via DRM fdinfo. */
+	PerfModeContext perf_context; /**< Performance mode state context. */
+	int perf_mode_active; /**< Performance/GameMode optimization active. */
+	int log_gpu_metrics;  /**< Toggle console logging of GPU stats. */
+} AppProfiling;
+
+/**
+ * @brief Initialize all profiling sub-systems to default state.
+ * @param prof  Pointer to the profiling sub-struct.
+ * @param width  Initial viewport width (for Tracy screenshot buffer).
+ * @param height Initial viewport height.
+ */
+void app_profiling_init(AppProfiling* prof, int width, int height);
+
+/**
+ * @brief Release all profiling resources in reverse init order.
+ * @param prof  Pointer to the profiling sub-struct.
+ */
+void app_profiling_cleanup(AppProfiling* prof);
+
+#endif /* APP_PROFILING_H */

--- a/src/app.c
+++ b/src/app.c
@@ -1,18 +1,14 @@
 #include "app.h"
 
 #include "action_notifier.h"
-#include "adaptive_sampler.h"
-#include "app_binding.h"
 #include "app_input.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
 #include "app_settings.h"
 #include "app_ui.h"
 #include "async_loader.h"
-#include "camera.h"
-#include "fps.h"
-#include "gamepad_input.h"
 #include "gl_common.h"
 #include "glad/glad.h"
-#include "perf_mode.h"
 #include "postprocess.h"
 #include "profiler.h"
 #include "renderer.h"
@@ -32,18 +28,11 @@ int app_init(App* app, int width, int height, const char* title)
 	app->width = width;
 	app->height = height;
 
-	app->input.camera_enabled = true;
+	app_input_state_init(&app->input);
 	app->is_fullscreen = false;
 	app->resize_pending = 0;
 	app->scene.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
 	app->env_mgr.is_first_load = true;
-
-	/* Initialize Help UI state */
-	app_binding_registry_init(&app->input.binding_registry);
-
-	camera_init(&app->input.camera, DEFAULT_CAMERA_DISTANCE,
-	            DEFAULT_CAMERA_YAW, DEFAULT_CAMERA_PITCH);
-	gamepad_input_init(&app->input.gamepad);
 
 	app->window = window_create(width, height, title, DEFAULT_SAMPLES);
 	if (!app->window) {
@@ -62,8 +51,8 @@ int app_init(App* app, int width, int height, const char* title)
 		                 GLFW_CURSOR_DISABLED);
 	}
 
-	/* Initialize Tracy Manager */
-	tracy_manager_init(&app->profiling.tracy_mgr, width, height);
+	/* Initialize all profiling sub-systems (needs GL context) */
+	app_profiling_init(&app->profiling, width, height);
 
 	/* Transition Snapshot Initialization (GL Context Ready) */
 	/* Transition Initialization (Starts Black, fades in when IBL is done)
@@ -113,10 +102,6 @@ int app_init(App* app, int width, int height, const char* title)
 	app->u_exposure = DEFAULT_EXPOSURE;
 	glEnable(GL_DEPTH_TEST);
 
-	fps_init(&app->profiling.fps_counter, DEFAULT_FPS_SMOOTHING,
-	         DEFAULT_FPS_WINDOW);
-	adaptive_sampler_init(&app->input.fps_sampler, DEFAULT_FPS_WINDOW,
-	                      DEFAULT_FPS_SAMPLER_SIZE, DEFAULT_FPS_TARGET);
 	app->last_frame_time = glfwGetTime();
 	app_ui_init(&app->overlay);
 
@@ -135,15 +120,10 @@ int app_init(App* app, int width, int height, const char* title)
 	                              app->postprocess.active_effects);
 #endif
 
-	perf_mode_init(&app->profiling.perf_context);
 	action_notifier_init(&app->notifier);
 
-	gpu_profiler_init(&app->profiling.gpu_profiler);
-	gpu_profiler_ui_init(&app->profiling.timeline_ui);
-	gpu_usage_init(&app->profiling.gpu_usage);
 	effect_benchmark_init(&app->effect_bench, &app->postprocess,
 	                      &app->profiling.gpu_profiler);
-	app->profiling.log_gpu_metrics = 0; /* Console logging off by default */
 
 	return 1;
 }
@@ -169,23 +149,17 @@ void app_cleanup(App* app)
 
 	async_coordinator_cleanup(&app->async_coord);
 
-	adaptive_sampler_cleanup(&app->input.fps_sampler);
+	app_input_state_cleanup(&app->input);
 
 	if (app->lum_histogram_buffer) {
 		free(app->lum_histogram_buffer);
 		app->lum_histogram_buffer = NULL;
 	}
 
-	perf_mode_cleanup(&app->profiling.perf_context);
-
-	gpu_profiler_cleanup(&app->profiling.gpu_profiler);
-	gpu_profiler_ui_cleanup(&app->profiling.timeline_ui);
-	gpu_usage_cleanup(&app->profiling.gpu_usage);
+	app_profiling_cleanup(&app->profiling);
 
 	window_destroy(app->window);
 	app->window = NULL;
-
-	tracy_manager_cleanup(&app->profiling.tracy_mgr);
 }
 
 static void app_render_ui_trampoline(void* user_data)

--- a/src/app_input_state.c
+++ b/src/app_input_state.c
@@ -1,0 +1,19 @@
+#include "app_input_state.h"
+
+#include "app_settings.h"
+
+void app_input_state_init(AppInput* input)
+{
+	input->camera_enabled = true;
+	app_binding_registry_init(&input->binding_registry);
+	camera_init(&input->camera, DEFAULT_CAMERA_DISTANCE, DEFAULT_CAMERA_YAW,
+	            DEFAULT_CAMERA_PITCH);
+	gamepad_input_init(&input->gamepad);
+	adaptive_sampler_init(&input->fps_sampler, DEFAULT_FPS_WINDOW,
+	                      DEFAULT_FPS_SAMPLER_SIZE, DEFAULT_FPS_TARGET);
+}
+
+void app_input_state_cleanup(AppInput* input)
+{
+	adaptive_sampler_cleanup(&input->fps_sampler);
+}

--- a/src/app_profiling.c
+++ b/src/app_profiling.c
@@ -1,0 +1,24 @@
+#include "app_profiling.h"
+
+#include "app_settings.h"
+
+void app_profiling_init(AppProfiling* prof, int width, int height)
+{
+	tracy_manager_init(&prof->tracy_mgr, width, height);
+	fps_init(&prof->fps_counter, DEFAULT_FPS_SMOOTHING, DEFAULT_FPS_WINDOW);
+	perf_mode_init(&prof->perf_context);
+	gpu_profiler_init(&prof->gpu_profiler);
+	gpu_profiler_ui_init(&prof->timeline_ui);
+	gpu_usage_init(&prof->gpu_usage);
+	prof->perf_mode_active = 0;
+	prof->log_gpu_metrics = 0;
+}
+
+void app_profiling_cleanup(AppProfiling* prof)
+{
+	perf_mode_cleanup(&prof->perf_context);
+	gpu_profiler_cleanup(&prof->gpu_profiler);
+	gpu_profiler_ui_cleanup(&prof->timeline_ui);
+	gpu_usage_cleanup(&prof->gpu_usage);
+	tracy_manager_cleanup(&prof->tracy_mgr);
+}


### PR DESCRIPTION
## Summary

Phase 3 of #203: extract sub-struct type definitions into dedicated headers and delegate init/cleanup.

### Changes

- **app_profiling.h** (new): AppProfiling typedef + 6 includes + app_profiling_init/cleanup prototypes
- **app_input_state.h** (new): AppInput typedef + 4 includes + app_input_state_init/cleanup prototypes
- **app_profiling.c** (new): profiling delegation implementation
- **app_input_state.c** (new): input delegation implementation
- **app.h**: 22 to 14 includes (target <=15), removed duplicate struct definitions
- **app.c**: replaced 15 scattered init/cleanup calls with 2 delegation calls each
- **CMakeLists.txt**: added new source files
- **docs/architecture.md** + **.fr.md**: updated App Decomposition section

### Naming Convention

app_input_state.h hosts the AppInput sub-struct; the existing app_input.h hosts the AppInputContext seam (#204).

### Testing

- Build: clean (0 warnings)
- Tests: 63/63 pass
- Format + Lint: clean

Closes #203