### PR TITLE
refactor(postprocess): migrate all effects to EffectContext seam (#225)

### DIFF
--- a/docs/application_lifecycle.fr.md
+++ b/docs/application_lifecycle.fr.md
@@ -539,11 +539,11 @@ Chaque effet de post-traitement initialise ses propres ressources. Les effets re
 
 | Effet | Ressources GPU |
 |-------|---------------|
-| **Bloom** | FBOs en chaîne mip (6 niveaux), textures prefiltre/downsample/upsample. Découplé via `EffectContext` : `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)` |
-| **Profondeur de Champ** | Texture de flou, texture CoC (Cercle de Confusion) |
-| **Auto-Exposition** | Texture downsample luminance, 2× PBOs (readback), 2× fences GLSync |
-| **Flou de Mouvement** | Texture vélocité tile-max (compute), texture neighbor-max (compute) |
-| **LUT 3D** | 32³ `GL_TEXTURE_3D` chargée depuis fichiers `.cube` |
+| **Bloom** | FBOs en chaîne mip (6 niveaux), textures prefiltre/downsample/upsample. `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)` |
+| **Profondeur de Champ** | Texture de flou, texture temporaire (ping-pong). `fx_dof_render(DoFFX*, DoFParams*, BloomFX*, EffectContext*)` — emprunte les shaders bloom pour downsample/upsample |
+| **Auto-Exposition** | Texture downsample luminance, 2× PBOs (readback), 2× fences GLSync. `fx_auto_exposure_render(AutoExposureFX*, AutoExposureParams*, EffectContext*)` |
+| **Flou de Mouvement** | Texture vélocité tile-max (compute), texture neighbor-max (compute). `fx_motion_blur_render(MotionBlurFX*, EffectContext*)` |
+| **LUT 3D** | 32³ `GL_TEXTURE_3D` chargée depuis fichiers `.cube`. `fx_lut3d_load_cube(LUT3DFX*, LUT3DParams*, const char*)` |
 
 ### 5.3 — UBO (Uniform Buffer Object)
 

--- a/docs/application_lifecycle.md
+++ b/docs/application_lifecycle.md
@@ -539,11 +539,11 @@ Each post-processing effect initializes its own resources. Effects receive share
 
 | Effect | GPU Resources |
 |--------|--------------|
-| **Bloom** | Mip-chain FBOs (6 levels), prefilter/downsample/upsample textures. Decoupled via `EffectContext`: `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)` |
-| **DoF** | Blur texture, CoC (Circle of Confusion) texture |
-| **Auto-Exposure** | Luminance downsample texture, 2× PBOs (readback), 2× GLSync fences |
-| **Motion Blur** | Tile-max velocity texture (compute), neighbor-max texture (compute) |
-| **3D LUT** | 32³ `GL_TEXTURE_3D` loaded from `.cube` files |
+| **Bloom** | Mip-chain FBOs (6 levels), prefilter/downsample/upsample textures. `fx_bloom_render(BloomFX*, BloomParams*, EffectContext*)` |
+| **DoF** | Blur texture, temp texture (ping-pong). `fx_dof_render(DoFFX*, DoFParams*, BloomFX*, EffectContext*)` — borrows bloom shaders for downsample/upsample |
+| **Auto-Exposure** | Luminance downsample texture, 2× PBOs (readback), 2× GLSync fences. `fx_auto_exposure_render(AutoExposureFX*, AutoExposureParams*, EffectContext*)` |
+| **Motion Blur** | Tile-max velocity texture (compute), neighbor-max texture (compute). `fx_motion_blur_render(MotionBlurFX*, EffectContext*)` |
+| **3D LUT** | 32³ `GL_TEXTURE_3D` loaded from `.cube` files. `fx_lut3d_load_cube(LUT3DFX*, LUT3DParams*, const char*)` |
 
 ### 5.3 — UBO (Uniform Buffer Object)
 

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -83,12 +83,12 @@ Cela réduit le nombre de champs directs de `App` (13 champs → 2 sous-structs)
 
 ### Découplage des effets (EffectContext)
 
-Les effets de post-traitement (bloom, DoF, auto-exposition, flou de mouvement, LUT, LUT viz) sont progressivement découplés de l'objet God `PostProcess` via un seam `EffectContext` :
+Les effets de post-traitement (bloom, DoF, auto-exposition, flou de mouvement, LUT, LUT viz) sont entièrement découplés de l'objet God `PostProcess` via un seam `EffectContext` :
 
 - **`EffectContext`** (`include/effects/effect_context.h`) : snapshot read-only de l'état partagé du pipeline (texture source, dimensions viewport, textures profondeur/vélocité, exposition).
 - Les effets reçoivent `(FX*, Params*, const EffectContext*)` au lieu de `PostProcess*`.
 - Cela élimine la dépendance bidirectionnelle : `postprocess.h` → `fx_*.h` (pour l'embedding des structs) reste, mais `fx_*.c` → `postprocess.h` est supprimé.
-- Actuellement migré : **bloom**. Les effets restants suivront le même pattern.
+- Tous les effets sont désormais entièrement migrés : **bloom**, **DoF**, **auto-exposition**, **flou de mouvement**, **LUT 3D** et **LUT viz**. Plus aucun fichier source d'effet n'inclut `postprocess.h`.
 
 ## Configuration CMake
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,12 +123,12 @@ This reduces `App`'s direct field count (13 fields → 2 sub-structs) and `app.h
 
 ### Effect Decoupling (EffectContext)
 
-Post-processing effects (bloom, DoF, auto-exposure, motion blur, LUT, LUT viz) are progressively decoupled from the `PostProcess` God Object via an `EffectContext` seam:
+Post-processing effects (bloom, DoF, auto-exposure, motion blur, LUT, LUT viz) are fully decoupled from the `PostProcess` God Object via an `EffectContext` seam:
 
 - **`EffectContext`** (`include/effects/effect_context.h`): Read-only snapshot of shared pipeline state (source texture, viewport dimensions, depth/velocity textures, exposure).
 - Effects receive `(FX*, Params*, const EffectContext*)` instead of `PostProcess*`.
 - This eliminates the bidirectional dependency: `postprocess.h` → `fx_*.h` (for struct embedding) remains, but `fx_*.c` → `postprocess.h` is removed.
-- Currently migrated: **bloom**. Remaining effects will follow the same pattern.
+- All effects are now fully migrated: **bloom**, **DoF**, **auto-exposure**, **motion blur**, **LUT 3D**, and **LUT viz**. No effect source file includes `postprocess.h` anymore.
 
 ## Build System
 

--- a/include/effects/effect_context.h
+++ b/include/effects/effect_context.h
@@ -12,6 +12,9 @@
 
 #include "gl_common.h"
 
+/* Forward declaration */
+struct GPUProfiler;
+
 /**
  * @struct EffectContext
  * @brief Read-only snapshot of pipeline state for a single frame.
@@ -24,6 +27,8 @@ typedef struct EffectContext {
 	GLuint depth_tex;    /**< Scene depth texture. */
 	GLuint velocity_tex; /**< Motion vector texture. */
 	float exposure;      /**< Current exposure value. */
+	struct GPUProfiler*
+	    gpu_profiler; /**< Optional GPU profiler (may be NULL). */
 } EffectContext;
 
 #endif /* EFFECT_CONTEXT_H */

--- a/include/effects/fx_auto_exposure.h
+++ b/include/effects/fx_auto_exposure.h
@@ -4,8 +4,8 @@
 #include "gl_common.h"
 #include "shader.h"
 
-/* Forward declaration */
-struct PostProcess;
+/* Forward declarations */
+struct EffectContext;
 
 #define EXPOSURE_MIN_LUM 0.05F
 #define EXPOSURE_DEFAULT_MAX_LUM 5000.0F
@@ -49,22 +49,23 @@ typedef struct {
 } AutoExposureFX;
 
 /* Initialisation des ressources Auto Exposure */
-int fx_auto_exposure_init(struct PostProcess* post_processing);
+int fx_auto_exposure_init(AutoExposureFX* auto_exp);
 
 /* Libération des ressources */
-void fx_auto_exposure_cleanup(struct PostProcess* post_processing);
+void fx_auto_exposure_cleanup(AutoExposureFX* auto_exp);
 
 /* Rendu de l'effet (Downsample + Adaptation) */
-void fx_auto_exposure_render(struct PostProcess* post_processing);
+void fx_auto_exposure_render(AutoExposureFX* auto_exp,
+                             const AutoExposureParams* params,
+                             const struct EffectContext* ctx);
 
 /* Récupère la valeur d'exposition actuelle (du GPU) */
-float fx_auto_exposure_get_current_exposure(
-    struct PostProcess* post_processing);
+float fx_auto_exposure_get_current_exposure(AutoExposureFX* auto_exp);
 
 /* Toggle entre fragment et compute downsample path */
-void fx_auto_exposure_toggle_path(struct PostProcess* post_processing);
+void fx_auto_exposure_toggle_path(AutoExposureFX* auto_exp);
 
 /* Retourne le nom du path actif */
-const char* fx_auto_exposure_path_name(struct PostProcess* post_processing);
+const char* fx_auto_exposure_path_name(AutoExposureFX* auto_exp);
 
 #endif /* FX_AUTO_EXPOSURE_H */

--- a/include/effects/fx_bloom.h
+++ b/include/effects/fx_bloom.h
@@ -25,7 +25,7 @@ typedef struct {
 } BloomMip;
 
 /* Structure regroupant les ressources graphiques du Bloom */
-typedef struct {
+typedef struct BloomFX {
 	Shader* prefilter_shader;
 	Shader* downsample_shader;
 	Shader* upsample_shader;

--- a/include/effects/fx_dof.h
+++ b/include/effects/fx_dof.h
@@ -4,8 +4,9 @@
 #include "gl_common.h"
 #include "shader.h"
 
-/* Forward declaration */
-struct PostProcess;
+/* Forward declarations */
+struct EffectContext;
+struct BloomFX;
 
 /* Paramètres pour le Depth of Field */
 typedef struct {
@@ -24,16 +25,17 @@ typedef struct {
 } DoFFX;
 
 /* Initialisation des ressources DoF */
-int fx_dof_init(struct PostProcess* post_processing);
+int fx_dof_init(DoFFX* dof);
 
 /* Libération des ressources */
-void fx_dof_cleanup(struct PostProcess* post_processing);
+void fx_dof_cleanup(DoFFX* dof);
 
 /* Redimensionnement des ressources */
-int fx_dof_resize(struct PostProcess* post_processing);
+int fx_dof_resize(DoFFX* dof, int width, int height);
 
 /* Rendu de l'effet */
-void fx_dof_render(struct PostProcess* post_processing);
+void fx_dof_render(DoFFX* dof, const DoFParams* params, struct BloomFX* bloom,
+                   const struct EffectContext* ctx);
 
 /* Upload des paramètres vers le shader principal */
 void fx_dof_upload_params(Shader* shader, const DoFParams* params);

--- a/include/effects/fx_lut3d.h
+++ b/include/effects/fx_lut3d.h
@@ -5,9 +5,6 @@
 #include "shader.h"
 #include <stdbool.h>
 
-/* Forward declaration */
-struct PostProcess;
-
 /**
  * @struct LUT3DParams
  * @brief Parameters for 3D LUT gamut mapping.
@@ -31,24 +28,26 @@ typedef struct {
 
 /**
  * @brief Prepares resources for 3D LUT processing.
- * @param post_processing Pointer to main pipeline.
+ * @param lut3d_sys Pointer to the LUT3D subsystem.
  * @return 0 on success.
  */
-int fx_lut3d_init(struct PostProcess* post_processing);
+int fx_lut3d_init(LUT3DFX* lut3d_sys);
 
 /**
  * @brief Releases GPU resources.
- * @param post_processing Pointer to main pipeline.
+ * @param lut3d_sys Pointer to the LUT3D subsystem.
  */
-void fx_lut3d_cleanup(struct PostProcess* post_processing);
+void fx_lut3d_cleanup(LUT3DFX* lut3d_sys);
 
 /**
  * @brief Parses a .cube file and uploads it to a 3D texture.
- * @param post_processing Pointer to main pipeline.
- * @param path Path to the Adobe .cube file.
+ * @param lut3d_sys Pointer to the LUT3D subsystem.
+ * @param params    Output params (texture + size updated on success).
+ * @param path      Path to the Adobe .cube file.
  * @return 0 on success, negative on error.
  */
-int fx_lut3d_load_cube(struct PostProcess* post_processing, const char* path);
+int fx_lut3d_load_cube(LUT3DFX* lut3d_sys, LUT3DParams* params,
+                       const char* path);
 
 /**
  * @brief Uploads LUT parameters to the destination shader.

--- a/include/effects/fx_lut_viz.h
+++ b/include/effects/fx_lut_viz.h
@@ -4,7 +4,8 @@
 #include "gl_common.h"
 #include "shader.h"
 
-struct PostProcess;
+/* Forward declarations */
+struct EffectContext;
 
 /**
  * @struct LUTVizFX
@@ -21,16 +22,20 @@ typedef struct {
 /**
  * @brief Initializes the LUT visualization resources.
  */
-int fx_lut_viz_init(struct PostProcess* post_processing);
+int fx_lut_viz_init(LUTVizFX* viz);
 
 /**
  * @brief Releases GPU resources.
  */
-void fx_lut_viz_cleanup(struct PostProcess* post_processing);
+void fx_lut_viz_cleanup(LUTVizFX* viz);
 
 /**
  * @brief Renders the LUT lattice.
+ * @param viz      LUT visualization resources.
+ * @param lut3d_tex OpenGL 3D texture handle (0 = skip).
+ * @param ctx      Pipeline context (width/height).
  */
-void fx_lut_viz_render(struct PostProcess* post_processing);
+void fx_lut_viz_render(LUTVizFX* viz, GLuint lut3d_tex,
+                       const struct EffectContext* ctx);
 
 #endif /* FX_LUT_VIZ_H */

--- a/include/effects/fx_motion_blur.h
+++ b/include/effects/fx_motion_blur.h
@@ -6,7 +6,7 @@
 #include <cglm/types.h>
 
 /* Forward declaration */
-struct PostProcess;
+struct EffectContext;
 
 /* Paramètres pour le Motion Blur */
 typedef struct {
@@ -25,20 +25,20 @@ typedef struct {
 } MotionBlurFX;
 
 /* Initialisation des ressources Motion Blur */
-int fx_motion_blur_init(struct PostProcess* post_processing);
+int fx_motion_blur_init(MotionBlurFX* mb_fx, MotionBlurParams* params);
 
 /* Libération des ressources */
-void fx_motion_blur_cleanup(struct PostProcess* post_processing);
+void fx_motion_blur_cleanup(MotionBlurFX* mb_fx);
 
 /* Redimensionnement des textures (tile/neighbor max) */
-int fx_motion_blur_resize(struct PostProcess* post_processing);
+int fx_motion_blur_resize(MotionBlurFX* mb_fx, int width, int height);
 
 /* Rendu de l'effet (Passes Compute pour Tile/Neighbor Max) */
-void fx_motion_blur_render(struct PostProcess* post_processing);
+void fx_motion_blur_render(MotionBlurFX* mb_fx,
+                           const struct EffectContext* ctx);
 
 /* Mise à jour de la matrice de vue-projection précédente */
-void fx_motion_blur_update_matrices(struct PostProcess* post_processing,
-                                    mat4 view_proj);
+void fx_motion_blur_update_matrices(MotionBlurFX* mb_fx, mat4 view_proj);
 
 /* Envoi des paramètres au shader final */
 void fx_motion_blur_upload_params(Shader* shader,

--- a/include/gpu_profiler.h
+++ b/include/gpu_profiler.h
@@ -85,7 +85,7 @@ typedef struct {
  * @struct GPUProfiler
  * @brief Manages GPU timing using double-buffered queries to avoid stalls.
  */
-typedef struct {
+typedef struct GPUProfiler {
 	GPUStage stages[MAX_GPU_STAGES];
 	int stage_count; /**< Number of stages from last completed read-back
 	                    (used by UI for display). */

--- a/src/effects/fx_auto_exposure.c
+++ b/src/effects/fx_auto_exposure.c
@@ -1,10 +1,11 @@
 #include "effects/fx_auto_exposure.h"
 
 #include "app_settings.h"
+#include "effects/effect_context.h"
 #include "effects/fx_utils.h"
 #include "gl_common.h"
+#include "gpu_profiler.h"
 #include "log.h"
-#include "postprocess.h"
 #include "shader.h"
 #include <stddef.h>
 
@@ -14,10 +15,8 @@ static const int LUM_DOWNSAMPLE_GROUP_SIZE = 16;
 
 static const char* const AE_PATH_NAMES[AE_PATH_COUNT] = {"Fragment", "Compute"};
 
-int fx_auto_exposure_init(PostProcess* post_processing)
+int fx_auto_exposure_init(AutoExposureFX* auto_exp)
 {
-	AutoExposureFX* auto_exp = &post_processing->auto_exposure_fx;
-
 	/* 1. Downsample texture — R32F for compute image access, also
 	 * compatible with fragment path via FBO attachment. */
 	FXTextureConfig ds_config = {.width = LUM_HISTOGRAM_MAP_SIZE,
@@ -41,7 +40,7 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	    GL_FRAMEBUFFER_COMPLETE) {
 		LOG_ERROR("suckless-ogl.postprocess.ae",
 		          "Lum Downsample FBO incomplete!");
-		fx_auto_exposure_cleanup(post_processing);
+		fx_auto_exposure_cleanup(auto_exp);
 		return 0;
 	}
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -72,7 +71,7 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	    !auto_exp->downsample_comp_shader || !auto_exp->adapt_shader) {
 		LOG_ERROR("suckless-ogl.postprocess.ae",
 		          "Failed to load auto-exposure shaders");
-		fx_auto_exposure_cleanup(post_processing);
+		fx_auto_exposure_cleanup(auto_exp);
 		return 0;
 	}
 
@@ -90,10 +89,8 @@ int fx_auto_exposure_init(PostProcess* post_processing)
 	return 1;
 }
 
-void fx_auto_exposure_cleanup(PostProcess* post_processing)
+void fx_auto_exposure_cleanup(AutoExposureFX* auto_exp)
 {
-	AutoExposureFX* auto_exp = &post_processing->auto_exposure_fx;
-
 	if (auto_exp->downsample_fbo) {
 		glDeleteFramebuffers(1, &auto_exp->downsample_fbo);
 		auto_exp->downsample_fbo = 0;
@@ -112,28 +109,28 @@ void fx_auto_exposure_cleanup(PostProcess* post_processing)
 }
 
 static void downsample_fragment(AutoExposureFX* auto_exp,
-                                PostProcess* post_processing)
+                                const EffectContext* ctx)
 {
 	glViewport(0, 0, LUM_HISTOGRAM_MAP_SIZE, LUM_HISTOGRAM_MAP_SIZE);
 	glBindFramebuffer(GL_FRAMEBUFFER, auto_exp->downsample_fbo);
 
 	shader_use(auto_exp->downsample_frag_shader);
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, post_processing->scene_color_tex);
+	glBindTexture(GL_TEXTURE_2D, ctx->src_tex);
 
 	glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glViewport(0, 0, post_processing->width, post_processing->height);
+	glViewport(0, 0, ctx->width, ctx->height);
 }
 
 static void downsample_compute(AutoExposureFX* auto_exp,
-                               PostProcess* post_processing)
+                               const EffectContext* ctx)
 {
 	shader_use(auto_exp->downsample_comp_shader);
 
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, post_processing->scene_color_tex);
+	glBindTexture(GL_TEXTURE_2D, ctx->src_tex);
 
 	glBindImageTexture(1, auto_exp->downsample_tex, 0, GL_FALSE, 0,
 	                   GL_WRITE_ONLY, GL_R32F);
@@ -146,30 +143,26 @@ static void downsample_compute(AutoExposureFX* auto_exp,
 	                (GLbitfield)GL_TEXTURE_FETCH_BARRIER_BIT);
 }
 
-void fx_auto_exposure_render(PostProcess* post_processing)
+void fx_auto_exposure_render(AutoExposureFX* auto_exp,
+                             const AutoExposureParams* params,
+                             const EffectContext* ctx)
 {
-	if (!postprocess_is_enabled(post_processing, POSTFX_AUTO_EXPOSURE)) {
-		return;
-	}
-
-	AutoExposureFX* auto_exp = &post_processing->auto_exposure_fx;
-
 	/* 1. Downsample Scene -> 64x64 Log Luminance */
 	if (auto_exp->active_path == AE_PATH_COMPUTE) {
-		GPU_STAGE_PROFILER(post_processing->gpu_profiler,
+		GPU_STAGE_PROFILER(ctx->gpu_profiler,
 		                   "Auto-Exposure Downsample (Compute)",
 		                   GPU_PROFILER_AUTO_EXPOSURE_COLOR);
-		downsample_compute(auto_exp, post_processing);
+		downsample_compute(auto_exp, ctx);
 	} else {
-		GPU_STAGE_PROFILER(post_processing->gpu_profiler,
+		GPU_STAGE_PROFILER(ctx->gpu_profiler,
 		                   "Auto-Exposure Downsample (Fragment)",
 		                   GPU_PROFILER_AUTO_EXPOSURE_COLOR);
-		downsample_fragment(auto_exp, post_processing);
+		downsample_fragment(auto_exp, ctx);
 	}
 
 	/* 2. Compute Adaptation (always compute — single invocation) */
 	{
-		GPU_STAGE_PROFILER(post_processing->gpu_profiler,
+		GPU_STAGE_PROFILER(ctx->gpu_profiler,
 		                   "Auto-Exposure (Adaptation)",
 		                   GPU_PROFILER_AUTO_EXPOSURE_COLOR);
 
@@ -188,17 +181,17 @@ void fx_auto_exposure_render(PostProcess* post_processing)
 		                   GL_READ_WRITE, GL_RGBA32F);
 
 		shader_set_float(auto_exp->adapt_shader, "deltaTime",
-		                 post_processing->delta_time);
+		                 ctx->delta_time);
 		shader_set_float(auto_exp->adapt_shader, "minLuminance",
-		                 post_processing->auto_exposure.min_luminance);
+		                 params->min_luminance);
 		shader_set_float(auto_exp->adapt_shader, "maxLuminance",
-		                 post_processing->auto_exposure.max_luminance);
+		                 params->max_luminance);
 		shader_set_float(auto_exp->adapt_shader, "speedUp",
-		                 post_processing->auto_exposure.speed_up);
+		                 params->speed_up);
 		shader_set_float(auto_exp->adapt_shader, "speedDown",
-		                 post_processing->auto_exposure.speed_down);
+		                 params->speed_down);
 		shader_set_float(auto_exp->adapt_shader, "keyValue",
-		                 post_processing->auto_exposure.key_value);
+		                 params->key_value);
 
 		glDispatchCompute(1, 1, 1);
 
@@ -208,9 +201,8 @@ void fx_auto_exposure_render(PostProcess* post_processing)
 	}
 }
 
-float fx_auto_exposure_get_current_exposure(PostProcess* post_processing)
+float fx_auto_exposure_get_current_exposure(AutoExposureFX* auto_exp)
 {
-	AutoExposureFX* auto_exp = &post_processing->auto_exposure_fx;
 	float pixel[4];
 	glBindTexture(GL_TEXTURE_2D, auto_exp->exposure_tex);
 	glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_FLOAT, pixel);
@@ -218,9 +210,8 @@ float fx_auto_exposure_get_current_exposure(PostProcess* post_processing)
 	return pixel[0];
 }
 
