### PR TITLE
ci: replace Surge.sh with GitHub Pages PR preview

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,9 @@ on:
   pull_request:
     # Pour tout le reste, on passe par les PRs (master/main comme cibles)
     # Cela garantit un seul run par commit dans une PR
+    # 'closed' is needed for PR preview cleanup on GitHub Pages
     branches: ["master", "main"]
+    types: [opened, reopened, synchronize, closed]
   schedule:
     # Build nightly tous les jours à 01h00 UTC
     - cron: '0 1 * * *'
@@ -23,6 +25,7 @@ on:
 jobs:
   # --- JOB 1 : QUALITÉ ET LINT (RAPIDE) ---
   lint-and-format:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     container: ghcr.io/${{ github.repository }}-ci:latest
     steps:
@@ -58,6 +61,7 @@ jobs:
 
   # --- JOB 2 : TESTS, COUVERTURE ET CAPTURES VISUELLES (LENT) ---
   test-and-coverage:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     container: ghcr.io/${{ github.repository }}-ci:latest
     env:
@@ -133,6 +137,7 @@ jobs:
 
   # --- NEW JOB : TESTS WINDOWS (WINE) ---
   test-windows:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -157,6 +162,7 @@ jobs:
   # --- JOB 3 : DOCS, DIAGRAMMES ET QUALITÉ DOC ---
   documentation:
     needs: [test-and-coverage]
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     container: ghcr.io/${{ github.repository }}-ci:latest
     env:
@@ -184,40 +190,37 @@ jobs:
           name: doxygen-docs
           path: site/
 
-      - name: Setup Node.js
-        if: github.event_name == 'pull_request'
-        uses: actions/setup-node@v6
+  # --- JOB 3b : DEPLOY PR PREVIEW TO GITHUB PAGES ---
+  deploy-preview:
+    needs: [documentation]
+    if: github.event_name == 'pull_request' && always()
+    runs-on: ubuntu-latest
+    concurrency: preview-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download Documentation Artifact
+        if: github.event.action != 'closed'
+        uses: actions/download-artifact@v8
         with:
-          node-version: '22'
+          name: doxygen-docs
+          path: preview-site
 
-      - name: Deploy Documentation Preview (Pull Request)
-        if: github.event_name == 'pull_request'
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: |
-          if [ -z "$SURGE_TOKEN" ]; then
-            echo "⚠️ SURGE_TOKEN est vide ou indisponible (PR provenant d'un fork potentiellement)."
-            echo "⏭️ Déploiement du preview Surge ignoré pour ne pas briser le CI."
-            echo "PREVIEW_URL=(Aperçu non disponible pour les forks)" >> $GITHUB_ENV
-            exit 0
-          fi
-          PR_NUMBER=${{ github.event.number }}
-          DEPLOY_DOMAIN="suckless-ogl-pr-$PR_NUMBER.surge.sh"
-          npx surge site/ $DEPLOY_DOMAIN --token $SURGE_TOKEN
-          echo "PREVIEW_URL=https://$DEPLOY_DOMAIN" >> $GITHUB_ENV
-
-      - name: Comment Preview Link on PR
-        if: github.event_name == 'pull_request'
-        uses: mshick/add-pr-comment@v3
+      - name: Download Coverage for Preview
+        if: github.event.action != 'closed'
+        uses: actions/download-artifact@v8
         with:
-          message-id: docs-preview
-          message: |
-            ## ⚗️ Documentation Preview
-            The Doxygen documentation for this PR has been generated and is ready for review:
+          name: coverage-report
+          path: preview-site/coverage
 
-            🔗 **[Preview Link](${{ env.PREVIEW_URL }})**
-
-            *Last updated: ${{ github.event.pull_request.updated_at || 'Just now' }} (commit: ${{ github.sha }})*
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./preview-site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto
+          comment: true
 
   # --- JOB 4 : DÉPLOIEMENT UNIFIÉ VERS GITHUB PAGES ---
   deploy-pages:
@@ -242,12 +245,12 @@ jobs:
           path: public-site/coverage
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public-site
-          keep_files: false
-          destination_dir: .
+          branch: gh-pages
+          folder: ./public-site
+          clean-exclude: pr-preview
+          force: false
 
   # --- JOB 3 : BUILDS DE PRODUCTION ---
   build-production:

--- a/.github/workflows/scripts/generate_visual_report.py
+++ b/.github/workflows/scripts/generate_visual_report.py
@@ -179,7 +179,7 @@ def generate_report(sha, repository, pr_number=None):
 
     comment += "\n> [!TIP]\n"
     if pr_number:
-        interactive_url = f"https://suckless-ogl-pr-{pr_number}.surge.sh/coverage/visual_tests/index.html"
+        interactive_url = f"https://yoyonel.github.io/suckless-ogl/pr-preview/pr-{pr_number}/coverage/visual_tests/index.html"
         comment += f"> Accédez au **[Rapport Interactif Complet]({interactive_url})** pour filtrer par vue/mode/effet et utiliser la loupe.\n"
     else:
         comment += "> Accédez au rapport interactif complet dans l'onglet **Summary** du CI pour filtrer par vue/mode/effet.\n"

--- a/docs/cicd_pipeline.md
+++ b/docs/cicd_pipeline.md
@@ -17,7 +17,7 @@ The workflow is triggered automatically events:
 - **Pull Requests**:
   - Runs quality checks (Lint, Format).
   - Runs unit tests and visual regression tests.
-  - Generates a documentation preview (deployed to Surge.sh).
+  - Generates a documentation preview (deployed to GitHub Pages).
 - **Tags (`v*`)**:
   - Triggers a **Stable Release** build.
   - Creates a GitHub Release with the corresponding version number.
@@ -52,7 +52,7 @@ The workflow is triggered automatically events:
 - **Tools**: Doxygen, Graphviz, MkDocs.
 - **Outputs**:
   - Combines manual Markdown docs and auto-generated C API docs.
