### PR TITLE
refactor(app): opacify AppProfiling + AppInput sub-structs (#226)

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -2,8 +2,6 @@
 #define APP_H
 
 #include "action_notifier.h"
-#include "app_input_state.h"
-#include "app_profiling.h"
 #include "app_ui.h"
 #include "async/async_coordinator.h"
 #include "async_loader.h"
@@ -19,6 +17,10 @@
 #include "ssbo_rendering.h"
 #endif
 
+/* --- Opaque sub-struct forward declarations --- */
+typedef struct AppProfiling AppProfiling;
+typedef struct AppInput AppInput;
+
 /**
  * @struct App
  * @brief The central state container for the entire application.
@@ -33,9 +35,9 @@ typedef struct App {
 	uint64_t frame_count;    /**< Monotonic frame counter. */
 	float* lum_histogram_buffer; /**< Pre-allocated buffer for histogram. */
 
-	/* --- Sub-Modules (RAII/In-Place) --- */
-	AppProfiling profiling; /**< Profiling and metrics sub-system. */
-	AppInput input;       /**< Camera, gamepad, key-bindings sub-system. */
+	/* --- Sub-Modules (Opaque, Heap-Allocated) --- */
+	AppProfiling* profiling; /**< Profiling and metrics sub-system. */
+	AppInput* input;      /**< Camera, gamepad, key-bindings sub-system. */
 	AppUIOverlay overlay; /**< Overlay and text rendering state. */
 
 	/* --- App State Flags and Values --- */

--- a/src/app.c
+++ b/src/app.c
@@ -28,7 +28,18 @@ int app_init(App* app, int width, int height, const char* title)
 	app->width = width;
 	app->height = height;
 
-	app_input_state_init(&app->input);
+	app->input = calloc(1, sizeof(*app->input));
+	if (!app->input) {
+		return 0;
+	}
+	app->profiling = calloc(1, sizeof(*app->profiling));
+	if (!app->profiling) {
+		free(app->input);
+		app->input = NULL;
+		return 0;
+	}
+
+	app_input_state_init(app->input);
 	app->is_fullscreen = false;
 	app->resize_pending = 0;
 	app->scene.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
@@ -46,13 +57,13 @@ int app_init(App* app, int width, int height, const char* title)
 	glfwSetScrollCallback(app->window, scroll_callback);
 	glfwSetFramebufferSizeCallback(app->window, framebuffer_size_callback);
 
-	if (app->input.camera_enabled) {
+	if (app->input->camera_enabled) {
 		glfwSetInputMode(app->window, GLFW_CURSOR,
 		                 GLFW_CURSOR_DISABLED);
 	}
 
 	/* Initialize all profiling sub-systems (needs GL context) */
-	app_profiling_init(&app->profiling, width, height);
+	app_profiling_init(app->profiling, width, height);
 
 	/* Transition Snapshot Initialization (GL Context Ready) */
 	/* Transition Initialization (Starts Black, fades in when IBL is done)
@@ -72,7 +83,7 @@ int app_init(App* app, int width, int height, const char* title)
 		return 0;
 	}
 
-	app->async_loader = async_loader_create(&app->profiling.tracy_mgr);
+	app->async_loader = async_loader_create(&app->profiling->tracy_mgr);
 	if (!app->async_loader) {
 		return 0;
 	}
@@ -105,7 +116,7 @@ int app_init(App* app, int width, int height, const char* title)
 	app->last_frame_time = glfwGetTime();
 	app_ui_init(&app->overlay);
 
-	if (!postprocess_init(&app->postprocess, &app->profiling.gpu_profiler,
+	if (!postprocess_init(&app->postprocess, &app->profiling->gpu_profiler,
 	                      width, height)) {
 		return 0;
 	}
@@ -123,7 +134,7 @@ int app_init(App* app, int width, int height, const char* title)
 	action_notifier_init(&app->notifier);
 
 	effect_benchmark_init(&app->effect_bench, &app->postprocess,
-	                      &app->profiling.gpu_profiler);
+	                      &app->profiling->gpu_profiler);
 
 	return 1;
 }
@@ -149,14 +160,18 @@ void app_cleanup(App* app)
 
 	async_coordinator_cleanup(&app->async_coord);
 
-	app_input_state_cleanup(&app->input);
+	app_input_state_cleanup(app->input);
+	free(app->input);
+	app->input = NULL;
 
 	if (app->lum_histogram_buffer) {
 		free(app->lum_histogram_buffer);
 		app->lum_histogram_buffer = NULL;
 	}
 
-	app_profiling_cleanup(&app->profiling);
+	app_profiling_cleanup(app->profiling);
+	free(app->profiling);
+	app->profiling = NULL;
 
 	window_destroy(app->window);
 	app->window = NULL;
@@ -191,16 +206,16 @@ void app_run(App* app)
 		}
 
 		bool profiling_enabled =
-		    (app->profiling.timeline_ui.visible ||
-		     app->profiling.log_gpu_metrics != 0 ||
+		    (app->profiling->timeline_ui.visible ||
+		     app->profiling->log_gpu_metrics != 0 ||
 		     effect_benchmark_is_running(&app->effect_bench)) != 0;
-		gpu_profiler_set_enabled(&app->profiling.gpu_profiler,
+		gpu_profiler_set_enabled(&app->profiling->gpu_profiler,
 		                         profiling_enabled);
-		gpu_profiler_begin_frame(&app->profiling.gpu_profiler,
+		gpu_profiler_begin_frame(&app->profiling->gpu_profiler,
 		                         app->frame_count);
 
 		/* 1. Global Measure (includes CPU update and GPU swap) */
-		GPU_STAGE_PROFILER(&app->profiling.gpu_profiler, "Total Frame",
+		GPU_STAGE_PROFILER(&app->profiling->gpu_profiler, "Total Frame",
 		                   GPU_PROFILER_TOTAL_FRAME_COLOR);
 
 		{
@@ -209,14 +224,14 @@ void app_run(App* app)
 			double current_time = glfwGetTime();
 			app->delta_time = current_time - app->last_frame_time;
 			app->last_frame_time = current_time;
-			fps_update(&app->profiling.fps_counter, app->delta_time,
-			           current_time);
+			fps_update(&app->profiling->fps_counter,
+			           app->delta_time, current_time);
 			adaptive_sampler_should_sample(
-			    &app->input.fps_sampler, (float)app->delta_time,
+			    &app->input->fps_sampler, (float)app->delta_time,
 			    current_time, app->frame_count);
 			if (adaptive_sampler_is_finished(
-			        &app->input.fps_sampler, current_time)) {
-				adaptive_sampler_reset(&app->input.fps_sampler,
+			        &app->input->fps_sampler, current_time)) {
+				adaptive_sampler_reset(&app->input->fps_sampler,
 				                       current_time);
 			}
 			PROFILE_ZONE_END(timing_ctx);
@@ -229,15 +244,15 @@ void app_run(App* app)
 			app_ui_update(&app->overlay, app->delta_time);
 			postprocess_update_time(&app->postprocess,
 			                        (float)app->delta_time);
-			gpu_usage_update(&app->profiling.gpu_usage);
+			gpu_usage_update(&app->profiling->gpu_usage);
 			PROFILE_ZONE_END(ui_notif_ctx);
 		}
 
 		{
 			PROFILE_ZONE(camera_ctx, "Camera Physics");
 			GamepadActions gp_actions = {0, 0, 0};
-			if (app->input.camera_enabled) {
-				gamepad_input_poll(&app->input.gamepad,
+			if (app->input->camera_enabled) {
+				gamepad_input_poll(&app->input->gamepad,
 				                   &gp_actions);
 			}
 			if (gp_actions.env_next || gp_actions.env_prev) {
@@ -260,35 +275,38 @@ void app_run(App* app)
 				}
 			}
 			if (gp_actions.camera_reset) {
-				camera_init(
-				    &app->input.camera, DEFAULT_CAMERA_DISTANCE,
-				    DEFAULT_CAMERA_YAW, DEFAULT_CAMERA_PITCH);
+				camera_init(&app->input->camera,
+				            DEFAULT_CAMERA_DISTANCE,
+				            DEFAULT_CAMERA_YAW,
+				            DEFAULT_CAMERA_PITCH);
 				app->scene.env_lod = DEFAULT_ENV_LOD;
 				action_notifier_push(&app->notifier,
 				                     "Camera & LOD Reset",
 				                     NOTIF_DUR_LONG);
 			}
-			app->input.camera.physics_accumulator +=
+			app->input->camera.physics_accumulator +=
 			    (float)app->delta_time;
-			while (app->input.camera.physics_accumulator >=
-			       app->input.camera.fixed_timestep) {
-				camera_build_keyboard_input(&app->input.camera);
-				gamepad_write_input(&app->input.gamepad,
-				                    &app->input.camera);
-				camera_fixed_update(&app->input.camera);
-				app->input.camera.physics_accumulator -=
-				    app->input.camera.fixed_timestep;
+			while (app->input->camera.physics_accumulator >=
+			       app->input->camera.fixed_timestep) {
+				camera_build_keyboard_input(
+				    &app->input->camera);
+				gamepad_write_input(&app->input->gamepad,
+				                    &app->input->camera);
+				camera_fixed_update(&app->input->camera);
+				app->input->camera.physics_accumulator -=
+				    app->input->camera.fixed_timestep;
 			}
 
-			float alpha = app->input.camera.rotation_smoothing;
-			app->input.camera.yaw += (app->input.camera.yaw_target -
-			                          app->input.camera.yaw) *
-			                         alpha;
-			app->input.camera.pitch +=
-			    (app->input.camera.pitch_target -
-			     app->input.camera.pitch) *
+			float alpha = app->input->camera.rotation_smoothing;
+			app->input->camera.yaw +=
+			    (app->input->camera.yaw_target -
+			     app->input->camera.yaw) *
 			    alpha;
-			camera_update_vectors(&app->input.camera);
+			app->input->camera.pitch +=
+			    (app->input->camera.pitch_target -
+			     app->input->camera.pitch) *
+			    alpha;
+			camera_update_vectors(&app->input->camera);
 			PROFILE_ZONE_END(camera_ctx);
 		}
 
@@ -329,9 +347,9 @@ void app_run(App* app)
 			RenderContext rctx = {
 			    .scene = &app->scene,
 			    .postprocess = &app->postprocess,
-			    .camera = &app->input.camera,
-			    .profiler = &app->profiling.gpu_profiler,
-			    .profiler_ui = &app->profiling.timeline_ui,
+			    .camera = &app->input->camera,
+			    .profiler = &app->profiling->gpu_profiler,
+			    .profiler_ui = &app->profiling->timeline_ui,
 			    .env_mgr = &app->env_mgr,
 			    .notifier = &app->notifier,
 			    .effect_bench = &app->effect_bench,
@@ -339,7 +357,7 @@ void app_run(App* app)
 			    .height = app->height,
 			    .delta_time = app->delta_time,
 			    .frame_count = app->frame_count,
-			    .log_gpu_metrics = app->profiling.log_gpu_metrics,
+			    .log_gpu_metrics = app->profiling->log_gpu_metrics,
 			    .render_ui = app_render_ui_trampoline,
 			    .render_ui_data = app,
 			};
@@ -350,12 +368,12 @@ void app_run(App* app)
 		{
 			PROFILE_ZONE(tracy_mark_ctx, "Tracy Mark/Screenshots");
 			tracy_manager_update_screenshots(
-			    &app->profiling.tracy_mgr, app);
+			    &app->profiling->tracy_mgr, app);
 			PROFILE_ZONE_END(tracy_mark_ctx);
 		}
 
 		{
-			GPU_STAGE_PROFILER(&app->profiling.gpu_profiler,
+			GPU_STAGE_PROFILER(&app->profiling->gpu_profiler,
 			                   "Swap Buffers",
 			                   GPU_PROFILER_UI_COLOR);
 			PROFILE_ZONE(swap_ctx, "GLFW SwapBuffers");

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -2,6 +2,8 @@
 
 #include "action_notifier.h"
 #include "app.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
 #include "app_settings.h"
 #include "app_ui.h"
 #include "camera.h"
@@ -33,20 +35,20 @@ static inline AppInputContext app_input_ctx_from_app(App* app)
 {
 	return (AppInputContext){
 	    .window = app->window,
-	    .camera = &app->input.camera,
+	    .camera = &app->input->camera,
 	    .scene = &app->scene,
 	    .postprocess = &app->postprocess,
 	    .env_mgr = &app->env_mgr,
 	    .notifier = &app->notifier,
 	    .overlay = &app->overlay,
-	    .timeline_ui = &app->profiling.timeline_ui,
+	    .timeline_ui = &app->profiling->timeline_ui,
 	    .effect_bench = &app->effect_bench,
-	    .perf_context = &app->profiling.perf_context,
-	    .gamepad = &app->input.gamepad,
+	    .perf_context = &app->profiling->perf_context,
+	    .gamepad = &app->input->gamepad,
 	    .async_loader = app->async_loader,
 	    .width = &app->width,
 	    .height = &app->height,
-	    .camera_enabled = &app->input.camera_enabled,
+	    .camera_enabled = &app->input->camera_enabled,
 	    .is_fullscreen = &app->is_fullscreen,
 	    .saved_x = &app->saved_x,
 	    .saved_y = &app->saved_y,
@@ -55,8 +57,8 @@ static inline AppInputContext app_input_ctx_from_app(App* app)
 	    .resize_pending = &app->resize_pending,
 	    .pending_width = &app->pending_width,
 	    .pending_height = &app->pending_height,
-	    .perf_mode_active = &app->profiling.perf_mode_active,
-	    .log_gpu_metrics = &app->profiling.log_gpu_metrics,
+	    .perf_mode_active = &app->profiling->perf_mode_active,
+	    .log_gpu_metrics = &app->profiling->log_gpu_metrics,
 	};
 }
 

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -4,6 +4,8 @@
 #include "adaptive_sampler.h"
 #include "app.h"
 #include "app_binding.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
 #include "app_settings.h"
 #include "glad/glad.h"
 #include "nbody.h"
@@ -605,8 +607,8 @@ static void gp_overlay_poll_active(const App* app,
 		active[i] = false;
 	}
 	GLFWgamepadstate gp_state;
-	if (!glfwJoystickIsGamepad(app->input.gamepad.joystick_id) ||
-	    !glfwGetGamepadState(app->input.gamepad.joystick_id, &gp_state)) {
+	if (!glfwJoystickIsGamepad(app->input->gamepad.joystick_id) ||
+	    !glfwGetGamepadState(app->input->gamepad.joystick_id, &gp_state)) {
 		return;
 	}
 	for (int i = 0; i < GAMEPAD_LAYOUT_COUNT; i++) {
@@ -617,12 +619,12 @@ static void gp_overlay_poll_active(const App* app,
 		}
 		if (gpc->gp_axis >= 0 &&
 		    gp_axis_active(gp_state.axes, gpc->gp_axis,
-		                   &app->input.gamepad)) {
+		                   &app->input->gamepad)) {
 			active[i] = true;
 		}
 		if (gpc->gp_axis2 >= 0 &&
 		    gp_axis_active(gp_state.axes, gpc->gp_axis2,
-		                   &app->input.gamepad)) {
+		                   &app->input->gamepad)) {
 			active[i] = true;
 		}
 	}
@@ -826,14 +828,15 @@ static void draw_help_overlay_keys(const App* app, float start_x, float start_y,
 	const float global_dim_mult = (float)app->overlay.help_global_dim;
 	int effective_mods = 0;
 	(void)get_active_binding(
-	    &app->input.binding_registry, app->overlay.help_pressed_key,
+	    &app->input->binding_registry, app->overlay.help_pressed_key,
 	    app->overlay.help_pressed_mods, &effective_mods);
 
 	int hovered_effective_mods = 0;
 	if (app->overlay.help_hovered_key != -1) {
-		(void)get_active_binding(
-		    &app->input.binding_registry, app->overlay.help_hovered_key,
-		    app->overlay.help_pressed_mods, &hovered_effective_mods);
+		(void)get_active_binding(&app->input->binding_registry,
+		                         app->overlay.help_hovered_key,
+		                         app->overlay.help_pressed_mods,
+		                         &hovered_effective_mods);
 	}
 
 	const unsigned int num_keys =
@@ -853,7 +856,7 @@ static void draw_help_overlay_keys(const App* app, float start_x, float start_y,
 
 		vec3 base_col;
 		bool has_binding = false;
-		get_key_base_color(&app->input.binding_registry, kpos->key,
+		get_key_base_color(&app->input->binding_registry, kpos->key,
 		                   base_col, &has_binding);
 
 		bool is_pressed = is_key_active_in_overlay(
@@ -890,7 +893,7 @@ static void draw_help_overlay_keys(const App* app, float start_x, float start_y,
 		if (is_pressed || is_hovered) {
 			vec3 base_col;
 			bool has_binding = false;
-			get_key_base_color(&app->input.binding_registry,
+			get_key_base_color(&app->input->binding_registry,
 			                   kpos->key, base_col, &has_binding);
 			if (is_pressed || is_hovered) {
 				glm_vec3_clamp(base_col, KEY_PRESS_BRIGHTEN_MIN,
@@ -928,7 +931,7 @@ static void draw_help_overlay_keys(const App* app, float start_x, float start_y,
 		                          ? app->overlay.help_pressed_mods
 		                          : 0;
 		const AppBinding* binding = get_active_binding(
-		    &app->input.binding_registry, target_key, desc_mods, NULL);
+		    &app->input->binding_registry, target_key, desc_mods, NULL);
 
 		if (binding != NULL) {
 			/* Show detailed description below help */
@@ -1074,11 +1077,12 @@ static void draw_main_info_overlay(const App* app, UILayout* layout)
 	float current_fps = 0.0F;
 	float frame_time_ms = 0.0F;
 
-	if (app->profiling.fps_counter.average_frame_time > 0.0F) {
+	if (app->profiling->fps_counter.average_frame_time > 0.0F) {
 		current_fps =
-		    1.0F / (float)app->profiling.fps_counter.average_frame_time;
+		    1.0F /
+		    (float)app->profiling->fps_counter.average_frame_time;
 		frame_time_ms =
-		    (float)app->profiling.fps_counter.average_frame_time *
+		    (float)app->profiling->fps_counter.average_frame_time *
 		    MS_PER_SECOND;
 	}
 
@@ -1087,11 +1091,11 @@ static void draw_main_info_overlay(const App* app, UILayout* layout)
 	ui_layout_text(layout, fps_text, DEFAULT_FONT_COLOR);
 
 	/* GPU Utilization (via DRM fdinfo, same as MangoHud) */
-	if (gpu_usage_is_available(&app->profiling.gpu_usage)) {
+	if (gpu_usage_is_available(&app->profiling->gpu_usage)) {
 		char gpu_text[MAX_FPS_TEXT_LENGTH];
 		(void)safe_snprintf(
 		    gpu_text, sizeof(gpu_text), "GPU: %.0f%%",
-		    gpu_usage_get_load(&app->profiling.gpu_usage));
+		    gpu_usage_get_load(&app->profiling->gpu_usage));
 		ui_layout_text(layout, gpu_text, DEFAULT_FONT_COLOR);
 	}
 
@@ -1099,7 +1103,7 @@ static void draw_main_info_overlay(const App* app, UILayout* layout)
 		static const size_t AVG_TEXT_SIZE = 64;
 		char avg_text[AVG_TEXT_SIZE];
 		float sampled_avg =
-		    adaptive_sampler_get_average(&app->input.fps_sampler);
+		    adaptive_sampler_get_average(&app->input->fps_sampler);
 		(void)safe_snprintf(avg_text, sizeof(avg_text),
 		                    "Sampled Avg: %.2f", sampled_avg);
 		ui_layout_text(layout, avg_text, DEFAULT_FONT_COLOR);
@@ -1108,9 +1112,9 @@ static void draw_main_info_overlay(const App* app, UILayout* layout)
 	/* 2. Position */
 	char pos_text[DEBUG_TEXT_BUFFER_SIZE];
 	(void)safe_snprintf(pos_text, sizeof(pos_text), "Pos: %.1f, %.1f, %.1f",
-	                    app->input.camera.position[0],
-	                    app->input.camera.position[1],
-	                    app->input.camera.position[2]);
+	                    app->input->camera.position[0],
+	                    app->input->camera.position[1],
+	                    app->input->camera.position[2]);
 	ui_layout_text(layout, pos_text, DEFAULT_FONT_COLOR);
 
 	/* 3. Environment */
@@ -1300,8 +1304,8 @@ void app_render_ui(const App* app)
 		app_draw_gamepad_help_overlay(app);
 	}
 
-	gpu_profiler_ui_draw((GPUProfilerUI*)&app->profiling.timeline_ui,
-	                     ui_ctx, app->width, app->height);
+	gpu_profiler_ui_draw(&app->profiling->timeline_ui, ui_ctx, app->width,
+	                     app->height);
 	action_notifier_draw((ActionNotifier*)&app->notifier, ui_ctx,
 	                     app->width, app->height);
 

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -1,5 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include "app.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
 #include "camera.h"
 #include "main.h"
 #include "postprocess_presets.h"
@@ -97,9 +99,9 @@ static RenderContext test_render_ctx_from_app(App* app)
 	return (RenderContext){
 	    .scene = &app->scene,
 	    .postprocess = &app->postprocess,
-	    .camera = &app->input.camera,
-	    .profiler = &app->profiling.gpu_profiler,
-	    .profiler_ui = &app->profiling.timeline_ui,
+	    .camera = &app->input->camera,
+	    .profiler = &app->profiling->gpu_profiler,
+	    .profiler_ui = &app->profiling->timeline_ui,
 	    .env_mgr = &app->env_mgr,
 	    .notifier = &app->notifier,
 	    .effect_bench = &app->effect_bench,
@@ -107,7 +109,7 @@ static RenderContext test_render_ctx_from_app(App* app)
 	    .height = app->height,
 	    .delta_time = app->delta_time,
 	    .frame_count = app->frame_count,
-	    .log_gpu_metrics = app->profiling.log_gpu_metrics,
+	    .log_gpu_metrics = app->profiling->log_gpu_metrics,
 	    .render_ui = test_render_ui_trampoline,
 	    .render_ui_data = app,
 	};
@@ -389,14 +391,14 @@ static void pipeline_run_test_loop(const char* test_tag,
 			const ViewPoint* vpoint = &G_VIEWPOINTS[i];
 			glm_vec3_copy((vec3){vpoint->pos[0], vpoint->pos[1],
 			                     vpoint->pos[2]},
-			              g_test_app.input.camera.position);
+			              g_test_app.input->camera.position);
 			glm_vec3_copy(
 			    (vec3){vpoint->world_up[0], vpoint->world_up[1],
 			           vpoint->world_up[2]},
-			    g_test_app.input.camera.world_up);
-			g_test_app.input.camera.yaw = vpoint->yaw;
-			g_test_app.input.camera.pitch = vpoint->pitch;
-			camera_update_vectors(&g_test_app.input.camera);
+			    g_test_app.input->camera.world_up);
+			g_test_app.input->camera.yaw = vpoint->yaw;
+			g_test_app.input->camera.pitch = vpoint->pitch;
+			camera_update_vectors(&g_test_app.input->camera);
 
 			if (pre_render) {
 				pre_render(vpoint, user_data);
@@ -504,7 +506,7 @@ static void apply_subtle_auto_exposure(const ViewPoint* vpoint, void* data)
 	postprocess_enable(&g_test_app.postprocess, POSTFX_AUTO_EXPOSURE);
 	postprocess_disable(&g_test_app.postprocess, POSTFX_VIGNETTE);
 	postprocess_disable(&g_test_app.postprocess, POSTFX_GRAIN);
-	g_test_app.profiling.log_gpu_metrics = 1;
+	g_test_app.profiling->log_gpu_metrics = 1;
 
 	// Note: warmup frames are handled inside the app_update cycles in the
 	// main loop. We might need a special case for this if 16 frames is not
@@ -568,19 +570,19 @@ static void pre_render_motion_blur(const ViewPoint* vpoint, void* data)
 	// generating deterministic velocity vectors.
 	float angle_disp = ANGLE_DISPLACEMENT;
 	if (strcmp(vpoint->name, "front") == 0) {
-		g_test_app.input.camera.yaw -= angle_disp;
+		g_test_app.input->camera.yaw -= angle_disp;
 	} else if (strcmp(vpoint->name, "back") == 0) {
-		g_test_app.input.camera.yaw += angle_disp;
+		g_test_app.input->camera.yaw += angle_disp;
 	} else if (strcmp(vpoint->name, "left") == 0) {
-		g_test_app.input.camera.pitch -= angle_disp;
+		g_test_app.input->camera.pitch -= angle_disp;
 	} else if (strcmp(vpoint->name, "right") == 0) {
-		g_test_app.input.camera.pitch += angle_disp;
+		g_test_app.input->camera.pitch += angle_disp;
 	} else if (strcmp(vpoint->name, "top") == 0) {
-		g_test_app.input.camera.pitch -= angle_disp;
+		g_test_app.input->camera.pitch -= angle_disp;
 	} else if (strcmp(vpoint->name, "bottom") == 0) {
-		g_test_app.input.camera.pitch += angle_disp;
+		g_test_app.input->camera.pitch += angle_disp;
 	}
-	camera_update_vectors(&g_test_app.input.camera);
+	camera_update_vectors(&g_test_app.input->camera);
 
 	app_update(&g_test_app);
 	{
@@ -589,9 +591,9 @@ static void pre_render_motion_blur(const ViewPoint* vpoint, void* data)
 	}
 
 	// Restore camera to exact baseline for the pipeline's capture render
-	g_test_app.input.camera.yaw = vpoint->yaw;
-	g_test_app.input.camera.pitch = vpoint->pitch;
-	camera_update_vectors(&g_test_app.input.camera);
+	g_test_app.input->camera.yaw = vpoint->yaw;
+	g_test_app.input->camera.pitch = vpoint->pitch;
+	camera_update_vectors(&g_test_app.input->camera);
 }
 
 static void pre_render_sony_a7siii(const ViewPoint* vpoint, void* data)
@@ -643,7 +645,7 @@ static void test_app_camera_initialization(void)
 	                         "App should be initialized");
 
 	// Verify camera is properly initialized
-	TEST_ASSERT_GREATER_THAN_FLOAT(0.0F, g_test_app.input.camera.zoom);
+	TEST_ASSERT_GREATER_THAN_FLOAT(0.0F, g_test_app.input->camera.zoom);
 }
 
 /**

--- a/tests/test_app_input.c
+++ b/tests/test_app_input.c
@@ -2,6 +2,8 @@
 
 #include "app.h"
 #include "app_input.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
 #include "camera_input.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
@@ -14,20 +16,20 @@ static AppInputContext test_ctx_from_app(App* app)
 {
 	return (AppInputContext){
 	    .window = app->window,
-	    .camera = &app->input.camera,
+	    .camera = &app->input->camera,
 	    .scene = &app->scene,
 	    .postprocess = &app->postprocess,
 	    .env_mgr = &app->env_mgr,
 	    .notifier = &app->notifier,
 	    .overlay = &app->overlay,
-	    .timeline_ui = &app->profiling.timeline_ui,
+	    .timeline_ui = &app->profiling->timeline_ui,
 	    .effect_bench = &app->effect_bench,
-	    .perf_context = &app->profiling.perf_context,
-	    .gamepad = &app->input.gamepad,
+	    .perf_context = &app->profiling->perf_context,
+	    .gamepad = &app->input->gamepad,
 	    .async_loader = app->async_loader,
 	    .width = &app->width,
 	    .height = &app->height,
-	    .camera_enabled = &app->input.camera_enabled,
+	    .camera_enabled = &app->input->camera_enabled,
 	    .is_fullscreen = &app->is_fullscreen,
 	    .saved_x = &app->saved_x,
 	    .saved_y = &app->saved_y,
@@ -36,8 +38,8 @@ static AppInputContext test_ctx_from_app(App* app)
 	    .resize_pending = &app->resize_pending,
 	    .pending_width = &app->pending_width,
 	    .pending_height = &app->pending_height,
-	    .perf_mode_active = &app->profiling.perf_mode_active,
-	    .log_gpu_metrics = &app->profiling.log_gpu_metrics,
+	    .perf_mode_active = &app->profiling->perf_mode_active,
+	    .log_gpu_metrics = &app->profiling->log_gpu_metrics,
 	};
 }
 
@@ -66,10 +68,12 @@ void setUp(void)
 	glfwSetWindowUserPointer(test_app->window, test_app);
 
 	/* Initialize sub-systems to avoid segfaults */
+	test_app->profiling = calloc(1, sizeof(*test_app->profiling));
+	test_app->input = calloc(1, sizeof(*test_app->input));
 	action_notifier_init(&test_app->notifier);
-	gpu_profiler_init(&test_app->profiling.gpu_profiler);
+	gpu_profiler_init(&test_app->profiling->gpu_profiler);
 	effect_benchmark_init(&test_app->effect_bench, &test_app->postprocess,
-	                      &test_app->profiling.gpu_profiler);
+	                      &test_app->profiling->gpu_profiler);
 	test_app->postprocess.active_effects = 0;
 	test_app->width = 640;
 	test_app->height = 480;
@@ -80,6 +84,8 @@ void tearDown(void)
 	if (test_app->window) {
 		glfwDestroyWindow(test_app->window);
 	}
+	free(test_app->profiling);
+	free(test_app->input);
 	free(test_app);
 	glfwTerminate();
 }
@@ -115,13 +121,13 @@ void test_handle_app_input_exhaustive(void)
 	handle_app_input(&ctx, GLFW_KEY_F2, 0);
 	TEST_ASSERT_EQUAL(HELP_MODE_KEYBOARD, test_app->overlay.show_help);
 	handle_app_input(&ctx, GLFW_KEY_F3, 0);
-	TEST_ASSERT_TRUE(test_app->profiling.timeline_ui.visible);
+	TEST_ASSERT_TRUE(test_app->profiling->timeline_ui.visible);
 	handle_app_input(&ctx, GLFW_KEY_F4, 0);
-	TEST_ASSERT_TRUE(test_app->profiling.log_gpu_metrics);
+	TEST_ASSERT_TRUE(test_app->profiling->log_gpu_metrics);
 	handle_app_input(&ctx, GLFW_KEY_Z, 0);
 	TEST_ASSERT_TRUE(test_app->scene.wireframe);
 	handle_app_input(&ctx, GLFW_KEY_C, 0);
-	TEST_ASSERT_TRUE(test_app->input.camera_enabled);
+	TEST_ASSERT_TRUE(test_app->input->camera_enabled);
 	handle_app_input(&ctx, GLFW_KEY_L, 0);
 	TEST_ASSERT_TRUE(test_app->scene.billboard_mode);
 	handle_app_input(&ctx, GLFW_KEY_K, 0);
@@ -254,12 +260,12 @@ void test_camera_movement_keys(void)
 	int keys[] = {GLFW_KEY_W, GLFW_KEY_S, GLFW_KEY_A,
 	              GLFW_KEY_D, GLFW_KEY_Q, GLFW_KEY_E};
 	for (int i = 0; i < 6; i++) {
-		camera_input_handle_key(&test_app->input.camera, keys[i],
+		camera_input_handle_key(&test_app->input->camera, keys[i],
 		                        GLFW_PRESS);
 		/* Check some flag in camera. W should set move_forward, etc.
 		   But since we don't assert every single one, just ensure it
 		   doesn't crash and covers the lines. */
-		camera_input_handle_key(&test_app->input.camera, keys[i],
+		camera_input_handle_key(&test_app->input->camera, keys[i],
 		                        GLFW_RELEASE);
 	}
 }
@@ -273,14 +279,14 @@ void test_camera_movement_keys(void)
  */
 void test_mouse_and_scroll_exhaustive(void)
 {
-	test_app->input.camera_enabled = true;
-	test_app->input.camera.first_mouse = 1;
+	test_app->input->camera_enabled = true;
+	test_app->input->camera.first_mouse = 1;
 	mouse_callback(test_app->window, 100.0, 100.0);
 	mouse_callback(test_app->window, 110.0, 120.0);
 	TEST_ASSERT_EQUAL_FLOAT(110.0F,
-	                        (float)test_app->input.camera.last_mouse_x);
+	                        (float)test_app->input->camera.last_mouse_x);
 	TEST_ASSERT_EQUAL_FLOAT(120.0F,
-	                        (float)test_app->input.camera.last_mouse_y);
+	                        (float)test_app->input->camera.last_mouse_y);
 
 	scroll_callback(test_app->window, 0.0, 1.0);
 	scroll_callback(test_app->window, 0.0, -1.0);

--- a/tests/test_stencil_masking.c
+++ b/tests/test_stencil_masking.c
@@ -1,5 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include "app.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
 #include "gl_common.h"
 #include "main.h"
 #include "renderer.h"
@@ -29,9 +31,9 @@ static RenderContext test_render_ctx_from_app(App* app)
 	return (RenderContext){
 	    .scene = &app->scene,
 	    .postprocess = &app->postprocess,
-	    .camera = &app->input.camera,
-	    .profiler = &app->profiling.gpu_profiler,
-	    .profiler_ui = &app->profiling.timeline_ui,
+	    .camera = &app->input->camera,
+	    .profiler = &app->profiling->gpu_profiler,
+	    .profiler_ui = &app->profiling->timeline_ui,
 	    .env_mgr = &app->env_mgr,
 	    .notifier = &app->notifier,
 	    .effect_bench = &app->effect_bench,
@@ -39,7 +41,7 @@ static RenderContext test_render_ctx_from_app(App* app)
 	    .height = app->height,
 	    .delta_time = app->delta_time,
 	    .frame_count = app->frame_count,
-	    .log_gpu_metrics = app->profiling.log_gpu_metrics,
+	    .log_gpu_metrics = app->profiling->log_gpu_metrics,
 	    .render_ui = test_render_ui_trampoline,
 	    .render_ui_data = app,
 	};
@@ -76,12 +78,12 @@ void test_stencil_depth_consistency(void)
 	/* 1. Ensure scene is ready */
 
 	/* 2. Set camera to look at center area */
-	g_test_app.input.camera.position[0] = 0.0F;
-	g_test_app.input.camera.position[1] = 0.0F;
-	g_test_app.input.camera.position[2] = TEST_CAMERA_Z;
-	g_test_app.input.camera.yaw = TEST_CAMERA_YAW;
-	g_test_app.input.camera.pitch = TEST_CAMERA_PITCH;
-	camera_update_vectors(&g_test_app.input.camera);
+	g_test_app.input->camera.position[0] = 0.0F;
+	g_test_app.input->camera.position[1] = 0.0F;
+	g_test_app.input->camera.position[2] = TEST_CAMERA_Z;
+	g_test_app.input->camera.yaw = TEST_CAMERA_YAW;
+	g_test_app.input->camera.pitch = TEST_CAMERA_PITCH;
+	camera_update_vectors(&g_test_app.input->camera);
 
 	/* 3. Wait for scene to be ready */
 	for (int i = 0; i < POLL_TIMEOUT; i++) {


### PR DESCRIPTION
## Summary

Opacify `AppProfiling` and `AppInput` sub-structs in `App` — replace value members with heap-allocated opaque pointers to break the include cascade from `app.h`.

### Changes

- **`include/app.h`**: Remove 2 includes (`app_profiling.h`, `app_input_state.h`), add forward declarations, change value members to `AppProfiling*` / `AppInput*`
- **`src/app.c`**: Heap-allocate in `app_init()`, free in `app_cleanup()`, update all access sites
- **`src/app_input.c`**, **`src/app_ui.c`**: Add concrete includes, update access patterns, remove redundant cast
- **`tests/test_app.c`**, **`tests/test_stencil_masking.c`**: Add concrete includes, update access patterns
- **`tests/test_app_input.c`**: Add `calloc`/`free` for sub-structs in setUp/tearDown (no `app_init`)

### Metrics

- `app.h` includes: 14 → 12 (11 unconditional + 1 conditional `#ifdef`)
- 141 access sites updated across 7 files
- 7 files changed, 166 insertions, 130 deletions

### Testing

- Build: clean (0 warnings)
- Lint: 0 failures
- Tests: 63/63 pass

Closes #226