-void fx_auto_exposure_toggle_path(PostProcess* post_processing)
+void fx_auto_exposure_toggle_path(AutoExposureFX* auto_exp)
 {
-	AutoExposureFX* auto_exp = &post_processing->auto_exposure_fx;
 	auto_exp->active_path =
 	    (AEDownsamplePath)((auto_exp->active_path + 1) % AE_PATH_COUNT);
 	LOG_INFO("suckless-ogl.postprocess.ae",
@@ -228,8 +219,7 @@ void fx_auto_exposure_toggle_path(PostProcess* post_processing)
 	         AE_PATH_NAMES[auto_exp->active_path]);
 }
 
-const char* fx_auto_exposure_path_name(PostProcess* post_processing)
+const char* fx_auto_exposure_path_name(AutoExposureFX* auto_exp)
 {
-	AutoExposureFX* auto_exp = &post_processing->auto_exposure_fx;
 	return AE_PATH_NAMES[auto_exp->active_path];
 }

--- a/src/effects/fx_dof.c
+++ b/src/effects/fx_dof.c
@@ -1,40 +1,21 @@
 #include "effects/fx_dof.h"
 
+#include "effects/effect_context.h"
 #include "effects/fx_bloom.h"
 #include "effects/fx_utils.h"
 #include "gl_common.h"
