### PR TITLE
refactor(app): group window/resize fields into AppWindow sub-struct

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,13 +17,13 @@ Repository: [yoyonel/suckless-ogl](https://github.com/yoyonel/suckless-ogl).
 
 | Subsystem | Key Files |
 |-----------|-----------|
-| **Core App** | `app.c`, `main.c`, `cli.c` |
+| **Core App** | `app.c`, `main.c`, `cli.c`, `app_window.h` (`AppWindow`), `app_profiling.h` (`AppProfiling`), `app_input_state.h` (`AppInput`) |
 | **Scene** | `scene.c`, `scene.h`, `scene_gpu_resources.h`, `scene_shaders.h`, `scene_config.h`, `scene_visuals.h`, `scene_lighting.h`, `scene_simulation.h` |
 | **Rendering** | `renderer.c` (`RenderContext`), `sphere_types.h`, `instanced_rendering.c`, `ssbo_rendering.c`, `billboard_rendering.c` |
 | **PBR / IBL** | `pbr.c`, `material.c`, `ibl_coordinator.c`, `light_probes.c`, `skybox.c` |
 | **Post-Processing** | `postprocess.c`, `effects/fx_*.c` (bloom, DoF, auto-exposure, FXAA, LUT, motion blur), `effect_context.h` (`EffectContext` seam) |
 | **Shaders** | 55+ GLSL files in `shaders/` (vertex, fragment, compute) |
-| **Input** | `app_input.c` (`AppInputContext`), `camera_input.c`, `postprocess_input.c` (`PostProcessInputContext`), `app_binding.c` |
+| **Input** | `app_input.c` (`AppInputContext`), `camera_input.c`, `gamepad_input.c`, `gamepad_context.h` (`GamepadContext`), `postprocess_input.c` (`PostProcessInputContext`), `app_binding.c` |
 | **Profiling** | `gpu_profiler.c`, `perf_timer.c`, `tracy_manager.c`, `effect_benchmark.c` |
 | **Tests** | 63 test files in `tests/` (Unity framework, visual regression, benchmarks) |
 

--- a/docs/application_lifecycle.fr.md
+++ b/docs/application_lifecycle.fr.md
@@ -150,11 +150,11 @@ Cela active `GL_DEBUG_OUTPUT_SYNCHRONOUS` et enregistre un callback ([src/gl_deb
 
 ```c
 glfwSwapInterval(0);                    // VSync OFF — FPS illimité
-glfwSetKeyCallback(app->window, key_callback);
-glfwSetCursorPosCallback(app->window, mouse_callback);
-glfwSetScrollCallback(app->window, scroll_callback);
-glfwSetFramebufferSizeCallback(app->window, framebuffer_size_callback);
-glfwSetInputMode(app->window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);  // Mode FPS
+glfwSetKeyCallback(app->win.handle, key_callback);
+glfwSetCursorPosCallback(app->win.handle, mouse_callback);
+glfwSetScrollCallback(app->win.handle, scroll_callback);
+glfwSetFramebufferSizeCallback(app->win.handle, framebuffer_size_callback);
+glfwSetInputMode(app->win.handle, GLFW_CURSOR, GLFW_CURSOR_DISABLED);  // Mode FPS
 ```
 
 Le curseur est capturé en **mode relatif** — les mouvements de souris produisent des décalages delta pour le contrôle de la caméra orbitale, pas des coordonnées écran absolues.
@@ -740,9 +740,9 @@ graph TB
 ### 8.1 — Redimensionnement Différé
 
 ```c
-if (app->resize_pending) {
-    postprocess_resize(&app->postprocess, app->pending_width, app->pending_height);
-    app->resize_pending = 0;
+if (app->win.resize_pending) {
+    postprocess_resize(&app->postprocess, app->win.pending_width, app->win.pending_height);
+    app->win.resize_pending = 0;
 }
 ```
 

--- a/docs/application_lifecycle.md
+++ b/docs/application_lifecycle.md
@@ -150,11 +150,11 @@ This enables `GL_DEBUG_OUTPUT_SYNCHRONOUS` and registers a callback ([src/gl_deb
 
 ```c
 glfwSwapInterval(0);                    // VSync OFF — unlimited FPS
-glfwSetKeyCallback(app->window, key_callback);
-glfwSetCursorPosCallback(app->window, mouse_callback);
-glfwSetScrollCallback(app->window, scroll_callback);
-glfwSetFramebufferSizeCallback(app->window, framebuffer_size_callback);
-glfwSetInputMode(app->window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);  // FPS-style
+glfwSetKeyCallback(app->win.handle, key_callback);
+glfwSetCursorPosCallback(app->win.handle, mouse_callback);
+glfwSetScrollCallback(app->win.handle, scroll_callback);
+glfwSetFramebufferSizeCallback(app->win.handle, framebuffer_size_callback);
+glfwSetInputMode(app->win.handle, GLFW_CURSOR, GLFW_CURSOR_DISABLED);  // FPS-style
 ```
 
 The cursor is captured in **relative mode** — mouse movements produce delta offsets for orbit camera control, not absolute screen coordinates.
@@ -740,9 +740,9 @@ graph TB
 ### 8.1 — Deferred Resize
 
 ```c
-if (app->resize_pending) {
-    postprocess_resize(&app->postprocess, app->pending_width, app->pending_height);
-    app->resize_pending = 0;
+if (app->win.resize_pending) {
+    postprocess_resize(&app->postprocess, app->win.pending_width, app->win.pending_height);
+    app->win.resize_pending = 0;
 }
 ```
 

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -73,16 +73,33 @@ La structure `Scene` est entièrement décomposée en six sous-structs par domai
 
 Cela réduit le nombre de champs directs de `Scene` de ~50 à ~19 et déplace les définitions de types par domaine hors du monolithique `scene.h`.
 
-### Décomposition de App (AppProfiling, AppInput)
+### Décomposition de App (AppProfiling, AppInput, AppWindow)
 
-La structure `App` est progressivement décomposée en sous-structs par domaine :
+La structure `App` est décomposée en sous-structs par domaine :
 
-- **`AppProfiling`** (`include/app_profiling.h`) : regroupe le profiling et les métriques — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Accès via `app->profiling.gpu_profiler`, etc. Init/cleanup délégués à `app_profiling_init()` / `app_profiling_cleanup()` dans `src/app_profiling.c`.
-- **`AppInput`** (`include/app_input_state.h`) : regroupe la caméra, le gamepad, les raccourcis clavier et le lissage d'entrée — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Accès via `app->input.camera`, etc. Init/cleanup délégués à `app_input_state_init()` / `app_input_state_cleanup()` dans `src/app_input_state.c`.
+- **`AppProfiling`** (`include/app_profiling.h`) : regroupe le profiling et les métriques — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Accès via `app->profiling->gpu_profiler`, etc. Init/cleanup délégués à `app_profiling_init()` / `app_profiling_cleanup()` dans `src/app_profiling.c`.
+- **`AppInput`** (`include/app_input_state.h`) : regroupe la caméra, le gamepad, les raccourcis clavier et le lissage d'entrée — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Accès via `app->input->camera`, etc. Init/cleanup délégués à `app_input_state_init()` / `app_input_state_cleanup()` dans `src/app_input_state.c`.
+- **`AppWindow`** (`include/app_window.h`) : regroupe le handle de fenêtre GLFW et tout l'état fenêtre/resize — `GLFWwindow* handle`, `is_fullscreen`, `saved_x/y`, `saved_width/height`, `resize_pending`, `pending_width/height`. Accès via `app->win.handle`, `app->win.is_fullscreen`, etc.
 
 > **Note de nommage** : `app_input_state.h` héberge la définition de la sous-struct `AppInput`, tandis que le fichier existant `app_input.h` héberge le seam `AppInputContext` (bundle de pointeurs ciblés pour les handlers d'entrée, issue #204).
 
-Cela réduit le nombre de champs directs de `App` (13 champs → 2 sous-structs) et le nombre d'includes de `app.h` de 22 à 14 (sous la cible ≤15). Chaque header de sous-struct possède ses dépendances de type et ses fonctions de délégation, gardant `app.c` focalisé sur l'orchestration.
+Cela réduit le nombre de champs directs de `App` de 24 à ~17. Chaque header de sous-struct possède ses dépendances de type et ses fonctions de délégation, gardant `app.c` focalisé sur l'orchestration.
+
+### Décomposition de PostProcess (PPGPUResources, PPShaderState, PPExposureReadback)
+
+La structure `PostProcess` est décomposée en trois sous-structs par domaine :
+
+- **`PPGPUResources`** (`postprocess.h`) : tous les handles de ressources GPU — FBOs, textures, PBOs, SSBOs d'histogramme. Accès via `postprocess.gpu.scene_fbo`, etc.
+- **`PPShaderState`** (`postprocess.h`) : programmes de shaders et état de compilation — IDs de shaders, flags d'optimisation. Accès via `postprocess.shaders.program`, etc.
+- **`PPExposureReadback`** (`postprocess.h`) : état de readback asynchrone de l'exposition — handles PBO, fence, index de readback. Accès via `postprocess.readback.histogram_pbo`, etc.
+
+### Seam GamepadContext
+
+Le `GamepadContext` (`include/gamepad_context.h`) découple `gamepad_input.c` de `camera.h` :
+
+- Contient uniquement la tranche minimale d'état caméra nécessaire pour l'entrée gamepad : `move_input[3]`, `yaw_target`, `pitch_target`, `fixed_timestep`, limites de pitch.
+- `gamepad_write_input()` prend `GamepadContext*` au lieu de `Camera*`.
+- Pattern bridge : `Camera ↔ GamepadContext` au site d'appel dans `app.c`.
 
 ### Découplage des effets (EffectContext)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,16 +113,33 @@ The `Scene` struct is fully decomposed into six domain-aligned sub-structs, each
 
 This reduces `Scene`'s direct field count from ~50 to ~19 and moves domain-specific type definitions out of the monolithic `scene.h`.
 
-### App Decomposition (AppProfiling, AppInput)
+### App Decomposition (AppProfiling, AppInput, AppWindow)
 
-The `App` struct is being decomposed into domain-aligned sub-structs:
+The `App` struct is decomposed into domain-aligned sub-structs:
 
-- **`AppProfiling`** (`include/app_profiling.h`): Groups profiling and metrics — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Access via `app->profiling.gpu_profiler`, etc. Init/cleanup delegated to `app_profiling_init()` / `app_profiling_cleanup()` in `src/app_profiling.c`.
-- **`AppInput`** (`include/app_input_state.h`): Groups camera, gamepad, key-bindings, and input smoothing — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Access via `app->input.camera`, etc. Init/cleanup delegated to `app_input_state_init()` / `app_input_state_cleanup()` in `src/app_input_state.c`.
+- **`AppProfiling`** (`include/app_profiling.h`): Groups profiling and metrics — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Access via `app->profiling->gpu_profiler`, etc. Init/cleanup delegated to `app_profiling_init()` / `app_profiling_cleanup()` in `src/app_profiling.c`.
+- **`AppInput`** (`include/app_input_state.h`): Groups camera, gamepad, key-bindings, and input smoothing — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Access via `app->input->camera`, etc. Init/cleanup delegated to `app_input_state_init()` / `app_input_state_cleanup()` in `src/app_input_state.c`.
+- **`AppWindow`** (`include/app_window.h`): Groups GLFW window handle and all window/resize state — `GLFWwindow* handle`, `is_fullscreen`, `saved_x/y`, `saved_width/height`, `resize_pending`, `pending_width/height`. Access via `app->win.handle`, `app->win.is_fullscreen`, etc.
 
 > **Naming note**: `app_input_state.h` hosts the `AppInput` sub-struct definition, while the existing `app_input.h` hosts the `AppInputContext` seam (focused pointer bundle for input handlers, issue #204).
 
-This reduces `App`'s direct field count (13 fields → 2 sub-structs) and `app.h`'s include count from 22 to 14 (below the ≤15 target). Each sub-struct header owns its type dependencies and its delegation functions, keeping `app.c` focused on orchestration.
+This reduces `App`'s direct field count from 24 to ~17. Each sub-struct header owns its type dependencies and its delegation functions, keeping `app.c` focused on orchestration.
+
+### PostProcess Decomposition (PPGPUResources, PPShaderState, PPExposureReadback)
+
+The `PostProcess` struct is decomposed into three domain-aligned sub-structs:
+
+- **`PPGPUResources`** (`postprocess.h`): All GPU resource handles — FBOs, textures, PBOs, histogram SSBOs. Access via `postprocess.gpu.scene_fbo`, etc.
+- **`PPShaderState`** (`postprocess.h`): Shader programs and compilation state — shader IDs, optimization flags. Access via `postprocess.shaders.program`, etc.
+- **`PPExposureReadback`** (`postprocess.h`): Async exposure readback state — PBO handles, fence, readback index. Access via `postprocess.readback.histogram_pbo`, etc.
+
+### GamepadContext Seam
+
+The `GamepadContext` (`include/gamepad_context.h`) decouples `gamepad_input.c` from `camera.h`:
+
+- Contains only the minimal camera state slice needed for gamepad input: `move_input[3]`, `yaw_target`, `pitch_target`, `fixed_timestep`, pitch limits.
+- `gamepad_write_input()` takes `GamepadContext*` instead of `Camera*`.
+- Bridge pattern: `Camera ↔ GamepadContext` at the call site in `app.c`.
 
 ### Effect Decoupling (EffectContext)
 

--- a/docs/fullscreen_deadlock.fr.md
+++ b/docs/fullscreen_deadlock.fr.md
@@ -26,9 +26,9 @@ Au lieu d'appeler directement `postprocess_resize` depuis le callback, on lève 
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
     App* app = glfwGetWindowUserPointer(window);
-    app->resize_pending = 1;
-    app->pending_width = width;
-    app->pending_height = height;
+    app->win.resize_pending = 1;
+    app->win.pending_width = width;
+    app->win.pending_height = height;
 }
 ```
 
@@ -44,9 +44,9 @@ Le travail lourd réel (`postprocess_resize`) est déplacé au début de l'image
 // Dans la boucle while de app_run()
 glfwPollEvents();
 
-if (app->resize_pending) {
-    postprocess_resize(&app->postprocess, app->pending_width, app->pending_height);
-    app->resize_pending = 0;
+if (app->win.resize_pending) {
+    postprocess_resize(&app->postprocess, app->win.pending_width, app->win.pending_height);
+    app->win.resize_pending = 0;
 }
 ```
 

--- a/docs/fullscreen_deadlock.md
+++ b/docs/fullscreen_deadlock.md
@@ -132,9 +132,9 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height) {
     glViewport(0, 0, width, height);
 
     // Only set the request flag
-    app->pending_width = width;
-    app->pending_height = height;
-    app->resize_pending = 1;
+    app->win.pending_width = width;
+    app->win.pending_height = height;
+    app->win.resize_pending = 1;
 }
 ```
 
@@ -150,9 +150,9 @@ The actual heavy lifting (`postprocess_resize`) is moved to the start of the nex
 // Inside app_run() while loop
 glfwPollEvents();
 
-if (app->resize_pending) {
-    postprocess_resize(&app->postprocess, app->pending_width, app->pending_height);
-    app->resize_pending = 0;
+if (app->win.resize_pending) {
+    postprocess_resize(&app->postprocess, app->win.pending_width, app->win.pending_height);
+    app->win.resize_pending = 0;
 }
 ```
 

--- a/docs/project_structure.fr.md
+++ b/docs/project_structure.fr.md
@@ -17,6 +17,11 @@ suckless-ogl/
 │   └── platform/         # Couche de portabilité
 ├── include/              # En-têtes C
 │   ├── app.h             # Structure App principale
+│   ├── app_input.h       # Seam AppInputContext
+│   ├── app_input_state.h # Sous-struct AppInput
+│   ├── app_profiling.h   # Sous-struct AppProfiling
+│   ├── app_window.h      # Sous-struct AppWindow
+│   ├── gamepad_context.h # Seam GamepadContext
 │   ├── scene.h           # Agrégat Scene (inclut les sous-structs)
 │   ├── scene_config.h    # SceneConfig : flags runtime et enums
 │   ├── scene_gpu_resources.h # SceneGPUResources : handles GLuint

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -33,9 +33,13 @@ icosphere/
 ├── include/
 │   ├── app.h               # Main App Structure
 │   ├── app_env.h
-│   ├── app_input.h
+│   ├── app_input.h         # AppInputContext seam
+│   ├── app_input_state.h   # AppInput sub-struct
+│   ├── app_profiling.h     # AppProfiling sub-struct
 │   ├── app_scene.h
 │   ├── app_ui.h
+│   ├── app_window.h        # AppWindow sub-struct
+│   ├── gamepad_context.h   # GamepadContext seam
 │   ├── scene.h             # Scene aggregate (includes sub-structs)
 │   ├── scene_config.h      # SceneConfig: runtime flags & enums
 │   ├── scene_gpu_resources.h # SceneGPUResources: GLuint handles

--- a/include/app.h
+++ b/include/app.h
@@ -3,6 +3,7 @@
 
 #include "action_notifier.h"
 #include "app_ui.h"
+#include "app_window.h"
 #include "async/async_coordinator.h"
 #include "async_loader.h"
 #include "effect_benchmark.h"
@@ -29,10 +30,10 @@ typedef struct App {
 	/* --- Pointers and Dynamic Objects --- */
 	Scene scene;             /**< The 3D scene (Includes GI Probe Grid). */
 	PostProcess postprocess; /**< Main post-processing pipeline. */
-	GLFWwindow* window;      /**< The GLFW window context. */
-	double last_frame_time;  /**< Absolute time of last frame start. */
-	double delta_time;       /**< Time elapsed since last frame. */
-	uint64_t frame_count;    /**< Monotonic frame counter. */
+	AppWindow win; /**< Window handle, fullscreen & resize state. */
+	double last_frame_time;      /**< Absolute time of last frame start. */
+	double delta_time;           /**< Time elapsed since last frame. */
+	uint64_t frame_count;        /**< Monotonic frame counter. */
 	float* lum_histogram_buffer; /**< Pre-allocated buffer for histogram. */
 
 	/* --- Sub-Modules (Opaque, Heap-Allocated) --- */
@@ -41,17 +42,11 @@ typedef struct App {
 	AppUIOverlay overlay; /**< Overlay and text rendering state. */
 
 	/* --- App State Flags and Values --- */
-	int width;                     /**< Current window/viewport width. */
-	int height;                    /**< Current window/viewport height. */
-	int is_fullscreen;             /**< Fullscreen toggle state. */
-	int saved_x, saved_y;          /**< Cached pos for window restore. */
-	int saved_width, saved_height; /**< Cached size for window restore. */
-	int resize_pending;            /**< Deferred resize flag. */
-	int pending_width;             /**< Deferred resize target width. */
-	int pending_height;            /**< Deferred resize target height. */
-	EnvManager env_mgr;            /**< Environment/IBL state. */
-	ActionNotifier notifier;       /**< Temporary user notifications. */
-	EffectBenchmark effect_bench;  /**< A/B effect cost measurement. */
+	int width;                    /**< Current window/viewport width. */
+	int height;                   /**< Current window/viewport height. */
+	EnvManager env_mgr;           /**< Environment/IBL state. */
+	ActionNotifier notifier;      /**< Temporary user notifications. */
+	EffectBenchmark effect_bench; /**< A/B effect cost measurement. */
 
 	/* --- Global GPU Resources --- */
 	GLuint lum_ssbo[2]; /**< Double-buffered storage for luminance. */

--- a/include/app_window.h
+++ b/include/app_window.h
@@ -1,0 +1,24 @@
+#ifndef APP_WINDOW_H
+#define APP_WINDOW_H
+
+#include "gl_common.h"
+
+/**
+ * @struct AppWindow
+ * @brief Groups GLFW window handle and all window/resize state.
+ *
+ * Extracted from App to reduce its direct field count and form a
+ * cohesive sub-struct for window management (fullscreen toggle,
+ * deferred resize, saved position/size for windowed restore).
+ */
+typedef struct {
+	GLFWwindow* handle;            /**< The GLFW window context. */
+	int is_fullscreen;             /**< Fullscreen toggle state. */
+	int saved_x, saved_y;          /**< Cached pos for window restore. */
+	int saved_width, saved_height; /**< Cached size for window restore. */
+	int resize_pending;            /**< Deferred resize flag. */
+	int pending_width;             /**< Deferred resize target width. */
+	int pending_height;            /**< Deferred resize target height. */
+} AppWindow;
+
+#endif /* APP_WINDOW_H */

--- a/src/app.c
+++ b/src/app.c
@@ -40,25 +40,26 @@ int app_init(App* app, int width, int height, const char* title)
 	}
 
 	app_input_state_init(app->input);
-	app->is_fullscreen = false;
-	app->resize_pending = 0;
+	app->win.is_fullscreen = false;
+	app->win.resize_pending = 0;
 	app->scene.config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
 	app->env_mgr.is_first_load = true;
 
-	app->window = window_create(width, height, title, DEFAULT_SAMPLES);
-	if (!app->window) {
+	app->win.handle = window_create(width, height, title, DEFAULT_SAMPLES);
+	if (!app->win.handle) {
 		return 0;
 	}
 
 	glfwSwapInterval(0);
-	glfwSetWindowUserPointer(app->window, app);
-	glfwSetKeyCallback(app->window, key_callback);
-	glfwSetCursorPosCallback(app->window, mouse_callback);
-	glfwSetScrollCallback(app->window, scroll_callback);
-	glfwSetFramebufferSizeCallback(app->window, framebuffer_size_callback);
+	glfwSetWindowUserPointer(app->win.handle, app);
+	glfwSetKeyCallback(app->win.handle, key_callback);
+	glfwSetCursorPosCallback(app->win.handle, mouse_callback);
+	glfwSetScrollCallback(app->win.handle, scroll_callback);
+	glfwSetFramebufferSizeCallback(app->win.handle,
+	                               framebuffer_size_callback);
 
 	if (app->input->camera_enabled) {
-		glfwSetInputMode(app->window, GLFW_CURSOR,
+		glfwSetInputMode(app->win.handle, GLFW_CURSOR,
 		                 GLFW_CURSOR_DISABLED);
 	}
 
@@ -173,8 +174,8 @@ void app_cleanup(App* app)
 	free(app->profiling);
 	app->profiling = NULL;
 
-	window_destroy(app->window);
-	app->window = NULL;
+	window_destroy(app->win.handle);
+	app->win.handle = NULL;
 }
 
 static void app_render_ui_trampoline(void* user_data)
@@ -185,7 +186,7 @@ static void app_render_ui_trampoline(void* user_data)
 void app_run(App* app)
 {
 	int last_subdiv = -1;
-	while (!glfwWindowShouldClose(app->window)) {
+	while (!glfwWindowShouldClose(app->win.handle)) {
 		{
 			PROFILE_ZONE(poll_ctx, "GLFW PollEvents (Start)");
 			glfwPollEvents();
@@ -196,12 +197,12 @@ void app_run(App* app)
 		 * Heavy GPU work (FBO/texture recreation) is done here, safely
 		 * outside any GLFW callback context, after the mode switch and
 		 * event processing are fully complete. */
-		if (app->resize_pending) {
+		if (app->win.resize_pending) {
 			PROFILE_ZONE(resize_ctx, "PostProcess Resize");
 			postprocess_resize(&app->postprocess,
-			                   app->pending_width,
-			                   app->pending_height);
-			app->resize_pending = 0;
+			                   app->win.pending_width,
+			                   app->win.pending_height);
+			app->win.resize_pending = 0;
 			PROFILE_ZONE_END(resize_ctx);
 		}
 
@@ -257,7 +258,7 @@ void app_run(App* app)
 			}
 			if (gp_actions.env_next || gp_actions.env_prev) {
 				AppInputContext env_ctx = {
-				    .window = app->window,
+				    .window = app->win.handle,
 				    .scene = &app->scene,
 				    .env_mgr = &app->env_mgr,
 				    .notifier = &app->notifier,
@@ -394,7 +395,7 @@ void app_run(App* app)
 			                   "Swap Buffers",
 			                   GPU_PROFILER_UI_COLOR);
 			PROFILE_ZONE(swap_ctx, "GLFW SwapBuffers");
-			glfwSwapBuffers(app->window);
+			glfwSwapBuffers(app->win.handle);
 			PROFILE_ZONE_END(swap_ctx);
 		}
 

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -34,7 +34,7 @@
 static inline AppInputContext app_input_ctx_from_app(App* app)
 {
 	return (AppInputContext){
-	    .window = app->window,
+	    .window = app->win.handle,
 	    .camera = &app->input->camera,
 	    .scene = &app->scene,
 	    .postprocess = &app->postprocess,
@@ -49,14 +49,14 @@ static inline AppInputContext app_input_ctx_from_app(App* app)
 	    .width = &app->width,
 	    .height = &app->height,
 	    .camera_enabled = &app->input->camera_enabled,
-	    .is_fullscreen = &app->is_fullscreen,
-	    .saved_x = &app->saved_x,
-	    .saved_y = &app->saved_y,
-	    .saved_width = &app->saved_width,
-	    .saved_height = &app->saved_height,
-	    .resize_pending = &app->resize_pending,
-	    .pending_width = &app->pending_width,
-	    .pending_height = &app->pending_height,
+	    .is_fullscreen = &app->win.is_fullscreen,
+	    .saved_x = &app->win.saved_x,
+	    .saved_y = &app->win.saved_y,
+	    .saved_width = &app->win.saved_width,
+	    .saved_height = &app->win.saved_height,
+	    .resize_pending = &app->win.resize_pending,
+	    .pending_width = &app->win.pending_width,
+	    .pending_height = &app->win.pending_height,
 	    .perf_mode_active = &app->profiling->perf_mode_active,
 	    .log_gpu_metrics = &app->profiling->log_gpu_metrics,
 	};

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -207,7 +207,7 @@ void setUp(void)
 		// Initialize PBOs for async pixel readback (optimization#2)
 		int fb_width = 0;
 		int fb_height = 0;
-		glfwGetFramebufferSize(g_test_app.window, &fb_width,
+		glfwGetFramebufferSize(g_test_app.win.handle, &fb_width,
 		                       &fb_height);
 		size_t pixel_data_size =
 		    (size_t)(fb_width * fb_height * BYTES_PER_PIXEL);
@@ -374,7 +374,7 @@ static void pipeline_run_test_loop(const char* test_tag,
 {
 	int fb_width = 0;
 	int fb_height = 0;
-	glfwGetFramebufferSize(g_test_app.window, &fb_width, &fb_height);
+	glfwGetFramebufferSize(g_test_app.win.handle, &fb_width, &fb_height);
 	size_t pixel_data_size =
 	    (size_t)(fb_width * fb_height * BYTES_PER_PIXEL);
 

--- a/tests/test_app_input.c
+++ b/tests/test_app_input.c
@@ -15,7 +15,7 @@ static App* test_app = NULL;
 static AppInputContext test_ctx_from_app(App* app)
 {
 	return (AppInputContext){
-	    .window = app->window,
+	    .window = app->win.handle,
 	    .camera = &app->input->camera,
 	    .scene = &app->scene,
 	    .postprocess = &app->postprocess,
@@ -30,14 +30,14 @@ static AppInputContext test_ctx_from_app(App* app)
 	    .width = &app->width,
 	    .height = &app->height,
 	    .camera_enabled = &app->input->camera_enabled,
-	    .is_fullscreen = &app->is_fullscreen,
-	    .saved_x = &app->saved_x,
-	    .saved_y = &app->saved_y,
-	    .saved_width = &app->saved_width,
-	    .saved_height = &app->saved_height,
-	    .resize_pending = &app->resize_pending,
-	    .pending_width = &app->pending_width,
-	    .pending_height = &app->pending_height,
+	    .is_fullscreen = &app->win.is_fullscreen,
+	    .saved_x = &app->win.saved_x,
+	    .saved_y = &app->win.saved_y,
+	    .saved_width = &app->win.saved_width,
+	    .saved_height = &app->win.saved_height,
+	    .resize_pending = &app->win.resize_pending,
+	    .pending_width = &app->win.pending_width,
+	    .pending_height = &app->win.pending_height,
 	    .perf_mode_active = &app->profiling->perf_mode_active,
 	    .log_gpu_metrics = &app->profiling->log_gpu_metrics,
 	};
@@ -52,20 +52,20 @@ void setUp(void)
 	test_app = malloc(sizeof(App));
 	memset(test_app, 0, sizeof(App));
 
-	test_app->window = glfwCreateWindow(640, 480, "Test", NULL, NULL);
-	if (!test_app->window) {
+	test_app->win.handle = glfwCreateWindow(640, 480, "Test", NULL, NULL);
+	if (!test_app->win.handle) {
 		glfwTerminate();
 		TEST_FAIL_MESSAGE("Failed to create GLFW window");
 	}
-	glfwMakeContextCurrent(test_app->window);
+	glfwMakeContextCurrent(test_app->win.handle);
 
 	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
-		glfwDestroyWindow(test_app->window);
+		glfwDestroyWindow(test_app->win.handle);
 		glfwTerminate();
 		TEST_FAIL_MESSAGE("Failed to initialize GLAD");
 	}
 
-	glfwSetWindowUserPointer(test_app->window, test_app);
+	glfwSetWindowUserPointer(test_app->win.handle, test_app);
 
 	/* Initialize sub-systems to avoid segfaults */
 	test_app->profiling = calloc(1, sizeof(*test_app->profiling));
@@ -81,8 +81,8 @@ void setUp(void)
 
 void tearDown(void)
 {
-	if (test_app->window) {
-		glfwDestroyWindow(test_app->window);
+	if (test_app->win.handle) {
+		glfwDestroyWindow(test_app->win.handle);
 	}
 	free(test_app->profiling);
 	free(test_app->input);
@@ -99,7 +99,7 @@ void tearDown(void)
  */
 void test_framebuffer_size_callback(void)
 {
-	framebuffer_size_callback(test_app->window, 1280, 720);
+	framebuffer_size_callback(test_app->win.handle, 1280, 720);
 	TEST_ASSERT_EQUAL(1280, test_app->width);
 	TEST_ASSERT_EQUAL(720, test_app->height);
 }
@@ -281,15 +281,15 @@ void test_mouse_and_scroll_exhaustive(void)
 {
 	test_app->input->camera_enabled = true;
 	test_app->input->camera.first_mouse = 1;
-	mouse_callback(test_app->window, 100.0, 100.0);
-	mouse_callback(test_app->window, 110.0, 120.0);
+	mouse_callback(test_app->win.handle, 100.0, 100.0);
+	mouse_callback(test_app->win.handle, 110.0, 120.0);
 	TEST_ASSERT_EQUAL_FLOAT(110.0F,
 	                        (float)test_app->input->camera.last_mouse_x);
 	TEST_ASSERT_EQUAL_FLOAT(120.0F,
 	                        (float)test_app->input->camera.last_mouse_y);
 
-	scroll_callback(test_app->window, 0.0, 1.0);
-	scroll_callback(test_app->window, 0.0, -1.0);
+	scroll_callback(test_app->win.handle, 0.0, 1.0);
+	scroll_callback(test_app->win.handle, 0.0, -1.0);
 }
 
 /**
@@ -303,11 +303,11 @@ void test_key_callback_dispatch(void)
 {
 	/* key_callback should dispatch to handle_app_input */
 	test_app->overlay.text_overlay_mode = 0;
-	key_callback(test_app->window, GLFW_KEY_F1, 0, GLFW_PRESS, 0);
+	key_callback(test_app->win.handle, GLFW_KEY_F1, 0, GLFW_PRESS, 0);
 	TEST_ASSERT_EQUAL(1, test_app->overlay.text_overlay_mode);
 
 	/* Release should be ignored for these toggles but covered */
-	key_callback(test_app->window, GLFW_KEY_F1, 0, GLFW_RELEASE, 0);
+	key_callback(test_app->win.handle, GLFW_KEY_F1, 0, GLFW_RELEASE, 0);
 	TEST_ASSERT_EQUAL(1, test_app->overlay.text_overlay_mode);
 }
 

--- a/tests/test_env_transition.c
+++ b/tests/test_env_transition.c
@@ -25,16 +25,16 @@ void setUp(void)
 	g_test_app = malloc(sizeof(App));
 	memset(g_test_app, 0, sizeof(App));
 
-	g_test_app->window =
+	g_test_app->win.handle =
 	    glfwCreateWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "Test", NULL, NULL);
-	if (!g_test_app->window) {
+	if (!g_test_app->win.handle) {
 		glfwTerminate();
 		TEST_FAIL_MESSAGE("Failed to create GLFW window");
 	}
-	glfwMakeContextCurrent(g_test_app->window);
+	glfwMakeContextCurrent(g_test_app->win.handle);
 
 	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
-		glfwDestroyWindow(g_test_app->window);
+		glfwDestroyWindow(g_test_app->win.handle);
 		glfwTerminate();
 		TEST_FAIL_MESSAGE("Failed to initialize GLAD");
 	}
@@ -47,8 +47,8 @@ void setUp(void)
 
 void tearDown(void)
 {
-	if (g_test_app->window) {
-		glfwDestroyWindow(g_test_app->window);
+	if (g_test_app->win.handle) {
+		glfwDestroyWindow(g_test_app->win.handle);
 	}
 	free(g_test_app);
 	glfwTerminate();


### PR DESCRIPTION
## Summary

Extract window/resize-related fields from `App` into a cohesive `AppWindow` value sub-struct (`App.win`).

### Changes

- **`include/app_window.h`** (new): `AppWindow` struct with `handle` (GLFWwindow*), `is_fullscreen`, `saved_x/y`, `saved_width/height`, `resize_pending`, `pending_width/height`
- **`include/app.h`**: replaced 8 window fields with single `AppWindow win` member
- **`src/app.c`**: all `app->window` → `app->win.handle`, resize/fullscreen fields → `app->win.*`
- **`src/app_input.c`**: `AppInputContext` construction updated
- **`tests/test_app.c`**, **`tests/test_app_input.c`**, **`tests/test_env_transition.c`**: all updated

### Validation

- Build: clean (0 errors, 0 warnings)
- Tests: 63/63 pass
- Format + Lint: clean
- ASan integration: PASS
- Ultra-release build: 0 warnings

Closes #233