### PR TITLE
refactor(input): introduce GamepadContext seam to decouple gamepad from camera

### DIFF
--- a/include/gamepad_context.h
+++ b/include/gamepad_context.h
@@ -1,0 +1,28 @@
+/**
+ * @file gamepad_context.h
+ * @brief Decoupling seam between gamepad input and camera internals.
+ *
+ * GamepadContext exposes only the minimal subset of camera state that
+ * gamepad_write_input() needs, breaking the direct dependency on camera.h.
+ */
+
+#ifndef GAMEPAD_CONTEXT_H
+#define GAMEPAD_CONTEXT_H
+
+/**
+ * @struct GamepadContext
+ * @brief Minimal camera state slice for gamepad input application.
+ *
+ * The caller fills this from Camera fields before calling
+ * gamepad_write_input(), then copies the results back.
+ */
+typedef struct GamepadContext {
+	float move_input[3];  /**< [right/left, up/down, fwd/back]. */
+	float yaw_target;     /**< Target yaw in degrees. */
+	float pitch_target;   /**< Target pitch in degrees. */
+	float fixed_timestep; /**< Physics step duration (seconds). */
+	float max_pitch;      /**< Upper pitch clamp (degrees). */
+	float min_pitch;      /**< Lower pitch clamp (degrees). */
+} GamepadContext;
+
+#endif /* GAMEPAD_CONTEXT_H */

--- a/include/gamepad_input.h
+++ b/include/gamepad_input.h
@@ -11,7 +11,7 @@
 #ifndef GAMEPAD_INPUT_H
 #define GAMEPAD_INPUT_H
 
-typedef struct Camera Camera;
+#include "gamepad_context.h"
 
 /** Maximum number of gamepad buttons tracked for edge detection. */
 #define GAMEPAD_BUTTON_COUNT 15
@@ -72,16 +72,15 @@ void gamepad_input_init(GamepadState* state);
 void gamepad_input_poll(GamepadState* state, GamepadActions* actions);
 
 /**
- * @brief Writes gamepad axes into cam->move_input and applies look.
+ * @brief Writes gamepad axes into a GamepadContext.
  *
- * Overlays analog stick values onto the camera's unified move_input.
- * Must be called after camera_build_keyboard_input and before
- * camera_fixed_update each physics step.
+ * Overlays analog stick values onto move_input and applies look
+ * (yaw/pitch).  The caller bridges Camera ↔ GamepadContext.
  *
  * @param state Pointer to the gamepad state (with cached axes).
- * @param cam   Pointer to the camera to drive.
+ * @param ctx   Pointer to the context to write into.
  */