-#include "log.h"
-#include "postprocess.h"
 #include "shader.h"
 #include <cglm/types.h>
 #include <stddef.h>
 
-int fx_dof_init(PostProcess* post_processing)
+int fx_dof_init(DoFFX* dof)
 {
-	DoFFX* dof = &post_processing->dof_fx;
-
 	glGenFramebuffers(1, &dof->fbo);
-	glBindFramebuffer(GL_FRAMEBUFFER, dof->fbo);
-
-	if (!fx_dof_resize(post_processing)) {
-		return 0;
-	}
-
-	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) !=
-	    GL_FRAMEBUFFER_COMPLETE) {
-		LOG_ERROR("suckless-ogl.postprocess.dof",
-		          "Failed to create DoF framebuffer");
-		return 0;
-	}
-
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	return 1;
 }
 
-void fx_dof_cleanup(PostProcess* post_processing)
+void fx_dof_cleanup(DoFFX* dof)
 {
-	DoFFX* dof = &post_processing->dof_fx;
-
 	if (dof->fbo) {
 		glDeleteFramebuffers(1, &dof->fbo);
 		dof->fbo = 0;
@@ -49,15 +30,13 @@ void fx_dof_cleanup(PostProcess* post_processing)
 	}
 }
 
-int fx_dof_resize(PostProcess* post_processing)
+int fx_dof_resize(DoFFX* dof, int width, int height)
 {
 	/* Ensure Unit 0 is active for initial texture setup */
 	glActiveTexture(GL_TEXTURE0);
 
-	DoFFX* dof = &post_processing->dof_fx;
-
-	int dof_width = post_processing->width / 4;
-	int dof_height = post_processing->height / 4;
+	int dof_width = width / 4;
+	int dof_height = height / 4;
 	if (dof_width < 1) {
 		dof_width = 1;
 	}
@@ -89,16 +68,11 @@ int fx_dof_resize(PostProcess* post_processing)
 	return 1;
 }
 
