### PR TITLE
refactor(scene): deepen Scene decomposition — extract GPU resources, shaders, and config (#224)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,13 +18,14 @@ Repository: [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
 | Subsystem | Key Files |
 |-----------|-----------|
 | **Core App** | `app.c`, `main.c`, `cli.c` |
+| **Scene** | `scene.c`, `scene.h`, `scene_gpu_resources.h`, `scene_shaders.h`, `scene_config.h`, `scene_visuals.h`, `scene_lighting.h`, `scene_simulation.h` |
 | **Rendering** | `renderer.c` (`RenderContext`), `sphere_types.h`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
 | **PBR / IBL** | `pbr.c`, `material.c`, `ibl_coordinator.c`, `light_probes.c`, `skybox.c` |
 | **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur), `effect_context.h` (`EffectContext` seam) |
 | **Shaders** | 55+ GLSL files in `shaders/` (vertex, fragment, compute) |
 | **Input** | `app_input.c` (`AppInputContext`), `camera_input.c`, `postprocess_input.c` (`PostProcessInputContext`), `app_binding.c` |
 | **Profiling** | `gpu_profiler.c`, `perf_timer.c`, `tracy_manager.c`, `effect_benchmark.c` |
-| **Tests** | 59 test files in `tests/` (Unity framework, visual regression, benchmarks) |
+| **Tests** | 63 test files in `tests/` (Unity framework, visual regression, benchmarks) |
 
 ## Build & Test
 

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -60,15 +60,18 @@ App
     └── EffectContext  (seam vers les effets individuels)
 ```
 
-### Décomposition de Scene (SceneVisuals, SceneSimulation, SceneLighting)
+### Décomposition de Scene
 
-La structure `Scene` est progressivement décomposée en sous-structs par domaine :
+La structure `Scene` est entièrement décomposée en six sous-structs par domaine, chacune dans son propre header :
 
-- **`SceneVisuals`** (`include/scene.h`) : regroupe les effets visuels — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Accès via `scene->visuals.skybox`, etc.
-- **`SceneSimulation`** (`include/scene.h`) : regroupe l'état N-body — `NBodySim`, `nbody_mode`. Accès via `scene->simulation.nbody_sim`, etc.
-- **`SceneLighting`** (`include/scene.h`) : regroupe IBL, probes et matériaux — `IBLCoordinator`, `LightProbeGrid`, `MaterialLib*`. Accès via `scene->lighting.ibl_coord`, etc.
+- **`SceneGPUResources`** (`include/scene_gpu_resources.h`) : tous les handles de ressources GPU — 28 GLuint pour textures, buffers, VAOs, programmes compute, plus le billboard UBO et les caches de binding IBL/SH. Accès via `scene->gpu.hdr_texture`, `scene->gpu.icosphere_vbo`, etc.
+- **`SceneShaders`** (`include/scene_shaders.h`) : tous les pointeurs de shaders — `pbr_instanced`, `pbr_billboard`, `debug`, `debug_line`, `skybox` (+ conditionnel `pbr_ssbo`). Accès via `scene->shaders.pbr_instanced`, etc.
+- **`SceneConfig`** (`include/scene_config.h`) : configuration runtime — `wireframe`, `billboard_mode`, `sorting_mode`, `pbr_debug_mode`, `show_envmap`, `env_lod`, `subdivisions`, `gi_mode`, `show_probe_grid`, `specular_aa_enabled`, `aa_mode`. Définit aussi les enums `SortingMode`, `GIMode`, `AAMode`. Accès via `scene->config.wireframe`, etc.
+- **`SceneVisuals`** (`include/scene_visuals.h`) : effets visuels — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Accès via `scene->visuals.skybox`, etc.
+- **`SceneSimulation`** (`include/scene_simulation.h`) : état N-body — `NBodySim`, `nbody_mode`. Accès via `scene->simulation.nbody_sim`, etc.
+- **`SceneLighting`** (`include/scene_lighting.h`) : IBL, probes et matériaux — `IBLCoordinator`, `LightProbeGrid`, `MaterialLib*`. Accès via `scene->lighting.ibl_coord`, etc.
 
-Cela réduit le nombre de champs directs de `Scene` et localise les changements par domaine.
+Cela réduit le nombre de champs directs de `Scene` de ~50 à ~19 et déplace les définitions de types par domaine hors du monolithique `scene.h`.
 
 ### Décomposition de App (AppProfiling, AppInput)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,15 +100,18 @@ To avoid cyclic dependencies:
 - Module headers are included at the **end** of `app.h` to ensure they can see the full `App` definition if necessary (though they primarily use pointers).
 - Specialized source files (`.c`) include `app.h` and the required renderer headers directly.
 
-### Scene Decomposition (SceneVisuals, SceneSimulation, SceneLighting)
+### Scene Decomposition
 
-The `Scene` struct is being decomposed into domain-aligned sub-structs:
+The `Scene` struct is fully decomposed into six domain-aligned sub-structs, each in its own header:
 
-- **`SceneVisuals`** (`include/scene.h`): Groups visual effects — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Access via `scene->visuals.skybox`, etc.
-- **`SceneSimulation`** (`include/scene.h`): Groups N-body state — `NBodySim`, `nbody_mode`. Access via `scene->simulation.nbody_sim`, etc.
-- **`SceneLighting`** (`include/scene.h`): Groups IBL, probes, and materials — `IBLCoordinator`, `LightProbeGrid`, `MaterialLib*`. Access via `scene->lighting.ibl_coord`, etc.
+- **`SceneGPUResources`** (`include/scene_gpu_resources.h`): All GPU resource handles — 28 GLuint handles for textures, buffers, VAOs, compute programs, plus billboard UBO and IBL/SH binding caches. Access via `scene->gpu.hdr_texture`, `scene->gpu.icosphere_vbo`, etc.
+- **`SceneShaders`** (`include/scene_shaders.h`): All shader pointers — `pbr_instanced`, `pbr_billboard`, `debug`, `debug_line`, `skybox` (+ conditional `pbr_ssbo`). Access via `scene->shaders.pbr_instanced`, etc.
+- **`SceneConfig`** (`include/scene_config.h`): Runtime configuration — `wireframe`, `billboard_mode`, `sorting_mode`, `pbr_debug_mode`, `show_envmap`, `env_lod`, `subdivisions`, `gi_mode`, `show_probe_grid`, `specular_aa_enabled`, `aa_mode`. Also defines `SortingMode`, `GIMode`, `AAMode` enums. Access via `scene->config.wireframe`, etc.
+- **`SceneVisuals`** (`include/scene_visuals.h`): Visual effects — `Skybox`, `TrailRenderer`, `ShockwaveRenderer`. Access via `scene->visuals.skybox`, etc.
+- **`SceneSimulation`** (`include/scene_simulation.h`): N-body state — `NBodySim`, `nbody_mode`. Access via `scene->simulation.nbody_sim`, etc.
+- **`SceneLighting`** (`include/scene_lighting.h`): IBL, probes, and materials — `IBLCoordinator`, `LightProbeGrid`, `MaterialLib*`. Access via `scene->lighting.ibl_coord`, etc.
 
-This reduces `Scene`'s direct field count and localizes domain-specific changes.
+This reduces `Scene`'s direct field count from ~50 to ~19 and moves domain-specific type definitions out of the monolithic `scene.h`.
 
 ### App Decomposition (AppProfiling, AppInput)
 

--- a/docs/project_structure.fr.md
+++ b/docs/project_structure.fr.md
@@ -16,6 +16,15 @@ suckless-ogl/
 │   ├── app_binding.c     # Registre des raccourcis
 │   └── platform/         # Couche de portabilité
 ├── include/              # En-têtes C
+│   ├── app.h             # Structure App principale
+│   ├── scene.h           # Agrégat Scene (inclut les sous-structs)
+│   ├── scene_config.h    # SceneConfig : flags runtime et enums
+│   ├── scene_gpu_resources.h # SceneGPUResources : handles GLuint
+│   ├── scene_lighting.h  # SceneLighting : IBL, probes, matériaux
+│   ├── scene_shaders.h   # SceneShaders : pointeurs Shader
+│   ├── scene_simulation.h # SceneSimulation : état N-body
+│   ├── scene_visuals.h   # SceneVisuals : skybox, trails, shockwave
+│   └── ...
 ├── shaders/              # Shaders GLSL
 │   ├── pbr.vert/.frag    # Shader PBR principal
 │   ├── skybox.vert/.frag # Rendu de la skybox

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -36,6 +36,13 @@ icosphere/
 │   ├── app_input.h
 │   ├── app_scene.h
 │   ├── app_ui.h
+│   ├── scene.h             # Scene aggregate (includes sub-structs)
+│   ├── scene_config.h      # SceneConfig: runtime flags & enums
+│   ├── scene_gpu_resources.h # SceneGPUResources: GLuint handles
+│   ├── scene_lighting.h    # SceneLighting: IBL, probes, materials
+│   ├── scene_shaders.h     # SceneShaders: Shader pointers
+│   ├── scene_simulation.h  # SceneSimulation: N-body state
+│   ├── scene_visuals.h     # SceneVisuals: skybox, trails, shockwave
 │   └── ...
 │
 ├── shaders/

--- a/include/scene.h
+++ b/include/scene.h
@@ -4,18 +4,14 @@
 #include "app_settings.h"
 #include "billboard_rendering.h"
 #include "billboard_sorting.h"
-#include "gl_common.h"
-#include "gpu_profiler.h"
-#include "ibl_coordinator.h"
 #include "icosphere.h"
 #include "instanced_rendering.h"
-#include "light_probes.h"
-#include "material.h"
-#include "nbody.h"
-#include "shader.h"
-#include "shockwave.h"
-#include "skybox.h"
-#include "trail_renderer.h"
+#include "scene_config.h"
+#include "scene_gpu_resources.h"
+#include "scene_lighting.h"
+#include "scene_shaders.h"
+#include "scene_simulation.h"
+#include "scene_visuals.h"
 #include <cglm/cglm.h>
 
 #ifdef USE_SSBO_RENDERING
@@ -23,46 +19,12 @@
 #endif
 
 typedef struct PostProcess PostProcess;
-
-/**
- * @enum SortingMode
- * @brief Sorting algorithms for transparent billboards.
- */
-typedef enum {
-	SORTING_MODE_CPU_QSORT = 0,
-	SORTING_MODE_CPU_RADIX,
-	SORTING_MODE_GPU_BITONIC,
-	SORTING_MODE_COUNT /**< Sentinel — must remain last. */
-} SortingMode;
-
-/**
- * @enum GIMode
- * @brief Global Illumination sampling methods.
- */
-typedef enum {
-	GI_MODE_OFF = 0,
-	GI_MODE_3D_TEX,
-	GI_MODE_SSBO,
-	GI_MODE_COUNT
-} GIMode;
-
-/**
- * @enum AAMode
- * @brief Specular Anti-Aliasing modes.
- */
-typedef enum {
-	AA_MODE_SCREEN_SPACE = 0,
-	AA_MODE_CURVATURE,
-	AA_MODE_COUNT
-} AAMode;
+typedef struct GPUProfiler GPUProfiler;
 
 /**
  * @struct InstancedUniforms
  * @brief Cached uniform locations for PBR instanced rendering.
  */
-
-enum { IBL_TEXTURE_COUNT = 3 };
-enum { TEXTURE_UNIT_IBL_START = 15 };
 
 typedef struct {
 	GLint irradiance_map;        /**< Location of 'irradianceMap' */
@@ -135,35 +97,6 @@ typedef struct {
 } BillboardUniforms;
 
 /**
- * @struct SceneVisuals
- * @brief Visual effects grouped into a sub-struct to reduce Scene fan-out.
- */
-typedef struct SceneVisuals {
-	Skybox skybox;                        /**< Environment renderer. */
-	TrailRenderer trail_renderer;         /**< Orbital trail renderer. */
-	ShockwaveRenderer shockwave_renderer; /**< Confinement impact VFX. */
-} SceneVisuals;
-
-/**
- * @struct SceneSimulation
- * @brief N-body simulation state grouped to reduce Scene fan-out.
- */
-typedef struct SceneSimulation {
-	NBodySim nbody_sim; /**< N-body gravitational simulation. */
-	int nbody_mode;     /**< Toggle: 0=grid, 1=N-body. */
-} SceneSimulation;
-
-/**
- * @struct SceneLighting
- * @brief IBL, probes, and materials grouped to reduce Scene fan-out.
- */
-typedef struct SceneLighting {
-	MaterialLib* material_lib; /**< Loaded material presets. */
-	IBLCoordinator ibl_coord;  /**< IBL state machine. */
-	LightProbeGrid probe_grid; /**< Global Illumination spatial grid. */
-} SceneLighting;
-
-/**
  * @struct Scene
  * @brief Encapsulates all 3D scene data, geometry, and rendering state.
  */
@@ -184,70 +117,18 @@ typedef struct Scene {
 	int billboard_instance_count; /**< Active billboard count. */
 #endif
 
-	SceneVisuals visuals;   /**< Visual effects sub-system. */
-	SceneLighting lighting; /**< IBL, probes, and materials. */
-	char** hdr_files;       /**< List of found HDR files in assets. */
-	int hdr_count;          /**< Number of available environment maps. */
-	int current_hdr_index;  /**< Index of active HDR in file list. */
-
-	/* --- Shaders --- */
-	Shader* pbr_instanced_shader; /**< Shared PBR shader for opaque geo. */
-	Shader*
-	    pbr_billboard_shader; /**< Shader for volumetric/alpha spheres. */
-#ifdef USE_SSBO_RENDERING
-	Shader* pbr_ssbo_shader; /**< Optimized SSBO shader. */
-#endif
-	Shader* debug_shader;      /**< Generic debug/visualization shader. */
-	Shader* debug_line_shader; /**< Shader for wireframe lines. */
-	Shader* skybox_shader;     /**< Skybox shader wrapper. */
-
-	/* --- GPU Resources --- */
-	GLuint icosphere_vao;        /**< Shared icosphere geometry VAO. */
-	GLuint icosphere_vbo;        /**< Shared icosphere vertex buffer. */
-	GLuint icosphere_nbo;        /**< Shared icosphere normal buffer. */
-	GLuint icosphere_ebo;        /**< Shared icosphere index buffer. */
-	GLuint quad_vbo;             /**< Shared full-screen quad (FSQ). */
-	GLuint wire_cube_vbo;        /**< Shared wireframe cube. */
-	GLuint wire_quad_vbo;        /**< Shared wireframe quad. */
-	GLuint hdr_texture;          /**< Active HDR cubemap. */
-	GLuint recycled_hdr_tex;     /**< Recycled texture for next load. */
-	GLuint spec_prefiltered_tex; /**< Active Specular map. */
-	GLuint irradiance_tex;       /**< Active Irradiance map. */
-	GLuint brdf_lut_tex;         /**< Shared BRDF lookup table. */
-	GLuint empty_vao;            /**< Vertex-less drawing VAO. */
-	GLuint spmap_program;        /**< Internal IBL specular shader. */
-	GLuint irmap_program;        /**< Internal IBL irradiance shader. */
-	GLuint lum_pass1_program;    /**< Luminance downsample pass. */
-	GLuint lum_pass2_program;    /**< Mean luminance compute pass. */
-	GLuint dummy_black_tex;      /**< Safe fallback (0,0,0,1). */
-	GLuint dummy_white_tex;      /**< Safe fallback (1,1,1,1). */
-	GLuint lum_ssbo[2]; /**< Double-buffered storage for luminance. */
-	GLuint transition_snapshot_tex; /**< For crossfade mode. */
-	GLuint billboard_ubo;    /**< UBO for billboard per-frame uniforms. */
-	void* billboard_ubo_ptr; /**< Persistent mapped CPU pointer for UBO. */
-
-	/* --- IBL Binding Cache (Tier 5 — units 15-17) --- */
-	GLuint bound_ibl_textures[IBL_TEXTURE_COUNT]; /**< Last IBL active. */
-
-	/* --- SH/Probe Binding Cache (Tier 3 — units 8-14 + SSBO 3) --- */
-	GLuint bound_sh_textures[SH_TEXTURE_COUNT]; /**< Last SH tex bound. */
-	GLuint bound_probe_ssbo; /**< Last probe SSBO bound. */
-
-	/* --- Render Configuration --- */
-	int wireframe;            /**< OpenGL wireframe mode toggle. */
-	int billboard_mode;       /**< Toggle for billboard rendering path. */
-	SortingMode sorting_mode; /**< Selected sorting algorithm. */
-	int pbr_debug_mode;       /**< Swap to wireframe/normal/roughness */
-	int show_envmap;          /**< Draw skybox toggle. */
-	float env_lod;            /**< Skybox blurriness. */
-	int subdivisions;         /**< LOD of the shared icosphere. */
-	GIMode gi_mode;           /**< Selected GI sampling method. */
-	int show_probe_grid;      /**< Debug visualization of probes. */
-	int specular_aa_enabled;  /**< Screen-Space Specular Anti-Aliasing. */
-	AAMode aa_mode;           /**< AA Mode: Screen-space or Curvature. */
-
-	/* --- N-Body Simulation --- */
+	/* --- Domain Sub-Structs --- */
+	SceneVisuals visuals;       /**< Visual effects sub-system. */
+	SceneLighting lighting;     /**< IBL, probes, and materials. */
 	SceneSimulation simulation; /**< N-body simulation sub-system. */
+	SceneGPUResources gpu;      /**< GPU resource handles. */
+	SceneShaders shaders;       /**< Shader pointers. */
+	SceneConfig config;         /**< Render configuration. */
+
+	/* --- HDR Environment --- */
+	char** hdr_files;      /**< List of found HDR files in assets. */
+	int hdr_count;         /**< Number of available environment maps. */
+	int current_hdr_index; /**< Index of active HDR in file list. */
 
 	/* --- Uniform Caches --- */
 	BillboardUniforms billboard_uniforms; /**< Cached locations. */

--- a/include/scene_config.h
+++ b/include/scene_config.h
@@ -1,0 +1,59 @@
+#ifndef SCENE_CONFIG_H
+#define SCENE_CONFIG_H
+
+/**
+ * @file scene_config.h
+ * @brief Render configuration flags extracted from Scene.
+ */
+
+/**
+ * @enum SortingMode
+ * @brief Sorting algorithms for transparent billboards.
+ */
+typedef enum {
+	SORTING_MODE_CPU_QSORT = 0,
+	SORTING_MODE_CPU_RADIX,
+	SORTING_MODE_GPU_BITONIC,
+	SORTING_MODE_COUNT /**< Sentinel — must remain last. */
+} SortingMode;
+
+/**
+ * @enum GIMode
+ * @brief Global Illumination sampling methods.
+ */
+typedef enum {
+	GI_MODE_OFF = 0,
+	GI_MODE_3D_TEX,
+	GI_MODE_SSBO,
+	GI_MODE_COUNT
+} GIMode;
+
+/**
+ * @enum AAMode
+ * @brief Specular Anti-Aliasing modes.
+ */
+typedef enum {
+	AA_MODE_SCREEN_SPACE = 0,
+	AA_MODE_CURVATURE,
+	AA_MODE_COUNT
+} AAMode;
+
+/**
+ * @struct SceneConfig
+ * @brief Render configuration flags and toggles.
+ */
+typedef struct SceneConfig {
+	int wireframe;            /**< OpenGL wireframe mode toggle. */
+	int billboard_mode;       /**< Toggle for billboard rendering path. */
+	SortingMode sorting_mode; /**< Selected sorting algorithm. */
+	int pbr_debug_mode;       /**< Swap to wireframe/normal/roughness */
+	int show_envmap;          /**< Draw skybox toggle. */
+	float env_lod;            /**< Skybox blurriness. */
+	int subdivisions;         /**< LOD of the shared icosphere. */
+	GIMode gi_mode;           /**< Selected GI sampling method. */
+	int show_probe_grid;      /**< Debug visualization of probes. */
+	int specular_aa_enabled;  /**< Screen-Space Specular Anti-Aliasing. */
+	AAMode aa_mode;           /**< AA Mode: Screen-space or Curvature. */
+} SceneConfig;
+
+#endif /* SCENE_CONFIG_H */

--- a/include/scene_gpu_resources.h
+++ b/include/scene_gpu_resources.h
@@ -1,0 +1,64 @@
+#ifndef SCENE_GPU_RESOURCES_H
+#define SCENE_GPU_RESOURCES_H
+
+/**
+ * @file scene_gpu_resources.h
+ * @brief GPU resource handles extracted from Scene to reduce fan-out.
+ *
+ * Owns all GLuint handles for textures, buffers, VAOs, and compute programs
+ * that were previously scattered across the Scene struct.
+ */
+
+#include "gl_common.h"
+#include "light_probes.h" /* SH_TEXTURE_COUNT */
+
+enum { IBL_TEXTURE_COUNT = 3 };
+enum { TEXTURE_UNIT_IBL_START = 15 };
+
+/**
+ * @struct SceneGPUResources
+ * @brief All GPU resource handles owned by the scene.
+ */
+typedef struct SceneGPUResources {
+	/* --- Geometry Buffers --- */
+	GLuint icosphere_vao; /**< Shared icosphere geometry VAO. */
+	GLuint icosphere_vbo; /**< Shared icosphere vertex buffer. */
+	GLuint icosphere_nbo; /**< Shared icosphere normal buffer. */
+	GLuint icosphere_ebo; /**< Shared icosphere index buffer. */
+	GLuint quad_vbo;      /**< Shared full-screen quad (FSQ). */
+	GLuint wire_cube_vbo; /**< Shared wireframe cube. */
+	GLuint wire_quad_vbo; /**< Shared wireframe quad. */
+	GLuint empty_vao;     /**< Vertex-less drawing VAO. */
+
+	/* --- Textures --- */
+	GLuint hdr_texture;             /**< Active HDR cubemap. */
+	GLuint recycled_hdr_tex;        /**< Recycled texture for next load. */
+	GLuint spec_prefiltered_tex;    /**< Active Specular map. */
+	GLuint irradiance_tex;          /**< Active Irradiance map. */
+	GLuint brdf_lut_tex;            /**< Shared BRDF lookup table. */
+	GLuint dummy_black_tex;         /**< Safe fallback (0,0,0,1). */
+	GLuint dummy_white_tex;         /**< Safe fallback (1,1,1,1). */
+	GLuint transition_snapshot_tex; /**< For crossfade mode. */
+
+	/* --- Compute Programs --- */
+	GLuint spmap_program;     /**< Internal IBL specular shader. */
+	GLuint irmap_program;     /**< Internal IBL irradiance shader. */
+	GLuint lum_pass1_program; /**< Luminance downsample pass. */
+	GLuint lum_pass2_program; /**< Mean luminance compute pass. */
+
+	/* --- Storage Buffers --- */
+	GLuint lum_ssbo[2]; /**< Double-buffered storage for luminance. */
+
+	/* --- Billboard UBO --- */
+	GLuint billboard_ubo;    /**< UBO for billboard per-frame uniforms. */
+	void* billboard_ubo_ptr; /**< Persistent mapped CPU pointer for UBO. */
+
+	/* --- IBL Binding Cache (Tier 5 — units 15-17) --- */
+	GLuint bound_ibl_textures[IBL_TEXTURE_COUNT]; /**< Last IBL active. */
+
+	/* --- SH/Probe Binding Cache (Tier 3 — units 8-14 + SSBO 3) --- */
+	GLuint bound_sh_textures[SH_TEXTURE_COUNT]; /**< Last SH tex bound. */
+	GLuint bound_probe_ssbo; /**< Last probe SSBO bound. */
+} SceneGPUResources;
+
+#endif /* SCENE_GPU_RESOURCES_H */

--- a/include/scene_lighting.h
+++ b/include/scene_lighting.h
@@ -1,0 +1,23 @@
+#ifndef SCENE_LIGHTING_H
+#define SCENE_LIGHTING_H
+
+/**
+ * @file scene_lighting.h
+ * @brief IBL, probes, and materials sub-struct extracted from Scene.
+ */
+
+#include "ibl_coordinator.h"
+#include "light_probes.h"
+#include "material.h"
+
+/**
+ * @struct SceneLighting
+ * @brief IBL, probes, and materials grouped to reduce Scene fan-out.
+ */
+typedef struct SceneLighting {
+	MaterialLib* material_lib; /**< Loaded material presets. */
+	IBLCoordinator ibl_coord;  /**< IBL state machine. */
+	LightProbeGrid probe_grid; /**< Global Illumination spatial grid. */
+} SceneLighting;
+
+#endif /* SCENE_LIGHTING_H */

--- a/include/scene_shaders.h
+++ b/include/scene_shaders.h
@@ -1,0 +1,26 @@
+#ifndef SCENE_SHADERS_H
+#define SCENE_SHADERS_H
+
+/**
+ * @file scene_shaders.h
+ * @brief Shader pointers extracted from Scene to reduce fan-out.
+ */
+
+#include "shader.h"
+
+/**
+ * @struct SceneShaders
+ * @brief All shader pointers owned by the scene.
+ */
+typedef struct SceneShaders {
+	Shader* pbr_instanced; /**< Shared PBR shader for opaque geo. */
+	Shader* pbr_billboard; /**< Shader for volumetric/alpha spheres. */
+	Shader* debug;         /**< Generic debug/visualization shader. */
+	Shader* debug_line;    /**< Shader for wireframe lines. */
+	Shader* skybox;        /**< Skybox shader wrapper. */
+#ifdef USE_SSBO_RENDERING
+	Shader* pbr_ssbo; /**< Optimized SSBO shader. */
+#endif
+} SceneShaders;
+
+#endif /* SCENE_SHADERS_H */

--- a/include/scene_simulation.h
+++ b/include/scene_simulation.h
@@ -1,0 +1,20 @@
+#ifndef SCENE_SIMULATION_H
+#define SCENE_SIMULATION_H
+
+/**
+ * @file scene_simulation.h
+ * @brief N-body simulation sub-struct extracted from Scene.
+ */
+
+#include "nbody.h"
+
+/**
+ * @struct SceneSimulation
+ * @brief N-body simulation state grouped to reduce Scene fan-out.
+ */
+typedef struct SceneSimulation {
+	NBodySim nbody_sim; /**< N-body gravitational simulation. */
+	int nbody_mode;     /**< Toggle: 0=grid, 1=N-body. */
+} SceneSimulation;
+
+#endif /* SCENE_SIMULATION_H */

--- a/include/scene_visuals.h
+++ b/include/scene_visuals.h
@@ -1,0 +1,23 @@
+#ifndef SCENE_VISUALS_H
+#define SCENE_VISUALS_H
+
+/**
+ * @file scene_visuals.h
+ * @brief Visual effects sub-struct extracted from Scene.
+ */
+
+#include "shockwave.h"
+#include "skybox.h"
+#include "trail_renderer.h"
+
+/**
+ * @struct SceneVisuals
+ * @brief Visual effects grouped into a sub-struct to reduce Scene fan-out.
+ */
+typedef struct SceneVisuals {
+	Skybox skybox;                        /**< Environment renderer. */
+	TrailRenderer trail_renderer;         /**< Orbital trail renderer. */
+	ShockwaveRenderer shockwave_renderer; /**< Confinement impact VFX. */
+} SceneVisuals;
+
+#endif /* SCENE_VISUALS_H */

--- a/src/app.c
+++ b/src/app.c
@@ -42,7 +42,7 @@ int app_init(App* app, int width, int height, const char* title)
 	app_input_state_init(app->input);
 	app->is_fullscreen = false;
 	app->resize_pending = 0;
-	app->scene.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
+	app->scene.config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
 	app->env_mgr.is_first_load = true;
 
 	app->window = window_create(width, height, title, DEFAULT_SAMPLES);
@@ -121,7 +121,7 @@ int app_init(App* app, int width, int height, const char* title)
 		return 0;
 	}
 	postprocess_set_dummy_textures(&app->postprocess,
-	                               app->scene.dummy_black_tex);
+	                               app->scene.gpu.dummy_black_tex);
 	postprocess_set_exposure(&app->postprocess,
 	                         app->postprocess.auto_threshold);
 	postprocess_enable(&app->postprocess, POSTFX_FXAA);
@@ -279,7 +279,7 @@ void app_run(App* app)
 				            DEFAULT_CAMERA_DISTANCE,
 				            DEFAULT_CAMERA_YAW,
 				            DEFAULT_CAMERA_PITCH);
-				app->scene.env_lod = DEFAULT_ENV_LOD;
+				app->scene.config.env_lod = DEFAULT_ENV_LOD;
 				action_notifier_push(&app->notifier,
 				                     "Camera & LOD Reset",
 				                     NOTIF_DUR_LONG);
@@ -310,23 +310,24 @@ void app_run(App* app)
 			PROFILE_ZONE_END(camera_ctx);
 		}
 
-		if (app->scene.subdivisions != last_subdiv) {
+		if (app->scene.config.subdivisions != last_subdiv) {
 			PROFILE_ZONE(ico_ctx, "Icosphere Regen");
 			icosphere_generate(&app->scene.geometry,
-			                   app->scene.subdivisions);
+			                   app->scene.config.subdivisions);
 			scene_update_gpu_buffers(&app->scene);
 
 #ifdef USE_SSBO_RENDERING
-			ssbo_group_bind_mesh(
-			    &app->scene.ssbo_group, app->scene.icosphere_vbo,
-			    app->scene.icosphere_nbo, app->scene.icosphere_ebo);
+			ssbo_group_bind_mesh(&app->scene.ssbo_group,
+			                     app->scene.gpu.icosphere_vbo,
+			                     app->scene.gpu.icosphere_nbo,
+			                     app->scene.gpu.icosphere_ebo);
 #else
 			instanced_group_bind_mesh(&app->scene.instanced_group,
-			                          app->scene.icosphere_vbo,
-			                          app->scene.icosphere_nbo,
-			                          app->scene.icosphere_ebo);
+			                          app->scene.gpu.icosphere_vbo,
+			                          app->scene.gpu.icosphere_nbo,
+			                          app->scene.gpu.icosphere_ebo);
 #endif
-			last_subdiv = app->scene.subdivisions;
+			last_subdiv = app->scene.config.subdivisions;
 			PROFILE_ZONE_END(ico_ctx);
 		}
 
@@ -396,10 +397,10 @@ void app_update(App* app)
 	 * frame as PBO Setup & Map.
 	 */
 	if (app->async_coord.pending_prealloc_w > 0) {
-		app->scene.recycled_hdr_tex =
+		app->scene.gpu.recycled_hdr_tex =
 		    texture_preallocate_hdr(app->async_coord.pending_prealloc_w,
 		                            app->async_coord.pending_prealloc_h,
-		                            app->scene.recycled_hdr_tex);
+		                            app->scene.gpu.recycled_hdr_tex);
 		app->async_coord.pending_prealloc_w = 0;
 		app->async_coord.pending_prealloc_h = 0;
 	}
@@ -414,7 +415,7 @@ void app_update(App* app)
 
 	if (app->env_mgr.env_map_loading_step > 0) {
 		env_manager_process_loading_step(
-		    &app->env_mgr, &app->scene.recycled_hdr_tex,
+		    &app->env_mgr, &app->scene.gpu.recycled_hdr_tex,
 		    &app->scene.lighting.ibl_coord);
 	}
 

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -100,8 +100,8 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 
 static void handle_pbr_debug_mode(AppInputContext* ctx)
 {
-	ctx->scene->pbr_debug_mode =
-	    (ctx->scene->pbr_debug_mode + 1) % PBR_DEBUG_MODE_COUNT;
+	ctx->scene->config.pbr_debug_mode =
+	    (ctx->scene->config.pbr_debug_mode + 1) % PBR_DEBUG_MODE_COUNT;
 	const char* modeNames[] = {"Final PBR",
 	                           "Albedo",
 	                           "Normal",
@@ -113,18 +113,19 @@ static void handle_pbr_debug_mode(AppInputContext* ctx)
 	                           "BRDF LUT",
 	                           "1-Bounce GI (Probes)"};
 	LOG_INFO("suckless-ogl.app", "PBR Debug Mode: %s",
-	         modeNames[ctx->scene->pbr_debug_mode]);
+	         modeNames[ctx->scene->config.pbr_debug_mode]);
 
 	char buf[NOTIF_BUF_SIZE];
 	(void)safe_snprintf(buf, sizeof(buf), "Debug: %s",
-	                    modeNames[ctx->scene->pbr_debug_mode]);
+	                    modeNames[ctx->scene->config.pbr_debug_mode]);
 	action_notifier_push(ctx->notifier, buf, NOTIF_DUR_LONG);
 }
 
 static void handle_aa_mode_input(AppInputContext* ctx)
 {
-	ctx->scene->aa_mode = (ctx->scene->aa_mode + 1) % AA_MODE_COUNT;
-	const char* mode_name = aa_mode_to_string(ctx->scene->aa_mode);
+	ctx->scene->config.aa_mode =
+	    (ctx->scene->config.aa_mode + 1) % AA_MODE_COUNT;
+	const char* mode_name = aa_mode_to_string(ctx->scene->config.aa_mode);
 	LOG_INFO("suckless-ogl.app", "Specular AA Mode: %s", mode_name);
 
 	char buf[NOTIF_BUF_SIZE];
@@ -139,16 +140,16 @@ void app_handle_env_input(AppInputContext* ctx, int action, int mods, int key)
 	}
 	if (key == GLFW_KEY_PAGE_UP) {
 		if (check_flag(mods, GLFW_MOD_SHIFT)) {
-			ctx->scene->env_lod += LOD_STEP;
-			if (ctx->scene->env_lod > MAX_ENV_LOD) {
-				ctx->scene->env_lod = MAX_ENV_LOD;
+			ctx->scene->config.env_lod += LOD_STEP;
+			if (ctx->scene->config.env_lod > MAX_ENV_LOD) {
+				ctx->scene->config.env_lod = MAX_ENV_LOD;
 			}
 			LOG_INFO("suckless-ogl.app", "Env LOD: %.1F",
-			         ctx->scene->env_lod);
+			         ctx->scene->config.env_lod);
 			char lod_buf[NOTIF_BUF_SIZE];
 			(void)safe_snprintf(lod_buf, sizeof(lod_buf),
 			                    "Env LOD: %.1F",
-			                    ctx->scene->env_lod);
+			                    ctx->scene->config.env_lod);
 			action_notifier_push(ctx->notifier, lod_buf,
 			                     NOTIF_DUR_SHORT);
 		} else if (ctx->scene->hdr_count > 1) {
@@ -176,16 +177,16 @@ void app_handle_env_input(AppInputContext* ctx, int action, int mods, int key)
 		}
 	} else if (key == GLFW_KEY_PAGE_DOWN) {
 		if (check_flag(mods, GLFW_MOD_SHIFT)) {
-			ctx->scene->env_lod -= LOD_STEP;
-			if (ctx->scene->env_lod < MIN_ENV_LOD) {
-				ctx->scene->env_lod = MIN_ENV_LOD;
+			ctx->scene->config.env_lod -= LOD_STEP;
+			if (ctx->scene->config.env_lod < MIN_ENV_LOD) {
+				ctx->scene->config.env_lod = MIN_ENV_LOD;
 			}
 			LOG_INFO("suckless-ogl.app", "Env LOD: %.1F",
-			         ctx->scene->env_lod);
+			         ctx->scene->config.env_lod);
 			char lod_buf[NOTIF_BUF_SIZE];
 			(void)safe_snprintf(lod_buf, sizeof(lod_buf),
 			                    "Env LOD: %.1F",
-			                    ctx->scene->env_lod);
+			                    ctx->scene->config.env_lod);
 			action_notifier_push(ctx->notifier, lod_buf,
 			                     NOTIF_DUR_SHORT);
 		} else if (ctx->scene->hdr_count > 1) {
@@ -236,19 +237,20 @@ static void handle_overlay_input(AppInputContext* ctx)
 static void handle_subdiv_input(AppInputContext* ctx, int key)
 {
 	int changed = 0;
-	if (key == GLFW_KEY_UP && ctx->scene->subdivisions < MAX_SUBDIV) {
-		ctx->scene->subdivisions++;
+	if (key == GLFW_KEY_UP &&
+	    ctx->scene->config.subdivisions < MAX_SUBDIV) {
+		ctx->scene->config.subdivisions++;
 		changed = 1;
 	} else if (key == GLFW_KEY_DOWN &&
-	           ctx->scene->subdivisions > MIN_SUBDIV) {
-		ctx->scene->subdivisions--;
+	           ctx->scene->config.subdivisions > MIN_SUBDIV) {
+		ctx->scene->config.subdivisions--;
 		changed = 1;
 	}
 
 	if (changed) {
 		char buf[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(buf, sizeof(buf), "Subdiv: %d",
-		                    ctx->scene->subdivisions);
+		                    ctx->scene->config.subdivisions);
 		action_notifier_push(ctx->notifier, buf, NOTIF_DUR_SHORT);
 	}
 }
@@ -425,22 +427,25 @@ static bool handle_f_key_input(AppInputContext* ctx, int key, int mods)
 static void handle_y_key_input(AppInputContext* ctx, int mods)
 {
 	if ((unsigned int)mods & (unsigned int)GLFW_MOD_SHIFT) {
-		ctx->scene->show_probe_grid = !ctx->scene->show_probe_grid;
+		ctx->scene->config.show_probe_grid =
+		    !ctx->scene->config.show_probe_grid;
 		LOG_INFO("suckless-ogl.app", "Probe Grid Debug: %s",
-		         ctx->scene->show_probe_grid ? "ON" : "OFF");
-		action_notifier_push(
-		    ctx->notifier,
-		    ctx->scene->show_probe_grid ? "Probes: ON" : "Probes: OFF",
-		    NOTIF_DUR_NORMAL);
+		         ctx->scene->config.show_probe_grid ? "ON" : "OFF");
+		action_notifier_push(ctx->notifier,
+		                     ctx->scene->config.show_probe_grid
+		                         ? "Probes: ON"
+		                         : "Probes: OFF",
+		                     NOTIF_DUR_NORMAL);
 	} else {
-		ctx->scene->gi_mode = (ctx->scene->gi_mode + 1) % GI_MODE_COUNT;
+		ctx->scene->config.gi_mode =
+		    (ctx->scene->config.gi_mode + 1) % GI_MODE_COUNT;
 		const char* mode_names[] = {"OFF", "3D Texture", "SSBO"};
 		LOG_INFO("suckless-ogl.app", "GI Mode: %s",
-		         mode_names[ctx->scene->gi_mode]);
+		         mode_names[ctx->scene->config.gi_mode]);
 
 		char buf[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(buf, sizeof(buf), "GI: %s",
-		                    mode_names[ctx->scene->gi_mode]);
+		                    mode_names[ctx->scene->config.gi_mode]);
 		action_notifier_push(ctx->notifier, buf, NOTIF_DUR_NORMAL);
 	}
 }
@@ -454,9 +459,10 @@ static void handle_system_key_input(AppInputContext* ctx, int key, int mods)
 			                     NOTIF_DUR_LONG);
 			break;
 		case GLFW_KEY_Z:
-			ctx->scene->wireframe = !ctx->scene->wireframe;
+			ctx->scene->config.wireframe =
+			    !ctx->scene->config.wireframe;
 			action_notifier_push(ctx->notifier,
-			                     ctx->scene->wireframe
+			                     ctx->scene->config.wireframe
 			                         ? "Wireframe: ON"
 			                         : "Wireframe: OFF",
 			                     NOTIF_DUR_NORMAL);
@@ -471,7 +477,7 @@ static void handle_system_key_input(AppInputContext* ctx, int key, int mods)
 		case GLFW_KEY_SPACE:
 			camera_init(ctx->camera, DEFAULT_CAMERA_DISTANCE,
 			            DEFAULT_CAMERA_YAW, DEFAULT_CAMERA_PITCH);
-			ctx->scene->env_lod = DEFAULT_ENV_LOD;
+			ctx->scene->config.env_lod = DEFAULT_ENV_LOD;
 			LOG_INFO("suckless-ogl.app", "Camera and LOD reset");
 			action_notifier_push(ctx->notifier,
 			                     "Camera & LOD Reset",
@@ -588,12 +594,12 @@ static void handle_sim_or_gravity_input(AppInputContext* ctx, int mods,
 
 static void handle_o_key_input(AppInputContext* ctx)
 {
-	ctx->scene->sorting_mode =
-	    (ctx->scene->sorting_mode + 1) % SORTING_MODE_COUNT;
+	ctx->scene->config.sorting_mode =
+	    (ctx->scene->config.sorting_mode + 1) % SORTING_MODE_COUNT;
 	const char* mode_name = "Unknown";
 	const char* notif_name = "Sort: Unknown";
 
-	switch (ctx->scene->sorting_mode) {
+	switch (ctx->scene->config.sorting_mode) {
 		case SORTING_MODE_CPU_QSORT:
 			mode_name = "CPU (qsort)";
 			notif_name = "Sort: CPU (qsort)";
@@ -704,14 +710,15 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 			handle_y_key_input(ctx, mods);
 			break;
 		case GLFW_KEY_L:
-			ctx->scene->billboard_mode =
-			    !ctx->scene->billboard_mode;
+			ctx->scene->config.billboard_mode =
+			    !ctx->scene->config.billboard_mode;
 			// app_update_instancing_mode(app) was empty and
 			// removed.
-			LOG_INFO("suckless-ogl.app", "Billboard Mode: %s",
-			         ctx->scene->billboard_mode ? "ON" : "OFF");
+			LOG_INFO(
+			    "suckless-ogl.app", "Billboard Mode: %s",
+			    ctx->scene->config.billboard_mode ? "ON" : "OFF");
 			action_notifier_push(ctx->notifier,
-			                     ctx->scene->billboard_mode
+			                     ctx->scene->config.billboard_mode
 			                         ? "Billboards: ON"
 			                         : "Billboards: OFF",
 			                     NOTIF_DUR_NORMAL);
@@ -743,22 +750,23 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 			if (check_flag(mods, GLFW_MOD_SHIFT)) {
 				handle_aa_mode_input(ctx);
 			} else {
-				ctx->scene->specular_aa_enabled =
-				    !ctx->scene->specular_aa_enabled;
+				ctx->scene->config.specular_aa_enabled =
+				    !ctx->scene->config.specular_aa_enabled;
 				action_notifier_push(
 				    ctx->notifier,
-				    ctx->scene->specular_aa_enabled
+				    ctx->scene->config.specular_aa_enabled
 				        ? "Specular AA: ON"
 				        : "Specular AA: OFF",
 				    NOTIF_DUR_SHORT);
 			}
 			break;
 		case GLFW_KEY_K:
-			ctx->scene->show_envmap = !ctx->scene->show_envmap;
+			ctx->scene->config.show_envmap =
+			    !ctx->scene->config.show_envmap;
 			LOG_INFO("suckless-ogl.app", "Envmap: %s",
-			         ctx->scene->show_envmap ? "ON" : "OFF");
+			         ctx->scene->config.show_envmap ? "ON" : "OFF");
 			action_notifier_push(ctx->notifier,
-			                     ctx->scene->show_envmap
+			                     ctx->scene->config.show_envmap
 			                         ? "Skybox: ON"
 			                         : "Skybox: OFF",
 			                     NOTIF_DUR_NORMAL);

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -131,10 +131,10 @@ int env_manager_trigger_transition(EnvManager* mgr, AsyncLoader* loader,
 
 static void capture_snapshot(Scene* scene, int width, int height)
 {
-	if (scene->transition_snapshot_tex == 0) {
-		glGenTextures(1, &scene->transition_snapshot_tex);
+	if (scene->gpu.transition_snapshot_tex == 0) {
+		glGenTextures(1, &scene->gpu.transition_snapshot_tex);
 	}
-	glBindTexture(GL_TEXTURE_2D, scene->transition_snapshot_tex);
+	glBindTexture(GL_TEXTURE_2D, scene->gpu.transition_snapshot_tex);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
 	             GL_UNSIGNED_BYTE, NULL);
 	glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width, height);
@@ -151,26 +151,26 @@ static void finalize_ibl_swap(Scene* scene, PostProcess* postproc,
 	postprocess_set_exposure_target(postproc, threshold);
 
 	/* Recycle the old HDR texture instead of deleting it */
-	if (scene->hdr_texture) {
-		if (scene->recycled_hdr_tex) {
+	if (scene->gpu.hdr_texture) {
+		if (scene->gpu.recycled_hdr_tex) {
 			/* If we already have one (weird edge case),
 			 * delete the old one */
-			glDeleteTextures(1, &scene->recycled_hdr_tex);
+			glDeleteTextures(1, &scene->gpu.recycled_hdr_tex);
 		}
-		scene->recycled_hdr_tex = scene->hdr_texture;
-		/* scene->hdr_texture will be overwritten below */
+		scene->gpu.recycled_hdr_tex = scene->gpu.hdr_texture;
+		/* scene->gpu.hdr_texture will be overwritten below */
 	}
 
-	if (scene->spec_prefiltered_tex) {
-		glDeleteTextures(1, &scene->spec_prefiltered_tex);
+	if (scene->gpu.spec_prefiltered_tex) {
+		glDeleteTextures(1, &scene->gpu.spec_prefiltered_tex);
 	}
-	if (scene->irradiance_tex) {
-		glDeleteTextures(1, &scene->irradiance_tex);
+	if (scene->gpu.irradiance_tex) {
+		glDeleteTextures(1, &scene->gpu.irradiance_tex);
 	}
 
-	scene->hdr_texture = hdr_tex;
-	scene->spec_prefiltered_tex = spec_tex;
-	scene->irradiance_tex = irr_tex;
+	scene->gpu.hdr_texture = hdr_tex;
+	scene->gpu.spec_prefiltered_tex = spec_tex;
+	scene->gpu.irradiance_tex = irr_tex;
 
 	LOG_INFO("suckless-ogl.env", "[Frame %llu] Environment swap finalized.",
 	         (unsigned long long)frame_count);
@@ -292,26 +292,27 @@ void env_manager_render_overlay(const EnvManager* mgr, const Scene* scene)
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glDisable(GL_DEPTH_TEST);
 
-		shader_use(scene->debug_shader);
-		shader_set_int(scene->debug_shader, "u_tex", 0);
-		shader_set_float(scene->debug_shader, "u_alpha",
+		shader_use(scene->shaders.debug);
+		shader_set_int(scene->shaders.debug, "u_tex", 0);
+		shader_set_float(scene->shaders.debug, "u_alpha",
 		                 mgr->transition_alpha);
-		shader_set_int(scene->debug_shader, "u_bypass_processing", 1);
-		shader_set_float(scene->debug_shader, "lod", 0.0F);
+		shader_set_int(scene->shaders.debug, "u_bypass_processing", 1);
+		shader_set_float(scene->shaders.debug, "lod", 0.0F);
 
 		glActiveTexture(GL_TEXTURE0);
 		if (mgr->env_transition_mode == ENV_TRANSITION_CROSSFADE &&
-		    scene->transition_snapshot_tex != 0 &&
+		    scene->gpu.transition_snapshot_tex != 0 &&
 		    mgr->transition_state == TRANSITION_FADE_IN) {
 			/* Crossfade: Bind snapshot texture */
 			glBindTexture(GL_TEXTURE_2D,
-			              scene->transition_snapshot_tex);
+			              scene->gpu.transition_snapshot_tex);
 		} else {
 			/* Black Screen / Initial Load: Bind dummy black */
-			glBindTexture(GL_TEXTURE_2D, scene->dummy_black_tex);
+			glBindTexture(GL_TEXTURE_2D,
+			              scene->gpu.dummy_black_tex);
 		}
 
-		glBindVertexArray(scene->quad_vbo);
+		glBindVertexArray(scene->gpu.quad_vbo);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 		glBindVertexArray(0);
 

--- a/src/scene.c
+++ b/src/scene.c
@@ -144,11 +144,13 @@ static void scene_init_instancing(Scene* scene)
 	}
 #endif
 
-	instanced_group_bind_mesh(&scene->instanced_group, scene->icosphere_vbo,
-	                          scene->icosphere_nbo, scene->icosphere_ebo);
+	instanced_group_bind_mesh(
+	    &scene->instanced_group, scene->gpu.icosphere_vbo,
+	    scene->gpu.icosphere_nbo, scene->gpu.icosphere_ebo);
 	billboard_group_init(&scene->billboard_group, data, total_count);
-	billboard_group_prepare(&scene->billboard_group, scene->quad_vbo,
-	                        scene->wire_quad_vbo, scene->wire_cube_vbo);
+	billboard_group_prepare(&scene->billboard_group, scene->gpu.quad_vbo,
+	                        scene->gpu.wire_quad_vbo,
+	                        scene->gpu.wire_cube_vbo);
 
 	/* Initialize Light Probe Grid with Scene Data */
 	light_probe_grid_set_scene(&scene->lighting.probe_grid, data,
@@ -204,8 +206,9 @@ static void scene_init_ssbo(Scene* scene)
 	}
 
 	ssbo_group_init(&scene->ssbo_group, data, total_count);
-	ssbo_group_bind_mesh(&scene->ssbo_group, scene->icosphere_vbo,
-	                     scene->icosphere_nbo, scene->icosphere_ebo);
+	ssbo_group_bind_mesh(&scene->ssbo_group, scene->gpu.icosphere_vbo,
+	                     scene->gpu.icosphere_nbo,
+	                     scene->gpu.icosphere_ebo);
 
 	/* Initialize Light Probe Grid with Scene Data (SSBO Mode) */
 	light_probe_grid_set_scene(&scene->lighting.probe_grid, data,
@@ -223,36 +226,36 @@ static void scene_init_ssbo(Scene* scene)
 
 static void scene_init_state(Scene* scene)
 {
-	scene->subdivisions = INITIAL_SUBDIVISIONS;
-	scene->wireframe = 0;
-	scene->env_lod = DEFAULT_ENV_LOD;
-	scene->pbr_debug_mode = 0;
-	scene->show_envmap = 1;
-	scene->billboard_mode = 1;
-	scene->specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
-	scene->aa_mode = AA_MODE_CURVATURE;
-	scene->sorting_mode = SORTING_MODE_GPU_BITONIC;
-	scene->gi_mode = GI_MODE_OFF;
-	scene->show_probe_grid = 0;
-	scene->billboard_ubo_ptr = NULL;
+	scene->config.subdivisions = INITIAL_SUBDIVISIONS;
+	scene->config.wireframe = 0;
+	scene->config.env_lod = DEFAULT_ENV_LOD;
+	scene->config.pbr_debug_mode = 0;
+	scene->config.show_envmap = 1;
+	scene->config.billboard_mode = 1;
+	scene->config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
+	scene->config.aa_mode = AA_MODE_CURVATURE;
+	scene->config.sorting_mode = SORTING_MODE_GPU_BITONIC;
+	scene->config.gi_mode = GI_MODE_OFF;
+	scene->config.show_probe_grid = 0;
+	scene->gpu.billboard_ubo_ptr = NULL;
 
 	// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
 	memset(&scene->billboard_sorter, 0, sizeof(BillboardSorter));
 
-	scene->dummy_black_tex =
+	scene->gpu.dummy_black_tex =
 	    render_utils_create_color_texture(0.0F, 0.0F, 0.0F, 0.0F);
-	scene->dummy_white_tex =
+	scene->gpu.dummy_white_tex =
 	    render_utils_create_color_texture(1.0F, 1.0F, 1.0F, 1.0F);
 
-	scene->brdf_lut_tex = build_brdf_lut_map(BRDF_LUT_MAP_SIZE);
-	scene->hdr_texture = 0;
-	scene->recycled_hdr_tex = 0;
-	scene->spec_prefiltered_tex = 0;
-	scene->irradiance_tex = 0;
-	scene->transition_snapshot_tex = 0;
+	scene->gpu.brdf_lut_tex = build_brdf_lut_map(BRDF_LUT_MAP_SIZE);
+	scene->gpu.hdr_texture = 0;
+	scene->gpu.recycled_hdr_tex = 0;
+	scene->gpu.spec_prefiltered_tex = 0;
+	scene->gpu.irradiance_tex = 0;
+	scene->gpu.transition_snapshot_tex = 0;
 
 	for (int i = 0; i < IBL_TEXTURE_COUNT; i++) {
-		scene->bound_ibl_textures[i] = 0;
+		scene->gpu.bound_ibl_textures[i] = 0;
 	}
 
 	scene_scan_hdr_files(scene);
@@ -262,21 +265,21 @@ static void scene_init_state(Scene* scene)
 
 static int scene_init_core_shaders(Scene* scene)
 {
-	scene->skybox_shader =
+	scene->shaders.skybox =
 	    shader_load("shaders/background.vert", "shaders/background.frag");
-	if (!scene->skybox_shader) {
+	if (!scene->shaders.skybox) {
 		return 0;
 	}
 
-	scene->debug_shader =
+	scene->shaders.debug =
 	    shader_load("shaders/debug_tex.vert", "shaders/debug_tex.frag");
-	if (!scene->debug_shader) {
+	if (!scene->shaders.debug) {
 		return 0;
 	}
 
-	scene->debug_line_shader =
+	scene->shaders.debug_line =
 	    shader_load("shaders/debug_line.vert", "shaders/debug_line.frag");
-	if (!scene->debug_line_shader) {
+	if (!scene->shaders.debug_line) {
 		return 0;
 	}
 	return 1;
@@ -284,27 +287,27 @@ static int scene_init_core_shaders(Scene* scene)
 
 static int scene_init_billboard_shader(Scene* scene)
 {
-	scene->pbr_billboard_shader = shader_load(
+	scene->shaders.pbr_billboard = shader_load(
 	    "shaders/pbr_ibl_billboard.vert", "shaders/pbr_ibl_billboard.frag");
-	if (!scene->pbr_billboard_shader) {
+	if (!scene->shaders.pbr_billboard) {
 		return 0;
 	}
 
 	/* Create UBO for billboard per-frame uniforms (binding = 1) */
-	glGenBuffers(1, &scene->billboard_ubo);
-	glBindBuffer(GL_UNIFORM_BUFFER, scene->billboard_ubo);
+	glGenBuffers(1, &scene->gpu.billboard_ubo);
+	glBindBuffer(GL_UNIFORM_BUFFER, scene->gpu.billboard_ubo);
 	GLbitfield flags = (GLbitfield)GL_MAP_WRITE_BIT |
 	                   (GLbitfield)GL_MAP_PERSISTENT_BIT |
 	                   (GLbitfield)GL_MAP_COHERENT_BIT;
 	glBufferStorage(GL_UNIFORM_BUFFER, sizeof(BillboardUBO), NULL, flags);
-	scene->billboard_ubo_ptr =
+	scene->gpu.billboard_ubo_ptr =
 	    glMapBufferRange(GL_UNIFORM_BUFFER, 0, sizeof(BillboardUBO), flags);
-	glBindBufferBase(GL_UNIFORM_BUFFER, 1, scene->billboard_ubo);
+	glBindBufferBase(GL_UNIFORM_BUFFER, 1, scene->gpu.billboard_ubo);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 	/* Set Billboard SH Sampler Indices (units 8-14) */
 	{
-		shader_use(scene->pbr_billboard_shader);
+		shader_use(scene->shaders.pbr_billboard);
 		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 			enum { MAX_UNIFORM_NAME_LEN = 32 };
 			char name[MAX_UNIFORM_NAME_LEN];
@@ -312,7 +315,7 @@ static int scene_init_billboard_shader(Scene* scene)
 			                    i);
 			scene->billboard_uniforms.sh_textures[i] =
 			    shader_get_uniform_location(
-			        scene->pbr_billboard_shader, name);
+			        scene->shaders.pbr_billboard, name);
 			if (scene->billboard_uniforms.sh_textures[i] != -1) {
 				glUniform1i(
 				    scene->billboard_uniforms.sh_textures[i],
@@ -325,21 +328,24 @@ static int scene_init_billboard_shader(Scene* scene)
 
 static int scene_init_compute_resources(Scene* scene)
 {
-	scene->spmap_program = shader_load_compute("shaders/IBL/spmap.glsl");
-	scene->irmap_program = shader_load_compute("shaders/IBL/irmap.glsl");
-	scene->lum_pass1_program =
+	scene->gpu.spmap_program =
+	    shader_load_compute("shaders/IBL/spmap.glsl");
+	scene->gpu.irmap_program =
+	    shader_load_compute("shaders/IBL/irmap.glsl");
+	scene->gpu.lum_pass1_program =
 	    shader_load_compute("shaders/IBL/luminance_reduce_pass1.glsl");
-	scene->lum_pass2_program =
+	scene->gpu.lum_pass2_program =
 	    shader_load_compute("shaders/IBL/luminance_reduce_pass2.glsl");
 
-	if (!scene->spmap_program || !scene->irmap_program ||
-	    !scene->lum_pass1_program || !scene->lum_pass2_program) {
+	if (!scene->gpu.spmap_program || !scene->gpu.irmap_program ||
+	    !scene->gpu.lum_pass1_program || !scene->gpu.lum_pass2_program) {
 		return 0;
 	}
 
-	ibl_coordinator_init(&scene->lighting.ibl_coord, scene->spmap_program,
-	                     scene->irmap_program, scene->lum_pass1_program,
-	                     scene->lum_pass2_program);
+	ibl_coordinator_init(&scene->lighting.ibl_coord,
+	                     scene->gpu.spmap_program, scene->gpu.irmap_program,
+	                     scene->gpu.lum_pass1_program,
+	                     scene->gpu.lum_pass2_program);
 	return 1;
 }
 
@@ -347,20 +353,20 @@ static int scene_init_instanced_shader(Scene* scene, Shader** out_shader)
 {
 #ifdef USE_SSBO_RENDERING
 	scene_init_ssbo(scene);
-	scene->pbr_ssbo_shader = shader_load("shaders/pbr_ibl_ssbo.vert",
-	                                     "shaders/pbr_ibl_instanced.frag");
-	if (!scene->pbr_ssbo_shader) {
+	scene->shaders.pbr_ssbo = shader_load("shaders/pbr_ibl_ssbo.vert",
+	                                      "shaders/pbr_ibl_instanced.frag");
+	if (!scene->shaders.pbr_ssbo) {
 		return 0;
 	}
-	*out_shader = scene->pbr_ssbo_shader;
+	*out_shader = scene->shaders.pbr_ssbo;
 #else
 	scene_init_instancing(scene);
-	scene->pbr_instanced_shader = shader_load(
+	scene->shaders.pbr_instanced = shader_load(
 	    "shaders/pbr_ibl_instanced.vert", "shaders/pbr_ibl_instanced.frag");
-	if (!scene->pbr_instanced_shader) {
+	if (!scene->shaders.pbr_instanced) {
 		return 0;
 	}
-	*out_shader = scene->pbr_instanced_shader;
+	*out_shader = scene->shaders.pbr_instanced;
 #endif
 
 	scene->instanced_uniforms.debug_mode =
@@ -416,22 +422,22 @@ int scene_init(Scene* scene)
 		return 0;
 	}
 
-	render_utils_create_empty_vao(&scene->empty_vao);
+	render_utils_create_empty_vao(&scene->gpu.empty_vao);
 
 	if (!scene_init_billboard_shader(scene)) {
 		return 0;
 	}
 
-	render_utils_create_quad_vbo(&scene->quad_vbo);
-	render_utils_create_wire_cube_vbo(&scene->wire_cube_vbo);
-	render_utils_create_wire_quad_vbo(&scene->wire_quad_vbo);
-	skybox_init(&scene->visuals.skybox, scene->skybox_shader);
+	render_utils_create_quad_vbo(&scene->gpu.quad_vbo);
+	render_utils_create_wire_cube_vbo(&scene->gpu.wire_cube_vbo);
+	render_utils_create_wire_quad_vbo(&scene->gpu.wire_quad_vbo);
+	skybox_init(&scene->visuals.skybox, scene->shaders.skybox);
 	icosphere_init(&scene->geometry);
 
-	glGenVertexArrays(1, &scene->icosphere_vao);
-	glGenBuffers(1, &scene->icosphere_vbo);
-	glGenBuffers(1, &scene->icosphere_nbo);
-	glGenBuffers(1, &scene->icosphere_ebo);
+	glGenVertexArrays(1, &scene->gpu.icosphere_vao);
+	glGenBuffers(1, &scene->gpu.icosphere_vbo);
+	glGenBuffers(1, &scene->gpu.icosphere_nbo);
+	glGenBuffers(1, &scene->gpu.icosphere_ebo);
 
 	scene->lighting.material_lib =
 	    material_load_presets("assets/materials/pbr_materials.json");
@@ -457,74 +463,74 @@ int scene_init(Scene* scene)
 		return 0;
 	}
 
-	scene->debug_uniforms.projection =
-	    shader_get_uniform_location(scene->debug_line_shader, "projection");
+	scene->debug_uniforms.projection = shader_get_uniform_location(
+	    scene->shaders.debug_line, "projection");
 	scene->debug_uniforms.view =
-	    shader_get_uniform_location(scene->debug_line_shader, "view");
-	scene->debug_uniforms.u_stippled =
-	    shader_get_uniform_location(scene->debug_line_shader, "u_stippled");
+	    shader_get_uniform_location(scene->shaders.debug_line, "view");
+	scene->debug_uniforms.u_stippled = shader_get_uniform_location(
+	    scene->shaders.debug_line, "u_stippled");
 	scene->debug_uniforms.u_billboard_mode = shader_get_uniform_location(
-	    scene->debug_line_shader, "u_billboardMode");
+	    scene->shaders.debug_line, "u_billboardMode");
 	scene->debug_uniforms.u_use_instance_col = shader_get_uniform_location(
-	    scene->debug_line_shader, "u_useInstanceColor");
+	    scene->shaders.debug_line, "u_useInstanceColor");
 	scene->debug_uniforms.u_color =
-	    shader_get_uniform_location(scene->debug_line_shader, "u_color");
+	    shader_get_uniform_location(scene->shaders.debug_line, "u_color");
 
 	return 1;
 }
 
 static void scene_cleanup_pbr_shaders(Scene* scene)
 {
-	SHADER_SAFE_DESTROY(scene->pbr_instanced_shader);
-	SHADER_SAFE_DESTROY(scene->pbr_billboard_shader);
+	SHADER_SAFE_DESTROY(scene->shaders.pbr_instanced);
+	SHADER_SAFE_DESTROY(scene->shaders.pbr_billboard);
 #ifdef USE_SSBO_RENDERING
-	SHADER_SAFE_DESTROY(scene->pbr_ssbo_shader);
+	SHADER_SAFE_DESTROY(scene->shaders.pbr_ssbo);
 #endif
-	GL_SAFE_DELETE_PROGRAM(scene->spmap_program);
-	GL_SAFE_DELETE_PROGRAM(scene->irmap_program);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu.spmap_program);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu.irmap_program);
 }
 
 static void scene_cleanup_shaders(Scene* scene)
 {
 	scene_cleanup_pbr_shaders(scene);
 
-	SHADER_SAFE_DESTROY(scene->debug_shader);
-	SHADER_SAFE_DESTROY(scene->debug_line_shader);
-	SHADER_SAFE_DESTROY(scene->skybox_shader);
-	GL_SAFE_DELETE_PROGRAM(scene->lum_pass1_program);
-	GL_SAFE_DELETE_PROGRAM(scene->lum_pass2_program);
+	SHADER_SAFE_DESTROY(scene->shaders.debug);
+	SHADER_SAFE_DESTROY(scene->shaders.debug_line);
+	SHADER_SAFE_DESTROY(scene->shaders.skybox);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu.lum_pass1_program);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu.lum_pass2_program);
 }
 
 static void scene_cleanup_geometry_buffers(Scene* scene)
 {
-	GL_SAFE_DELETE_VAO(scene->icosphere_vao);
-	GL_SAFE_DELETE_BUFFER(scene->icosphere_vbo);
-	GL_SAFE_DELETE_BUFFER(scene->icosphere_nbo);
-	GL_SAFE_DELETE_BUFFER(scene->icosphere_ebo);
+	GL_SAFE_DELETE_VAO(scene->gpu.icosphere_vao);
+	GL_SAFE_DELETE_BUFFER(scene->gpu.icosphere_vbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu.icosphere_nbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu.icosphere_ebo);
 }
 
 static void scene_cleanup_buffers(Scene* scene)
 {
 	scene_cleanup_geometry_buffers(scene);
 
-	GL_SAFE_DELETE_VAO(scene->empty_vao);
-	GL_SAFE_DELETE_BUFFER(scene->wire_cube_vbo);
-	GL_SAFE_DELETE_BUFFER(scene->wire_quad_vbo);
-	GL_SAFE_DELETE_BUFFER(scene->quad_vbo);
-	GL_SAFE_DELETE_BUFFERS(2, scene->lum_ssbo);
-	GL_SAFE_DELETE_BUFFER(scene->billboard_ubo);
+	GL_SAFE_DELETE_VAO(scene->gpu.empty_vao);
+	GL_SAFE_DELETE_BUFFER(scene->gpu.wire_cube_vbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu.wire_quad_vbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu.quad_vbo);
+	GL_SAFE_DELETE_BUFFERS(2, scene->gpu.lum_ssbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu.billboard_ubo);
 }
 
 static void scene_cleanup_textures(Scene* scene)
 {
-	GL_SAFE_DELETE_TEXTURE(scene->hdr_texture);
-	GL_SAFE_DELETE_TEXTURE(scene->recycled_hdr_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->brdf_lut_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->spec_prefiltered_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->irradiance_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->dummy_black_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->dummy_white_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->transition_snapshot_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.hdr_texture);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.recycled_hdr_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.brdf_lut_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.spec_prefiltered_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.irradiance_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.dummy_black_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.dummy_white_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu.transition_snapshot_tex);
 }
 
 static void scene_cleanup_gpu_resources(Scene* scene)
@@ -592,20 +598,20 @@ const char* aa_mode_to_string(AAMode mode)
 
 void scene_update_gpu_buffers(Scene* scene)
 {
-	glBindVertexArray(scene->icosphere_vao);
-	glBindBuffer(GL_ARRAY_BUFFER, scene->icosphere_vbo);
+	glBindVertexArray(scene->gpu.icosphere_vao);
+	glBindBuffer(GL_ARRAY_BUFFER, scene->gpu.icosphere_vbo);
 	glBufferData(GL_ARRAY_BUFFER,
 	             (GLsizeiptr)(scene->geometry.vertices.size * sizeof(vec3)),
 	             scene->geometry.vertices.data, GL_STATIC_DRAW);
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(vec3), (void*)0);
 	glEnableVertexAttribArray(0);
-	glBindBuffer(GL_ARRAY_BUFFER, scene->icosphere_nbo);
+	glBindBuffer(GL_ARRAY_BUFFER, scene->gpu.icosphere_nbo);
 	glBufferData(GL_ARRAY_BUFFER,
 	             (GLsizeiptr)(scene->geometry.normals.size * sizeof(vec3)),
 	             scene->geometry.normals.data, GL_STATIC_DRAW);
 	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(vec3), (void*)0);
 	glEnableVertexAttribArray(1);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, scene->icosphere_ebo);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, scene->gpu.icosphere_ebo);
 	glBufferData(
 	    GL_ELEMENT_ARRAY_BUFFER,
 	    (GLsizeiptr)(scene->geometry.indices.size * sizeof(unsigned int)),
@@ -623,36 +629,37 @@ static void scene_bind_probe_textures(Scene* scene)
 {
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 		GLuint tex = scene->lighting.probe_grid.sh_textures[i];
-		if (tex != scene->bound_sh_textures[i]) {
+		if (tex != scene->gpu.bound_sh_textures[i]) {
 			glActiveTexture(
 			    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_SH_START + i));
 			glBindTexture(GL_TEXTURE_3D, tex);
-			scene->bound_sh_textures[i] = tex;
+			scene->gpu.bound_sh_textures[i] = tex;
 		}
 	}
 
-	if (scene->lighting.probe_grid.ssbo != scene->bound_probe_ssbo) {
+	if (scene->lighting.probe_grid.ssbo != scene->gpu.bound_probe_ssbo) {
 		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3,
 		                 scene->lighting.probe_grid.ssbo);
-		scene->bound_probe_ssbo = scene->lighting.probe_grid.ssbo;
+		scene->gpu.bound_probe_ssbo = scene->lighting.probe_grid.ssbo;
 	}
 }
 
 static void scene_bind_ibl_textures(Scene* scene)
 {
 	GLuint textures[IBL_TEXTURE_COUNT] = {
-	    scene->irradiance_tex ? scene->irradiance_tex
-	                          : scene->dummy_black_tex,
-	    scene->spec_prefiltered_tex ? scene->spec_prefiltered_tex
-	                                : scene->dummy_black_tex,
-	    scene->brdf_lut_tex ? scene->brdf_lut_tex : scene->dummy_black_tex};
+	    scene->gpu.irradiance_tex ? scene->gpu.irradiance_tex
+	                              : scene->gpu.dummy_black_tex,
+	    scene->gpu.spec_prefiltered_tex ? scene->gpu.spec_prefiltered_tex
+	                                    : scene->gpu.dummy_black_tex,
+	    scene->gpu.brdf_lut_tex ? scene->gpu.brdf_lut_tex
+	                            : scene->gpu.dummy_black_tex};
 
 	for (int i = 0; i < IBL_TEXTURE_COUNT; i++) {
-		if (textures[i] != scene->bound_ibl_textures[i]) {
+		if (textures[i] != scene->gpu.bound_ibl_textures[i]) {
 			glActiveTexture(
 			    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_IBL_START + i));
 			glBindTexture(GL_TEXTURE_2D, textures[i]);
-			scene->bound_ibl_textures[i] = textures[i];
+			scene->gpu.bound_ibl_textures[i] = textures[i];
 		}
 	}
 }
@@ -661,7 +668,7 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
                                     vec3 camera_pos, mat4 previous_view_proj,
                                     int width, int height)
 {
-	Shader* current_shader = scene->pbr_billboard_shader;
+	Shader* current_shader = scene->shaders.pbr_billboard;
 	shader_use(current_shader);
 
 	scene_bind_ibl_textures(scene);
@@ -674,23 +681,23 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		glm_mat4_copy(previous_view_proj,
 		              (vec4*)ubo.previous_view_proj);
 		glm_vec3_copy(camera_pos, ubo.cam_pos);
-		ubo.debug_mode = scene->pbr_debug_mode;
+		ubo.debug_mode = scene->config.pbr_debug_mode;
 		ubo.screen_size[0] = (float)width;
 		ubo.screen_size[1] = (float)height;
 		glm_vec3_copy(scene->lighting.probe_grid.aabb_min,
 		              ubo.probe_grid_min);
-		ubo.gi_mode = (int32_t)scene->gi_mode;
+		ubo.gi_mode = (int32_t)scene->config.gi_mode;
 		glm_vec3_copy(scene->lighting.probe_grid.aabb_max,
 		              ubo.probe_grid_max);
-		ubo.specular_aa_enabled = scene->specular_aa_enabled;
+		ubo.specular_aa_enabled = scene->config.specular_aa_enabled;
 		ubo.probe_grid_dim[0] = scene->lighting.probe_grid.grid_dim[0];
 		ubo.probe_grid_dim[1] = scene->lighting.probe_grid.grid_dim[1];
 		ubo.probe_grid_dim[2] = scene->lighting.probe_grid.grid_dim[2];
-		ubo.aa_mode = scene->aa_mode;
+		ubo.aa_mode = scene->config.aa_mode;
 
-		if (scene->billboard_ubo_ptr) {
+		if (scene->gpu.billboard_ubo_ptr) {
 			// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-			memcpy(scene->billboard_ubo_ptr, &ubo,
+			memcpy(scene->gpu.billboard_ubo_ptr, &ubo,
 			       sizeof(BillboardUBO));
 		}
 	}
@@ -705,14 +712,14 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 
 	billboard_group_draw(&scene->billboard_group);
 
-	if (scene->pbr_debug_mode == 0 && scene->wireframe) {
+	if (scene->config.pbr_debug_mode == 0 && scene->config.wireframe) {
 		/* Wireframe Overlay */
 		/* Enable Depth Test but disable Depth Write to overlay
 		 * correctly */
 		glEnable(GL_DEPTH_TEST);
 		glDepthMask(GL_FALSE);
 
-		shader_use(scene->debug_line_shader);
+		shader_use(scene->shaders.debug_line);
 		shader_set_mat4_loc(scene->debug_uniforms.projection,
 		                    (float*)proj);
 		shader_set_mat4_loc(scene->debug_uniforms.view, (float*)view);
@@ -771,9 +778,9 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 {
 	Shader* current_shader = NULL;
 #ifdef USE_SSBO_RENDERING
-	current_shader = scene->pbr_ssbo_shader;
+	current_shader = scene->shaders.pbr_ssbo;
 #else
-	current_shader = scene->pbr_instanced_shader;
+	current_shader = scene->shaders.pbr_instanced;
 #endif
 
 	shader_use(current_shader);
@@ -781,7 +788,7 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 	scene_bind_ibl_textures(scene);
 
 	shader_set_int_loc(scene->instanced_uniforms.debug_mode,
-	                   scene->pbr_debug_mode);
+	                   scene->config.pbr_debug_mode);
 	shader_set_vec3_loc(scene->instanced_uniforms.cam_pos, camera_pos);
 	shader_set_mat4_loc(scene->instanced_uniforms.projection, (float*)proj);
 	shader_set_mat4_loc(scene->instanced_uniforms.view, (float*)view);
@@ -790,11 +797,11 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 
 	if (scene->instanced_uniforms.u_specular_aa_enabled != -1) {
 		glUniform1i(scene->instanced_uniforms.u_specular_aa_enabled,
-		            scene->specular_aa_enabled);
+		            scene->config.specular_aa_enabled);
 	}
 	if (scene->instanced_uniforms.u_aa_mode != -1) {
 		glUniform1i(scene->instanced_uniforms.u_aa_mode,
-		            scene->aa_mode);
+		            scene->config.aa_mode);
 	}
 
 	/* Probe Grid spatial bounds and GI Toggle */
@@ -810,7 +817,7 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 		            scene->lighting.probe_grid.grid_dim[2]);
 	}
 	shader_set_int_loc(scene->instanced_uniforms.gi_mode,
-	                   (int)scene->gi_mode);
+	                   (int)scene->config.gi_mode);
 
 	scene_bind_probe_textures(scene);
 
@@ -840,7 +847,8 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 	glm_mat4_inv(view_proj, inv_view_proj);
 
 	/* GI Probe SSBO sync — must happen before Spheres read it */
-	if (scene->gi_mode != GI_MODE_OFF || scene->show_probe_grid) {
+	if (scene->config.gi_mode != GI_MODE_OFF ||
+	    scene->config.show_probe_grid) {
 		PROFILE_ZONE(gi_sync_ctx,
 		             "GI Light Probe Grid Sync (buffer upload)");
 		light_probe_grid_sync(&scene->lighting.probe_grid);
@@ -848,21 +856,22 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 		 * via glBindTexture(GL_TEXTURE_3D, 0) — invalidate cache
 		 * so scene_bind_probe_textures() will re-bind. */
 		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
-			scene->bound_sh_textures[i] = 0;
+			scene->gpu.bound_sh_textures[i] = 0;
 		}
 		PROFILE_ZONE_END(gi_sync_ctx);
 	}
 
 #ifdef USE_TRANSPARENT_BILLBOARDS
-	if (scene->show_envmap) {
+	if (scene->config.show_envmap) {
 		GPU_STAGE_PROFILER(profiler, "Environment",
 		                   GPU_PROFILER_ENV_COLOR);
 		gl_debug_push_group("Skybox_Pass");
 		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 		glDisable(GL_DEPTH_TEST);
-		skybox_render(&scene->visuals.skybox, scene->skybox_shader,
-		              scene->hdr_texture, scene->dummy_black_tex,
-		              inv_view_proj, scene->env_lod);
+		skybox_render(&scene->visuals.skybox, scene->shaders.skybox,
+		              scene->gpu.hdr_texture,
+		              scene->gpu.dummy_black_tex, inv_view_proj,
+		              scene->config.env_lod);
 		glEnable(GL_DEPTH_TEST);
 		gl_debug_pop_group();
 	}
@@ -870,7 +879,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 	{
 		stencil_begin_object_pass();
 
-		if (scene->billboard_mode) {
+		if (scene->config.billboard_mode) {
 			gl_debug_push_group("Billboard_Sort_And_Render");
 			GLuint sorted_ssbo = 0;
 
@@ -880,7 +889,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 				    profiler, "Sphere Sort",
 				    GPU_PROFILER_MOTION_BLUR_COLOR);
 
-				switch (scene->sorting_mode) {
+				switch (scene->config.sorting_mode) {
 					case SORTING_MODE_CPU_QSORT:
 						sorted_ssbo =
 						    billboard_sorter_sort_cpu(
@@ -927,7 +936,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			/* Legacy VBO copy only for debug wireframe overlay
 			 * (debug_line_shader reads per-SphereInstance
 			 * attributes) */
-			if (scene->wireframe) {
+			if (scene->config.wireframe) {
 				billboard_group_update_from_buffer(
 				    &scene->billboard_group, sorted_ssbo,
 				    scene->billboard_instance_count);
@@ -955,13 +964,14 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			GPU_STAGE_PROFILER(profiler, "Instanced Render",
 			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
-			glPolygonMode(GL_FRONT_AND_BACK,
-			              scene->wireframe ? GL_LINE : GL_FILL);
+			glPolygonMode(GL_FRONT_AND_BACK, scene->config.wireframe
+			                                     ? GL_LINE
+			                                     : GL_FILL);
 
 			scene_render_instanced(scene, view, proj, camera_pos,
 			                       previous_view_proj);
 
-			if (scene->wireframe) {
+			if (scene->config.wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 			}
 			gl_debug_pop_group();
@@ -973,7 +983,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 	{
 		stencil_begin_object_pass();
 
-		if (scene->billboard_mode) {
+		if (scene->config.billboard_mode) {
 			gl_debug_push_group("Billboard_Render");
 
 			/* 1. Dummy sort (legacy/fallback path) */
@@ -999,12 +1009,13 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			GPU_STAGE_PROFILER(profiler, "Instanced Render",
 			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
-			glPolygonMode(GL_FRONT_AND_BACK,
-			              scene->wireframe ? GL_LINE : GL_FILL);
+			glPolygonMode(GL_FRONT_AND_BACK, scene->config.wireframe
+			                                     ? GL_LINE
+			                                     : GL_FILL);
 			scene_render_instanced(scene, view, proj, camera_pos,
 			                       previous_view_proj);
 
-			if (scene->wireframe) {
+			if (scene->config.wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 			}
 			gl_debug_pop_group();
@@ -1031,21 +1042,21 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			GPU_STAGE_PROFILER(profiler, "Shockwave VFX",
 			                   GPU_PROFILER_SHOCKWAVE_COLOR);
 			gl_debug_push_group("Shockwave_VFX");
-			if (scene->wireframe) {
+			if (scene->config.wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 			}
 			shockwave_draw(&scene->visuals.shockwave_renderer, view,
 			               proj, camera_pos,
 			               scene->simulation.nbody_sim.sim_time,
 			               width, height);
-			if (scene->wireframe) {
+			if (scene->config.wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 			}
 			gl_debug_pop_group();
 		}
 	}
 
-	if (scene->show_probe_grid) {
+	if (scene->config.show_probe_grid) {
 		light_probe_grid_render_debug(&scene->lighting.probe_grid, view,
 		                              proj);
 	}

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -186,7 +186,7 @@ void setUp(void)
 		int timeout = POLL_TIMEOUT_ITERATIONS;
 		double last_time = glfwGetTime();
 		while (
-		    (g_test_app.scene.hdr_texture == 0 ||
+		    (g_test_app.scene.gpu.hdr_texture == 0 ||
 		     g_test_app.env_mgr.transition_state != TRANSITION_IDLE) &&
 		    timeout-- > 0) {
 			double current_time = glfwGetTime();
@@ -200,8 +200,8 @@ void setUp(void)
 		}
 
 		// Cache the loaded texture for subsequent tests
-		if (g_test_app.scene.hdr_texture != 0) {
-			g_cached_hdr_texture = g_test_app.scene.hdr_texture;
+		if (g_test_app.scene.gpu.hdr_texture != 0) {
+			g_cached_hdr_texture = g_test_app.scene.gpu.hdr_texture;
 		}
 
 		// Initialize PBOs for async pixel readback (optimization#2)
@@ -225,7 +225,7 @@ void setUp(void)
 		preload_all_references();
 	} else if (g_cached_hdr_texture != 0) {
 		// Reuse cached texture for subsequent tests
-		g_test_app.scene.hdr_texture = g_cached_hdr_texture;
+		g_test_app.scene.gpu.hdr_texture = g_cached_hdr_texture;
 	}
 }
 

--- a/tests/test_app_input.c
+++ b/tests/test_app_input.c
@@ -125,19 +125,19 @@ void test_handle_app_input_exhaustive(void)
 	handle_app_input(&ctx, GLFW_KEY_F4, 0);
 	TEST_ASSERT_TRUE(test_app->profiling->log_gpu_metrics);
 	handle_app_input(&ctx, GLFW_KEY_Z, 0);
-	TEST_ASSERT_TRUE(test_app->scene.wireframe);
+	TEST_ASSERT_TRUE(test_app->scene.config.wireframe);
 	handle_app_input(&ctx, GLFW_KEY_C, 0);
 	TEST_ASSERT_TRUE(test_app->input->camera_enabled);
 	handle_app_input(&ctx, GLFW_KEY_L, 0);
-	TEST_ASSERT_TRUE(test_app->scene.billboard_mode);
+	TEST_ASSERT_TRUE(test_app->scene.config.billboard_mode);
 	handle_app_input(&ctx, GLFW_KEY_K, 0);
-	TEST_ASSERT_TRUE(test_app->scene.show_envmap);
+	TEST_ASSERT_TRUE(test_app->scene.config.show_envmap);
 
 	/* PBR Debug Modes (cycle) */
-	int initial_debug = test_app->scene.pbr_debug_mode;
+	int initial_debug = test_app->scene.config.pbr_debug_mode;
 	handle_app_input(&ctx, GLFW_KEY_F5, 0);
 	TEST_ASSERT_EQUAL((initial_debug + 1) % 9,
-	                  test_app->scene.pbr_debug_mode);
+	                  test_app->scene.config.pbr_debug_mode);
 
 	/* Banding Styles (cycle) */
 	/* First press enables banding and sets idx to 0 (Linear) */
@@ -321,11 +321,11 @@ void test_key_callback_dispatch(void)
 void test_subdiv_input(void)
 {
 	AppInputContext ctx = test_ctx_from_app(test_app);
-	test_app->scene.subdivisions = 2;
+	test_app->scene.config.subdivisions = 2;
 	handle_app_input(&ctx, GLFW_KEY_UP, 0);
-	TEST_ASSERT_EQUAL(3, test_app->scene.subdivisions);
+	TEST_ASSERT_EQUAL(3, test_app->scene.config.subdivisions);
 	handle_app_input(&ctx, GLFW_KEY_DOWN, 0);
-	TEST_ASSERT_EQUAL(2, test_app->scene.subdivisions);
+	TEST_ASSERT_EQUAL(2, test_app->scene.config.subdivisions);
 }
 
 /**

--- a/tests/test_env_transition.c
+++ b/tests/test_env_transition.c
@@ -93,7 +93,7 @@ void test_transition_crossfade_flow(void)
 	TEST_ASSERT_EQUAL_FLOAT(1.0F, g_test_app->env_mgr.transition_alpha);
 	/* Snapshot texture should have been generated */
 	TEST_ASSERT_NOT_EQUAL(TEXTURE_ID_ZERO,
-	                      g_test_app->scene.transition_snapshot_tex);
+	                      g_test_app->scene.gpu.transition_snapshot_tex);
 }
 
 /**


### PR DESCRIPTION
## Summary

Final issue of Phase 7: extract GPU resources, shaders, and config into dedicated sub-struct headers, completing the Scene decomposition.

### Changes (4 SoC commits)

1. **`refactor(scene)`**: Add 6 dedicated headers decomposing Scene:
   - `scene_gpu_resources.h`: `SceneGPUResources` (28 GLuint handles, UBO, binding caches)
   - `scene_shaders.h`: `SceneShaders` (6 Shader* pointers)
   - `scene_config.h`: `SceneConfig` (11 runtime flags + `SortingMode`/`GIMode`/`AAMode` enums)
   - `scene_visuals.h`: `SceneVisuals` (Skybox, TrailRenderer, ShockwaveRenderer)
   - `scene_lighting.h`: `SceneLighting` (IBLCoordinator, LightProbeGrid, MaterialLib*)
   - `scene_simulation.h`: `SceneSimulation` (NBodySim, nbody_mode)
   - `scene.h` rewritten to compose via value members (`gpu`, `shaders`, `config`, `visuals`, `lighting`, `simulation`)

2. **`refactor(scene)`**: Migrate all source access sites:
   - `scene->X` → `scene->gpu.X` / `scene->shaders.X` / `scene->config.X`
   - Files: `scene.c`, `app.c`, `app_input.c`, `env_manager.c`

3. **`test(scene)`**: Update tests for new access paths:
   - `test_app.c`, `test_app_input.c`, `test_env_transition.c`

4. **`docs(scene)`**: Sync EN + FR architecture docs:
   - `architecture.md`/`.fr.md`: Scene Decomposition section updated
   - `project_structure.md`/`.fr.md`: new headers in include/ tree
   - `copilot-instructions.md`: Scene row in architecture table

### Metrics
- Scene direct field count: ~50 → ~19
- `scene.h` includes: focused on sub-struct headers
- Build: clean (0 warnings), Tests: 63/63, Format + Lint: clean

Closes #224