-  - **Pull Requests**: Deploys a preview link to [Surge.sh](https://surge.sh).
+  - **Pull Requests**: Deploys a preview link to [GitHub Pages](https://pages.github.com/) under `pr-preview/pr-<N>/`.
   - **Master/Main**: Prepares artifacts for GitHub Pages deployment.
 
 ### 4. `build-production` (Compilation)

--- a/docs/docs_staging_guide.fr.md
+++ b/docs/docs_staging_guide.fr.md
@@ -2,59 +2,95 @@
 
 Ce document explique comment prévisualiser la documentation sur une PR avant la fusion.
 
-## Aperçu via Surge.sh
+## Aperçu via GitHub Pages
 
-Le projet utilise [Surge.sh](https://surge.sh) pour déployer automatiquement la documentation sur chaque Pull Request. Cela permet de valider les modifications de documentation avant la fusion dans `master`.
+Le projet utilise [GitHub Pages](https://pages.github.com/) pour déployer automatiquement la documentation sur chaque Pull Request. Cela permet de valider les modifications de documentation avant la fusion dans `master`.
 
-## Configuration du token
+L'action [`rossjrw/pr-preview-action`](https://github.com/rossjrw/pr-preview-action) déploie chaque preview dans un sous-dossier `pr-preview/pr-<N>/` sur la branche `gh-pages`.
 
-### 1. Obtenir un token Surge
+## Format des URLs de preview
 
-```bash
-# Installer Surge
-npm install -g surge
-
-# Se connecter / créer un compte
-surge login
-
-# Obtenir le token
-surge token
+```text
+https://yoyonel.github.io/suckless-ogl/pr-preview/pr-<NUMERO>/
 ```
 
-### 2. Configurer le secret GitHub
+Par exemple, la PR #42 serait accessible à :
+`https://yoyonel.github.io/suckless-ogl/pr-preview/pr-42/`
 
-Ajoutez le token comme secret dans les paramètres du dépôt GitHub :
-- `Settings` → `Secrets and variables` → `Actions`
-- Créer un secret nommé `SURGE_TOKEN`
+## Configuration requise
+
+Aucun token ou service externe n'est nécessaire. Le déploiement utilise le `GITHUB_TOKEN` natif fourni par GitHub Actions.
+
+### Configuration du dépôt
+
+1. Allez dans les **Settings** du dépôt > **Pages**.
+2. Vérifiez que la source est **Deploy from a branch** (`gh-pages`).
+3. Dans **Settings** > **Actions** > **General** > **Workflow permissions**, sélectionnez **Read and write permissions**.
 
 ## Intégration dans le workflow
 
-Le workflow de documentation (`.github/workflows/docs.yml`) déploie automatiquement sur Surge.sh pour chaque PR :
+Le workflow CI (`.github/workflows/main.yml`) contient deux jobs de déploiement :
+
+### Preview PR (job deploy-preview)
 
 ```yaml
-- name: Deploy to Surge
-  if: github.event_name == 'pull_request'
-  run: |
-    surge ./site ${{ github.event.pull_request.number }}-preview.surge.sh \
-      --token ${{ secrets.SURGE_TOKEN }}
+deploy-preview:
+  needs: [documentation]
+  if: github.event_name == 'pull_request' && always()
+  runs-on: ubuntu-latest
+  concurrency: preview-${{ github.ref }}
+  steps:
+    - uses: actions/checkout@v6
+    - uses: actions/download-artifact@v8
+      if: github.event.action != 'closed'
+      with:
+        name: doxygen-docs
+        path: preview-site
+    - uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: ./preview-site/
+        preview-branch: gh-pages
+        umbrella-dir: pr-preview
+        action: auto
+        comment: true
 ```
 
-L'URL de prévisualisation est publiée en commentaire sur la PR :
+### Déploiement production (job deploy-pages)
 
+Le déploiement de production sur `master` utilise `JamesIves/github-pages-deploy-action` avec `clean-exclude: pr-preview` pour préserver les previews actives :
+
+```yaml
+- uses: JamesIves/github-pages-deploy-action@v4
+  with:
+    branch: gh-pages
+    folder: ./public-site
+    clean-exclude: pr-preview
+    force: false
 ```
-📚 Documentation preview: https://123-preview.surge.sh
-```
+
+## Contenu du preview
+
+Le preview inclut le **site complet de documentation** :
+
+- Documentation MkDocs (architecture, guides, API)
+- Référence API Doxygen
+- Rapports de couverture
 
 ## Nettoyage
 
-Les déploiements Surge sont automatiquement supprimés à la fermeture/fusion de la PR :
+### Nettoyage automatique
 
-```yaml
-on:
-  pull_request:
-    types: [closed]
-steps:
-  - run: surge teardown ${{ github.event.pull_request.number }}-preview.surge.sh
+Les previews sont automatiquement supprimées à la fermeture ou fusion d'une PR. L'événement `pull_request: closed` déclenche le job `deploy-preview` avec `action: auto`, qui détecte la fermeture et supprime le dossier `pr-preview/pr-<N>/` de `gh-pages`.
+
+### Nettoyage manuel
+
+Si un preview n'a pas été correctement nettoyé :
+
+```bash
+git checkout gh-pages
+rm -rf pr-preview/pr-<NUMERO>
+git add -A && git commit -m "chore: remove stale PR preview"
+git push origin gh-pages
 ```
 
 ## Voir aussi

--- a/docs/docs_staging_guide.md
+++ b/docs/docs_staging_guide.md
@@ -1,60 +1,101 @@
 # Documentation Staging & Preview Guide
 
-This project automatically generates and deploys a live preview of the Doxygen documentation for every Pull Request. This allows for functional validation of documentation changes before merging.
+This project automatically generates and deploys a live preview of the documentation for every Pull Request. This allows for functional validation of documentation changes before merging.
 
 ## How it Works
 
-1.  **Trigger**: Every push to a Pull Request triggers the `documentation` job in GitHub Actions.
-2.  **Generation**: Doxygen builds the HTML documentation.
-3.  **Deployment**: The documentation is deployed to [Surge.sh](https://surge.sh) using a unique domain per PR: `suckless-ogl-pr-[NUMBER].surge.sh`.
-4.  **Feedback**: A comment is automatically posted on the Pull Request with a link to the live preview.
+1. **Trigger**: Every push to a Pull Request triggers the `documentation` job in GitHub Actions.
+2. **Generation**: MkDocs + Doxygen build the full documentation site.
+3. **Deployment**: The documentation is deployed to [GitHub Pages](https://pages.github.com/) as a subdirectory under `pr-preview/pr-<NUMBER>/` using [`rossjrw/pr-preview-action`](https://github.com/rossjrw/pr-preview-action).
+4. **Feedback**: A comment is automatically posted on the Pull Request with a link to the live preview.
+5. **Cleanup**: When the PR is closed or merged, the preview is automatically removed.
+
+## Preview URL Format
+
+```text
+https://yoyonel.github.io/suckless-ogl/pr-preview/pr-<NUMBER>/
+```
+
+For example, PR #42 would be available at:
+`https://yoyonel.github.io/suckless-ogl/pr-preview/pr-42/`
 
 ## Setup Instructions
 
-To enable automated deployments, you must configure a `SURGE_TOKEN` in your repository secrets.
+No external tokens or services are required. The deployment uses the built-in `GITHUB_TOKEN` provided by GitHub Actions.
 
-### 1. Obtain a Surge Token
+### Repository Configuration
 
-If you haven't used Surge before, you can install it and generate a token via CLI:
-
-```sh
-npx surge token
-```
-
-- If you don't have an account, it will prompt you to create one.
-- Copy the provided token string.
-
-### 2. Configure GitHub Secrets
-
-1. Navigate to your GitHub repository.
-2. Go to **Settings** > **Secrets and variables** > **Actions**.
-3. Create a **New repository secret**.
-4. Set the **Name** to `SURGE_TOKEN`.
-5. Paste your token into the **Value** field.
+1. Navigate to your GitHub repository **Settings** > **Pages**.
+2. Ensure the source is set to **Deploy from a branch** (`gh-pages`).
+3. In **Settings** > **Actions** > **General** > **Workflow permissions**, select **Read and write permissions**.
 
 ## Workflow Integration
 
-The staging logic is defined in `.github/workflows/main.yml`. It uses the `mshick/add-pr-comment` action to keep you informed:
+The preview logic is split into two jobs in `.github/workflows/main.yml`:
+
+### PR Preview (deploy-preview job)
 
 ```yaml
-- name: Comment Preview Link on PR
-  if: github.event_name == 'pull_request'
-  uses: mshick/add-pr-comment@v2
-  with:
-    message: |
-      ## 📚 Documentation Preview
-      The Doxygen documentation for this PR has been generated and is ready for review:
-      🔗 **[Preview Link](${{ env.PREVIEW_URL }})**
+deploy-preview:
+  needs: [documentation]
+  if: github.event_name == 'pull_request' && always()
+  runs-on: ubuntu-latest
+  concurrency: preview-${{ github.ref }}
+  steps:
+    - uses: actions/checkout@v6
+    - uses: actions/download-artifact@v8
+      if: github.event.action != 'closed'
+      with:
+        name: doxygen-docs
+        path: preview-site
+    - uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: ./preview-site/
+        preview-branch: gh-pages
+        umbrella-dir: pr-preview
+        action: auto
+        comment: true
 ```
+
+### Production Deployment (deploy-pages job)
+
+The production deployment on `master` uses `JamesIves/github-pages-deploy-action` with `clean-exclude: pr-preview` to preserve active PR previews:
+
+```yaml
+- uses: JamesIves/github-pages-deploy-action@v4
+  with:
+    branch: gh-pages
+    folder: ./public-site
+    clean-exclude: pr-preview
+    force: false
+```
+
+## Preview Content
+
+The preview includes the **full documentation site**:
+
+- MkDocs documentation (architecture, guides, API)
+- Doxygen API reference
+- Coverage reports
 
 ## Maintenance
 
-### Clearing Previews
-Surge.sh keeps the deployments indefinitely. Since the domains are reused per PR number, new pushes simply overwrite the previous version. If you need to manually tear down a preview:
+### Automatic Cleanup
 
-```sh
-npx surge teardown suckless-ogl-pr-[NUMBER].surge.sh --token your_token
+Previews are automatically removed when a PR is closed or merged. The `pull_request: closed` event triggers the `deploy-preview` job with `action: auto`, which detects the close and removes the `pr-preview/pr-<N>/` directory from `gh-pages`.
+
+### Manual Cleanup
+
+If a preview was not properly cleaned up, you can remove it manually:
+
+```bash
+git checkout gh-pages
+rm -rf pr-preview/pr-<NUMBER>
+git add -A && git commit -m "chore: remove stale PR preview"
+git push origin gh-pages
 ```
 
-### Security
-The `SURGE_TOKEN` allows anyone with access to it to deploy sites to your Surge account. Keep it secret and only store it in GitHub Secrets.
+## See Also
+
+- [cicd_pipeline.md](./cicd_pipeline.md) — Full CI/CD pipeline overview
+- [documentation_system.md](./documentation_system.md) — Documentation system overview


### PR DESCRIPTION
## Summary

Replace the broken Surge.sh deployment with `rossjrw/pr-preview-action` that deploys PR doc previews directly to GitHub Pages.

### Problem

Surge.sh deployments are unreliable:
- Returns exit code 0 ("Success! Published") but site shows "project not found"
- Frequent 504 Gateway Timeouts
- Size limitations required excluding Doxygen + coverage from preview
- External service dependency with opaque failures

### Solution

Use `rossjrw/pr-preview-action@v1` to deploy previews as subdirectories on the existing GitHub Pages site:

```
https://yoyonel.github.io/suckless-ogl/pr-preview/pr-<N>/
```

### Changes

- **Removed**: Surge deploy steps (Setup Node.js, Deploy Surge, Comment PR link)
- **Added**: New `deploy-preview` job using `rossjrw/pr-preview-action@v1`
- **Added**: `closed` event type to `pull_request` trigger (for preview cleanup)
- **Added**: `if: github.event.action != 'closed'` guards on build/test/lint/docs jobs
- **Changed**: `deploy-pages` job uses `JamesIves/github-pages-deploy-action@v4` with `clean-exclude: pr-preview` and `force: false`

### Benefits

| | Surge.sh | GitHub Pages Preview |
|---|---|---|
| **Reliability** | Broken (504, project not found) | Same infra as production |
| **Size limit** | ~25 MB (free tier) | 1 GB |
| **Full site** | No (excluded Doxygen+coverage) | Yes (everything included) |
| **External dependency** | SURGE_TOKEN required | GITHUB_TOKEN (built-in) |
| **Cleanup** | Manual / never | Automatic on PR close |

### Preview URL format

`https://yoyonel.github.io/suckless-ogl/pr-preview/pr-<N>/`