-void fx_dof_render(PostProcess* post_processing)
+void fx_dof_render(DoFFX* dof, const DoFParams* params, BloomFX* bloom,
+                   const EffectContext* ctx)
 {
-	if (!postprocess_is_enabled(post_processing, POSTFX_DOF) &&
-	    !postprocess_is_enabled(post_processing, POSTFX_DOF_DEBUG)) {
-		return;
-	}
-
-	DoFFX* dof = &post_processing->dof_fx;
-	int dof_width = post_processing->width / 4;
-	int dof_height = post_processing->height / 4;
+	int dof_width = ctx->width / 4;
+	int dof_height = ctx->height / 4;
 	if (dof_width < 1) {
 		dof_width = 1;
 	}
@@ -115,18 +89,16 @@ void fx_dof_render(PostProcess* post_processing)
 	                       GL_TEXTURE_2D, dof->temp_tex, 0);
 
 	/* Pass 0: Set Anamorphic Scale */
-	float ratio = post_processing->dof.anamorphic_ratio;
+	float ratio = params->anamorphic_ratio;
 	vec2 texel_scale = {1.0F, ratio};
 
-	Shader* ds_shader =
-	    fx_bloom_get_downsample_shader(&post_processing->bloom_fx);
+	Shader* ds_shader = fx_bloom_get_downsample_shader(bloom);
 	shader_use(ds_shader);
 
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, post_processing->scene_color_tex);
+	glBindTexture(GL_TEXTURE_2D, ctx->src_tex);
 