-void gamepad_write_input(const GamepadState* state, Camera* cam);
+void gamepad_write_input(const GamepadState* state, GamepadContext* ctx);
 
 /**
  * @brief Applies a dead-zone filter to an axis value.

--- a/src/app.c
+++ b/src/app.c
@@ -290,8 +290,24 @@ void app_run(App* app)
 			       app->input->camera.fixed_timestep) {
 				camera_build_keyboard_input(
 				    &app->input->camera);
+				Camera* cam = &app->input->camera;
+				GamepadContext gctx = {
+				    .move_input = {cam->move_input[0],
+				                   cam->move_input[1],
+				                   cam->move_input[2]},
+				    .yaw_target = cam->yaw_target,
+				    .pitch_target = cam->pitch_target,
+				    .fixed_timestep = cam->fixed_timestep,
+				    .max_pitch = DEFAULT_MAX_PITCH,
+				    .min_pitch = DEFAULT_MIN_PITCH,
+				};
 				gamepad_write_input(&app->input->gamepad,
-				                    &app->input->camera);
+				                    &gctx);
+				cam->move_input[0] = gctx.move_input[0];
+				cam->move_input[1] = gctx.move_input[1];
+				cam->move_input[2] = gctx.move_input[2];
+				cam->yaw_target = gctx.yaw_target;
+				cam->pitch_target = gctx.pitch_target;
 				camera_fixed_update(&app->input->camera);
 				app->input->camera.physics_accumulator -=
 				    app->input->camera.fixed_timestep;

--- a/src/gamepad_input.c
+++ b/src/gamepad_input.c
@@ -1,6 +1,5 @@
 #include "gamepad_input.h"
 
-#include "camera.h"
 #include "log.h"
 #ifndef GLFW_INCLUDE_NONE
 #define GLFW_INCLUDE_NONE
@@ -135,7 +134,7 @@ void gamepad_input_poll(GamepadState* state, GamepadActions* actions)
 	gamepad_poll_buttons(state, &pad, actions);
 }
 
-void gamepad_write_input(const GamepadState* state, Camera* cam)
+void gamepad_write_input(const GamepadState* state, GamepadContext* ctx)
 {
 	if (!state->connected) {
 		return;
@@ -148,10 +147,10 @@ void gamepad_write_input(const GamepadState* state, Camera* cam)
 	float stick_ly = state->axes[GLFW_GAMEPAD_AXIS_LEFT_Y];
 
 	if (fabsf(stick_lx) > 0.0F) {
-		cam->move_input[0] = stick_lx * state->move_sensitivity;
+		ctx->move_input[0] = stick_lx * state->move_sensitivity;
 	}
 	if (fabsf(stick_ly) > 0.0F) {
-		cam->move_input[2] = -stick_ly * state->move_sensitivity;
+		ctx->move_input[2] = -stick_ly * state->move_sensitivity;
 	}
 
 	/* Triggers → move_input[1] (up/down).
@@ -160,7 +159,7 @@ void gamepad_write_input(const GamepadState* state, Camera* cam)
 	float trig_left = state->axes[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER];
 
 	if (trig_right > 0.0F || trig_left > 0.0F) {
-		cam->move_input[1] =
+		ctx->move_input[1] =
 		    (trig_right - trig_left) * state->move_sensitivity;
 	}
 
@@ -170,15 +169,15 @@ void gamepad_write_input(const GamepadState* state, Camera* cam)
 
 	if (fabsf(stick_rx) > 0.0F || fabsf(stick_ry) > 0.0F) {
 		float look_speed =
-		    state->look_sensitivity * cam->fixed_timestep;
-		cam->yaw_target += stick_rx * look_speed;
-		cam->pitch_target -= stick_ry * look_speed;
+		    state->look_sensitivity * ctx->fixed_timestep;
+		ctx->yaw_target += stick_rx * look_speed;
+		ctx->pitch_target -= stick_ry * look_speed;
 
-		if (cam->pitch_target > DEFAULT_MAX_PITCH) {
-			cam->pitch_target = DEFAULT_MAX_PITCH;
+		if (ctx->pitch_target > ctx->max_pitch) {
+			ctx->pitch_target = ctx->max_pitch;
 		}
-		if (cam->pitch_target < DEFAULT_MIN_PITCH) {
-			cam->pitch_target = DEFAULT_MIN_PITCH;
+		if (ctx->pitch_target < ctx->min_pitch) {
+			ctx->pitch_target = ctx->min_pitch;
 		}
 	}
 }

--- a/tests/test_gamepad_input.c
+++ b/tests/test_gamepad_input.c
@@ -7,6 +7,30 @@
 #include <stdarg.h>
 #include <string.h>
 
+/* ---- Camera ↔ GamepadContext bridge helpers ---- */
+
+static GamepadContext gamepad_ctx_from_camera(const Camera* cam)
+{
+	return (GamepadContext){
+	    .move_input = {cam->move_input[0], cam->move_input[1],
+	                   cam->move_input[2]},
+	    .yaw_target = cam->yaw_target,
+	    .pitch_target = cam->pitch_target,
+	    .fixed_timestep = cam->fixed_timestep,
+	    .max_pitch = DEFAULT_MAX_PITCH,
+	    .min_pitch = DEFAULT_MIN_PITCH,
+	};
+}
+
+static void gamepad_ctx_to_camera(const GamepadContext* ctx, Camera* cam)
+{
+	cam->move_input[0] = ctx->move_input[0];
+	cam->move_input[1] = ctx->move_input[1];
+	cam->move_input[2] = ctx->move_input[2];
+	cam->yaw_target = ctx->yaw_target;
+	cam->pitch_target = ctx->pitch_target;
+}
+
 /* ---- Stub for log_message (avoids linking log.c + platform deps) ---- */
 void log_message(LogLevel level, const char* tag, const char* fmt, ...)
 {
@@ -142,7 +166,9 @@ void test_poll_without_gamepad_does_nothing(void)
 
 	gamepad_input_poll(&state, NULL);
 	camera_build_keyboard_input(&cam);
-	gamepad_write_input(&state, &cam);
+	GamepadContext gctx = gamepad_ctx_from_camera(&cam);
+	gamepad_write_input(&state, &gctx);
+	gamepad_ctx_to_camera(&gctx, &cam);
 
 	TEST_ASSERT_EQUAL(0, state.connected);
 	/* move_input should stay zero. */
@@ -169,7 +195,9 @@ void test_poll_left_stick_forward_adds_velocity(void)
 
 	gamepad_input_poll(&state, NULL);
 	camera_build_keyboard_input(&cam);
-	gamepad_write_input(&state, &cam);
+	GamepadContext gctx = gamepad_ctx_from_camera(&cam);
+	gamepad_write_input(&state, &gctx);
+	gamepad_ctx_to_camera(&gctx, &cam);
 
 	TEST_ASSERT_EQUAL(1, state.connected);
 	/* move_input[2] should be positive (forward). */
@@ -197,7 +225,9 @@ void test_poll_right_stick_yaw(void)
 
 	gamepad_input_poll(&state, NULL);
 	camera_build_keyboard_input(&cam);
-	gamepad_write_input(&state, &cam);
+	GamepadContext gctx = gamepad_ctx_from_camera(&cam);
+	gamepad_write_input(&state, &gctx);
+	gamepad_ctx_to_camera(&gctx, &cam);
 
 	/* Yaw should have increased (looking right). */
 	TEST_ASSERT_TRUE(cam.yaw_target > yaw_before);
@@ -218,7 +248,9 @@ void test_poll_triggers_vertical_movement(void)
 
 	gamepad_input_poll(&state, NULL);
 	camera_build_keyboard_input(&cam);
-	gamepad_write_input(&state, &cam);
+	GamepadContext gctx = gamepad_ctx_from_camera(&cam);
+	gamepad_write_input(&state, &gctx);
+	gamepad_ctx_to_camera(&gctx, &cam);
 
 	/* move_input[1] should be positive (up). */
 	TEST_ASSERT_TRUE(cam.move_input[1] > 0.0F);
@@ -239,7 +271,9 @@ void test_poll_left_trigger_moves_down(void)
 
 	gamepad_input_poll(&state, NULL);
 	camera_build_keyboard_input(&cam);
-	gamepad_write_input(&state, &cam);
+	GamepadContext gctx = gamepad_ctx_from_camera(&cam);
+	gamepad_write_input(&state, &gctx);
+	gamepad_ctx_to_camera(&gctx, &cam);
 
 	/* move_input[1] should be negative (down). */
 	TEST_ASSERT_TRUE(cam.move_input[1] < 0.0F);
@@ -299,7 +333,9 @@ void test_poll_sticks_in_deadzone_no_effect(void)
 
 	gamepad_input_poll(&state, NULL);
 	camera_build_keyboard_input(&cam);
-	gamepad_write_input(&state, &cam);
+	GamepadContext gctx = gamepad_ctx_from_camera(&cam);
+	gamepad_write_input(&state, &gctx);
+	gamepad_ctx_to_camera(&gctx, &cam);
 
 	/* All inputs should be zero (within deadzone). */
 	TEST_ASSERT_FLOAT_WITHIN(0.0001F, 0.0F, cam.move_input[0]);


### PR DESCRIPTION
## Summary

Introduce a `GamepadContext` seam to break the direct `gamepad_input.c → camera.h` dependency.

### Changes

- **`include/gamepad_context.h`** (new): `GamepadContext` struct with `move_input[3]`, `yaw_target`, `pitch_target`, `fixed_timestep`, `max_pitch`, `min_pitch`
- **`include/gamepad_input.h`**: `gamepad_write_input()` takes `GamepadContext*` instead of `Camera*`
- **`src/gamepad_input.c`**: removed `#include "camera.h"`, uses `GamepadContext` fields
- **`src/app.c`**: bridges `Camera ↔ GamepadContext` at the call site
- **`tests/test_gamepad_input.c`**: bridge helpers `gamepad_ctx_from_camera()` / `gamepad_ctx_to_camera()`

### Validation

- Build: clean (0 errors, 0 warnings)
- Tests: 63/63 pass
- Format + Lint: clean
- ASan integration: PASS

Closes #232