-	vec2 src_res = {(float)post_processing->width,
-	                (float)post_processing->height};
+	vec2 src_res = {(float)ctx->width, (float)ctx->height};
 	shader_set_vec2(ds_shader, "srcResolution", (float*)&src_res);
 	shader_set_vec2(ds_shader, "texelScale", (float*)&texel_scale);
 
@@ -136,8 +108,7 @@ void fx_dof_render(PostProcess* post_processing)
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
 	                       GL_TEXTURE_2D, dof->blur_tex, 0);
 
-	Shader* us_shader =
-	    fx_bloom_get_upsample_shader(&post_processing->bloom_fx);
+	Shader* us_shader = fx_bloom_get_upsample_shader(bloom);
 	shader_use(us_shader);
 
 	glActiveTexture(GL_TEXTURE0);
@@ -148,7 +119,7 @@ void fx_dof_render(PostProcess* post_processing)
 	glDrawArrays(GL_TRIANGLES, 0, SCREEN_QUAD_VERTEX_COUNT);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glViewport(0, 0, post_processing->width, post_processing->height);
+	glViewport(0, 0, ctx->width, ctx->height);
 }
 
 void fx_dof_upload_params(Shader* shader, const DoFParams* params)

--- a/src/effects/fx_lut3d.c
+++ b/src/effects/fx_lut3d.c
@@ -2,7 +2,6 @@
 
 #include "gl_common.h"
 #include "log.h"
-#include "postprocess.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,18 +15,16 @@ enum LUT3DConstants {
 	LUT_SIZE_VALUE_OFFSET = 12
 };
 
-int fx_lut3d_init(PostProcess* post_processing)
+int fx_lut3d_init(LUT3DFX* lut3d_sys)
 {
-	LUT3DFX* lut3d_sys = &post_processing->lut3d_fx;
 	lut3d_sys->lut_tex = 0;
 	lut3d_sys->current_size = 0;
 	lut3d_sys->current_lut_idx = 0;
 	return 0;
 }
 
-void fx_lut3d_cleanup(PostProcess* post_processing)
+void fx_lut3d_cleanup(LUT3DFX* lut3d_sys)
 {
-	LUT3DFX* lut3d_sys = &post_processing->lut3d_fx;
 	if (lut3d_sys->lut_tex) {
 		glDeleteTextures(1, &lut3d_sys->lut_tex);
 		lut3d_sys->lut_tex = 0;
@@ -64,7 +61,8 @@ static int parse_lut_line(const char* line, float* lut_data, int* entry_count,
 	return 0;
 }
 
-int fx_lut3d_load_cube(PostProcess* post_processing, const char* path)
+int fx_lut3d_load_cube(LUT3DFX* lut3d_sys, LUT3DParams* params,
+                       const char* path)
 {
 	FILE* cube_file = fopen(path, "r");
 	if (!cube_file) {
@@ -123,7 +121,6 @@ int fx_lut3d_load_cube(PostProcess* post_processing, const char* path)
 		return -3;
 	}
 
-	LUT3DFX* lut3d_sys = &post_processing->lut3d_fx;
 	if (lut3d_sys->lut_tex) {
 		glDeleteTextures(1, &lut3d_sys->lut_tex);
 	}
@@ -141,8 +138,8 @@ int fx_lut3d_load_cube(PostProcess* post_processing, const char* path)
 
 	free(lut_data);
 	lut3d_sys->current_size = lut_size;
-	post_processing->lut3d.texture = lut3d_sys->lut_tex;
-	post_processing->lut3d.size = lut_size;
+	params->texture = lut3d_sys->lut_tex;
+	params->size = lut_size;
 
 	return 0;
 }

--- a/src/effects/fx_lut_viz.c
+++ b/src/effects/fx_lut_viz.c
@@ -1,16 +1,19 @@
 #include "effects/fx_lut_viz.h"
 
+#include "effects/effect_context.h"
 #include "log.h"
-#include "postprocess.h"
 #include "shader.h"
+#include <cglm/affine.h>  // IWYU pragma: keep
+#include <cglm/cam.h>     // IWYU pragma: keep
+#include <cglm/mat4.h>
+#include <cglm/types.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
 enum LUTVizConstants { DEFAULT_LUT_VIZ_GRID_SIZE = 32 };
 
-int fx_lut_viz_init(PostProcess* post_processing)
+int fx_lut_viz_init(LUTVizFX* viz)
 {
-	LUTVizFX* viz = &post_processing->lut_viz_fx;
 	viz->grid_size = DEFAULT_LUT_VIZ_GRID_SIZE;
 	viz->is_enabled = false;
 
@@ -63,9 +66,8 @@ int fx_lut_viz_init(PostProcess* post_processing)
 	return 0;
 }
 
-void fx_lut_viz_cleanup(PostProcess* post_processing)
+void fx_lut_viz_cleanup(LUTVizFX* viz)
 {
-	LUTVizFX* viz = &post_processing->lut_viz_fx;
 	if (viz->vao) {
 		glDeleteVertexArrays(1, &viz->vao);
 	}
@@ -77,10 +79,10 @@ void fx_lut_viz_cleanup(PostProcess* post_processing)
 	}
 }
 
-void fx_lut_viz_render(PostProcess* post_processing)
+void fx_lut_viz_render(LUTVizFX* viz, GLuint lut3d_tex,
+                       const EffectContext* ctx)
 {
-	LUTVizFX* viz = &post_processing->lut_viz_fx;
-	if (!viz->is_enabled || !post_processing->lut3d.texture) {
+	if (!viz->is_enabled || !lut3d_tex) {
 		return;
 	}
 
@@ -88,7 +90,7 @@ void fx_lut_viz_render(PostProcess* post_processing)
 
 	/* Pass 3D LUT texture */
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_3D, post_processing->lut3d.texture);
+	glBindTexture(GL_TEXTURE_3D, lut3d_tex);
 	shader_set_int(viz->shader, "u_lut3d", 0);
 
 	/* Set MVP with auto-rotation for visualization */
@@ -111,10 +113,8 @@ void fx_lut_viz_render(PostProcess* post_processing)
 
 	glm_lookat((vec3){0.0F, 0.0F, cam_z}, (vec3){0.0F, 0.0F, 0.0F},
 	           (vec3){0.0F, 1.0F, 0.0F}, view);
-	glm_perspective(
-	    glm_rad(fov),
-	    (float)post_processing->width / (float)post_processing->height,
-	    znear, zfar, proj);
+	glm_perspective(glm_rad(fov), (float)ctx->width / (float)ctx->height,
+	                znear, zfar, proj);
 
 	glm_mat4_mul(proj, view, mvp);
 	glm_mat4_mul(mvp, model, mvp);

--- a/src/effects/fx_motion_blur.c
+++ b/src/effects/fx_motion_blur.c
@@ -1,9 +1,9 @@
 #include "effects/fx_motion_blur.h"
 
+#include "effects/effect_context.h"
 #include "effects/fx_utils.h"
 #include "gl_common.h"
 #include "log.h"
-#include "postprocess.h"
 #include "shader.h"
 #include <cglm/mat4.h>
 #include <cglm/types.h>
@@ -17,14 +17,12 @@ static const float DEFAULT_MB_INTENSITY = 1.0F;
 static const float DEFAULT_MB_MAX_VELOCITY = 0.05F;
 static const int DEFAULT_MB_SAMPLES = 8;
 
-int fx_motion_blur_init(PostProcess* post_processing)
+int fx_motion_blur_init(MotionBlurFX* mb_fx, MotionBlurParams* params)
 {
-	MotionBlurFX* mb_fx = &post_processing->motion_blur_fx;
-
-	/* 1. Initialiser les paramètres par défaut dans PostProcess */
-	post_processing->motion_blur.intensity = DEFAULT_MB_INTENSITY;
-	post_processing->motion_blur.max_velocity = DEFAULT_MB_MAX_VELOCITY;
-	post_processing->motion_blur.samples = DEFAULT_MB_SAMPLES;
+	/* 1. Initialiser les paramètres par défaut */
+	params->intensity = DEFAULT_MB_INTENSITY;
+	params->max_velocity = DEFAULT_MB_MAX_VELOCITY;
+	params->samples = DEFAULT_MB_SAMPLES;
 
 	/* 2. Charger les shaders */
 	mb_fx->tile_max_shader =
@@ -47,14 +45,11 @@ int fx_motion_blur_init(PostProcess* post_processing)
 	/* 3. Initialiser les matrices */
 	glm_mat4_identity(mb_fx->previous_view_proj);
 
-	/* 4. Créer les textures */
-	return fx_motion_blur_resize(post_processing);
+	return 1;
 }
 
-void fx_motion_blur_cleanup(PostProcess* post_processing)
+void fx_motion_blur_cleanup(MotionBlurFX* mb_fx)
 {
-	MotionBlurFX* mb_fx = &post_processing->motion_blur_fx;
-
 	if (mb_fx->tile_max_tex) {
 		glDeleteTextures(1, &mb_fx->tile_max_tex);
 		mb_fx->tile_max_tex = 0;
@@ -67,19 +62,15 @@ void fx_motion_blur_cleanup(PostProcess* post_processing)
 	SHADER_SAFE_DESTROY(mb_fx->neighbor_max_shader);
 }
 
-int fx_motion_blur_resize(PostProcess* post_processing)
+int fx_motion_blur_resize(MotionBlurFX* mb_fx, int width, int height)
 {
 	/* Ensure Unit 0 is active for initial texture setup */
 	glActiveTexture(GL_TEXTURE0);
 
-	MotionBlurFX* mb_fx = &post_processing->motion_blur_fx;
-
 	int tile_width =
-	    (post_processing->width + (MB_COMPUTE_GROUP_SIZE - 1)) /
-	    MB_COMPUTE_GROUP_SIZE;
+	    (width + (MB_COMPUTE_GROUP_SIZE - 1)) / MB_COMPUTE_GROUP_SIZE;
 	int tile_height =
-	    (post_processing->height + (MB_COMPUTE_GROUP_SIZE - 1)) /
-	    MB_COMPUTE_GROUP_SIZE;
+	    (height + (MB_COMPUTE_GROUP_SIZE - 1)) / MB_COMPUTE_GROUP_SIZE;
 
 	if (tile_width < 1) {
 		tile_width = 1;
@@ -108,17 +99,13 @@ int fx_motion_blur_resize(PostProcess* post_processing)
 	return 1;
 }
 
-void fx_motion_blur_render(PostProcess* post_processing)
+void fx_motion_blur_render(MotionBlurFX* mb_fx, const EffectContext* ctx)
 {
-	MotionBlurFX* mb_fx = &post_processing->motion_blur_fx;
-
 	/* Tile dimensions (one tile per 16x16 pixel block) */
 	int tile_count_x =
-	    (post_processing->width + (MB_COMPUTE_GROUP_SIZE - 1)) /
-	    MB_COMPUTE_GROUP_SIZE;
+	    (ctx->width + (MB_COMPUTE_GROUP_SIZE - 1)) / MB_COMPUTE_GROUP_SIZE;
 	int tile_count_y =
-	    (post_processing->height + (MB_COMPUTE_GROUP_SIZE - 1)) /
-	    MB_COMPUTE_GROUP_SIZE;
+	    (ctx->height + (MB_COMPUTE_GROUP_SIZE - 1)) / MB_COMPUTE_GROUP_SIZE;
 
 	/* Pass 1: Tile Max Velocity
 	 * Each workgroup (16x16 threads) processes one 16x16 pixel tile,
@@ -127,7 +114,7 @@ void fx_motion_blur_render(PostProcess* post_processing)
 	shader_use(mb_fx->tile_max_shader);
 
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, post_processing->velocity_tex);
+	glBindTexture(GL_TEXTURE_2D, ctx->velocity_tex);
 
 	glBindImageTexture(1, mb_fx->tile_max_tex, 0, GL_FALSE, 0,
 	                   GL_WRITE_ONLY, GL_RG16F);
@@ -166,10 +153,8 @@ void fx_motion_blur_render(PostProcess* post_processing)
 	 * for this stage is therefore unreliable on this driver. */
 }
 
-void fx_motion_blur_update_matrices(PostProcess* post_processing,
-                                    mat4 view_proj)
+void fx_motion_blur_update_matrices(MotionBlurFX* mb_fx, mat4 view_proj)
 {
-	MotionBlurFX* mb_fx = &post_processing->motion_blur_fx;
 	glm_mat4_copy(view_proj, mb_fx->previous_view_proj);
 }
 

--- a/src/postprocess.c
+++ b/src/postprocess.c
@@ -107,14 +107,17 @@ int postprocess_init(PostProcess* post_processing,
 	post_processing->auto_threshold = 1.0F;
 
 	/* Initialisation Motion Blur */
-	if (!fx_motion_blur_init(post_processing)) {
+	if (!fx_motion_blur_init(&post_processing->motion_blur_fx,
+	                         &post_processing->motion_blur)) {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create motion blur resources");
 		/* On continue quand même */
 	}
+	fx_motion_blur_resize(&post_processing->motion_blur_fx,
+	                      post_processing->width, post_processing->height);
 
 	/* Initialisation LUT Viz */
-	if (fx_lut_viz_init(post_processing) != 0) {
+	if (fx_lut_viz_init(&post_processing->lut_viz_fx) != 0) {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create LUT viz resources");
 		/* On continue quand même */
@@ -213,18 +216,18 @@ int postprocess_init(PostProcess* post_processing,
 	glBindBufferBase(GL_UNIFORM_BUFFER, 0, post_processing->settings_ubo);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-	if (!fx_auto_exposure_init(post_processing)) {
+	if (!fx_auto_exposure_init(&post_processing->auto_exposure_fx)) {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create auto exposure resources");
 		destroy_framebuffer(post_processing);
 		fx_bloom_cleanup(&post_processing->bloom_fx);
-		fx_dof_cleanup(post_processing);
+		fx_dof_cleanup(&post_processing->dof_fx);
 		destroy_screen_quad(post_processing);
 		return 0;
 	}
 
 	/* Créer les ressources DoF */
-	if (!fx_dof_init(post_processing)) {
+	if (!fx_dof_init(&post_processing->dof_fx)) {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create dof resources");
 		destroy_framebuffer(post_processing);
@@ -232,9 +235,19 @@ int postprocess_init(PostProcess* post_processing,
 		destroy_screen_quad(post_processing);
 		return 0;
 	}
+	if (!fx_dof_resize(&post_processing->dof_fx, post_processing->width,
+	                   post_processing->height)) {
+		LOG_ERROR("suckless-ogl.postprocess",
+		          "Failed to resize dof resources");
+		fx_dof_cleanup(&post_processing->dof_fx);
+		destroy_framebuffer(post_processing);
+		fx_bloom_cleanup(&post_processing->bloom_fx);
+		destroy_screen_quad(post_processing);
+		return 0;
+	}
 
 	/* Créer les ressources 3D LUT */
-	if (fx_lut3d_init(post_processing) != 0) {
+	if (fx_lut3d_init(&post_processing->lut3d_fx) != 0) {
 		LOG_ERROR("suckless-ogl.postprocess",
 		          "Failed to create 3D LUT resources");
 		/* On continue quand même */
@@ -348,11 +361,11 @@ void postprocess_cleanup(PostProcess* post_processing)
 	SHADER_SAFE_DESTROY(post_processing->postprocess_shader);
 
 	fx_bloom_cleanup(&post_processing->bloom_fx);
-	fx_dof_cleanup(post_processing);
-	fx_auto_exposure_cleanup(post_processing);
-	fx_motion_blur_cleanup(post_processing);
-	fx_lut_viz_cleanup(post_processing);
-	fx_lut3d_cleanup(post_processing);
+	fx_dof_cleanup(&post_processing->dof_fx);
+	fx_auto_exposure_cleanup(&post_processing->auto_exposure_fx);
+	fx_motion_blur_cleanup(&post_processing->motion_blur_fx);
+	fx_lut_viz_cleanup(&post_processing->lut_viz_fx);
+	fx_lut3d_cleanup(&post_processing->lut3d_fx);
 
 	LOG_INFO("suckless-ogl.postprocess", "Post-processing cleaned up");
 }
@@ -391,8 +404,10 @@ void postprocess_resize(PostProcess* post_processing, int width, int height)
 		          "Failed to resize bloom resources");
 	}
 
-	fx_dof_resize(post_processing);
-	fx_motion_blur_resize(post_processing);
+	fx_dof_resize(&post_processing->dof_fx, post_processing->width,
+	              post_processing->height);
+	fx_motion_blur_resize(&post_processing->motion_blur_fx,
+	                      post_processing->width, post_processing->height);
 
 	/* Final Bridge: Ensure ALL used units are in a valid state.
 	 * NVIDIA driver validates units used by the last shader before resize.
@@ -730,7 +745,16 @@ void postprocess_end(PostProcess* post_processing)
 		GPU_STAGE_PROFILER(post_processing->gpu_profiler, "DoF",
 		                   GPU_PROFILER_DOF_COLOR);
 		gl_debug_push_group("PostFX_DepthOfField");
-		fx_dof_render(post_processing);
+		{
+			const EffectContext dof_ctx = {
+			    .src_tex = post_processing->scene_color_tex,
+			    .width = post_processing->width,
+			    .height = post_processing->height,
+			};
+			fx_dof_render(&post_processing->dof_fx,
+			              &post_processing->dof,
+			              &post_processing->bloom_fx, &dof_ctx);
+		}
 		gl_debug_pop_group();
 	}
 
@@ -749,7 +773,18 @@ void postprocess_end(PostProcess* post_processing)
 
 		/* We always need the downsample/luminance pass if either AE or
 		 * Debug is on */
-		fx_auto_exposure_render(post_processing);
+		{
+			const EffectContext ae_ctx = {
+			    .src_tex = post_processing->scene_color_tex,
+			    .width = post_processing->width,
+			    .height = post_processing->height,
+			    .delta_time = post_processing->delta_time,
+			    .gpu_profiler = post_processing->gpu_profiler,
+			};
+			fx_auto_exposure_render(
+			    &post_processing->auto_exposure_fx,
+			    &post_processing->auto_exposure, &ae_ctx);
+		}
 
 		/* Trigger Async Readbacks for current frame (will be ready in
 		 * next frames) */
@@ -792,7 +827,15 @@ void postprocess_end(PostProcess* post_processing)
 		GPU_STAGE_PROFILER(post_processing->gpu_profiler, "MB Compute",
 		                   GPU_PROFILER_MOTION_BLUR_COLOR);
 		gl_debug_push_group("PostFX_MotionBlur_Compute");
-		fx_motion_blur_render(post_processing);
+		{
+			const EffectContext mb_ctx = {
+			    .velocity_tex = post_processing->velocity_tex,
+			    .width = post_processing->width,
+			    .height = post_processing->height,
+			};
+			fx_motion_blur_render(&post_processing->motion_blur_fx,
+			                      &mb_ctx);
+		}
 		gl_debug_pop_group();
 	}
 
@@ -1023,7 +1066,15 @@ void postprocess_end(PostProcess* post_processing)
 		    post_processing->dummy_black_tex);
 
 		/* Render LUT Cube Visualization (if enabled) */
-		fx_lut_viz_render(post_processing);
+		{
+			const EffectContext lut_viz_ctx = {
+			    .width = post_processing->width,
+			    .height = post_processing->height,
+			};
+			fx_lut_viz_render(&post_processing->lut_viz_fx,
+			                  post_processing->lut3d.texture,
+			                  &lut_viz_ctx);
+		}
 
 		gl_debug_pop_group(); /* PostFX_Final_Composite */
 	}
@@ -1233,7 +1284,8 @@ int postprocess_compute_luminance_histogram(PostProcess* post_processing,
 
 void postprocess_update_matrices(PostProcess* post_processing, mat4 view_proj)
 {
-	fx_motion_blur_update_matrices(post_processing, view_proj);
+	fx_motion_blur_update_matrices(&post_processing->motion_blur_fx,
+	                               view_proj);
 }
 
 /* Fonctions privées */
@@ -1543,5 +1595,6 @@ void postprocess_set_lut3d(PostProcess* post_processing, float intensity,
 
 int postprocess_load_lut3d(PostProcess* post_processing, const char* path)
 {
-	return fx_lut3d_load_cube(post_processing, path);
+	return fx_lut3d_load_cube(&post_processing->lut3d_fx,
+	                          &post_processing->lut3d, path);
 }

--- a/src/postprocess_input.c
+++ b/src/postprocess_input.c
@@ -294,8 +294,9 @@ static void handle_fxaa_input(const PostProcessInputContext* ctx, int mods)
 
 static void handle_ae_path_toggle(const PostProcessInputContext* ctx)
 {
-	fx_auto_exposure_toggle_path(ctx->postprocess);
-	const char* pname = fx_auto_exposure_path_name(ctx->postprocess);
+	fx_auto_exposure_toggle_path(&ctx->postprocess->auto_exposure_fx);
+	const char* pname =
+	    fx_auto_exposure_path_name(&ctx->postprocess->auto_exposure_fx);
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "AE Path: %s", pname);
 	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_NORMAL);

--- a/tests/test_fx_lut3d.c
+++ b/tests/test_fx_lut3d.c
@@ -59,7 +59,8 @@ static void test_lut3d_load_invalid_file(void)
 	PostProcess post_proc = {0};
 	postprocess_init(&post_proc, &g_gpu_profiler_system, TEST_WIDTH,
 	                 TEST_HEIGHT);
-	int result = fx_lut3d_load_cube(&post_proc, "non_existent.cube");
+	int result = fx_lut3d_load_cube(&post_proc.lut3d_fx, &post_proc.lut3d,
+	                                "non_existent.cube");
 	TEST_ASSERT_NOT_EQUAL(0, result);
 	postprocess_cleanup(&post_proc);
 }
@@ -88,7 +89,8 @@ static void test_lut3d_load_valid_mock_cube(void)
 	postprocess_init(&post_proc, &g_gpu_profiler_system, TEST_WIDTH,
 	                 TEST_HEIGHT);
 
-	int result = fx_lut3d_load_cube(&post_proc, lut_path);
+	int result =
+	    fx_lut3d_load_cube(&post_proc.lut3d_fx, &post_proc.lut3d, lut_path);
 	TEST_ASSERT_EQUAL(0, result);
 	TEST_ASSERT_NOT_EQUAL(0, post_proc.lut3d.texture);
 
@@ -117,7 +119,8 @@ static void test_lut3d_cleanup_removes_texture(void)
 	PostProcess post_proc = {0};
 	postprocess_init(&post_proc, &g_gpu_profiler_system, TEST_WIDTH,
 	                 TEST_HEIGHT);
-	(void)fx_lut3d_load_cube(&post_proc, lut_path);
+	(void)fx_lut3d_load_cube(&post_proc.lut3d_fx, &post_proc.lut3d,
+	                         lut_path);
 	GLuint tex = post_proc.lut3d.texture;
 	TEST_ASSERT_TRUE(glIsTexture(tex));
 


### PR DESCRIPTION
## Summary

Complete migration of all post-processing effects to the `EffectContext` seam, fully decoupling them from `PostProcess`.

### Changes

**Structural enablers:**
- `effect_context.h`: added `gpu_profiler` field for GPU profiling without PostProcess dependency
- `gpu_profiler.h`: named the anonymous `GPUProfiler` struct for forward declaration support
- `fx_bloom.h`: named the anonymous `BloomFX` struct for forward declaration support

**Effect migrations (all 5 remaining):**
- **fx_lut_viz**: `fx_lut_viz_render(LUTVizFX*, GLuint, const EffectContext*)`
- **fx_lut3d**: `fx_lut3d_load_cube(LUT3DFX*, LUT3DParams*, const char*)` — standalone, no EffectContext needed
- **fx_auto_exposure**: `fx_auto_exposure_render(AutoExposureFX*, AutoExposureParams*, const EffectContext*)`
- **fx_dof**: `fx_dof_render(DoFFX*, DoFParams*, BloomFX*, const EffectContext*)` — borrows bloom shaders
- **fx_motion_blur**: `fx_motion_blur_render(MotionBlurFX*, const EffectContext*)`

**Result:** No effect source file includes `postprocess.h` anymore.

**Call sites:** `postprocess.c` constructs `EffectContext` at each call site. `postprocess_input.c` updated for auto-exposure toggle.

**Docs:** Architecture + lifecycle docs (EN + FR) updated to reflect full migration.

**Tests:** `test_fx_lut3d.c` updated for new signatures. 63/63 tests pass.

Closes #225.