### PR TITLE
fix: Valgrind GFNI SIGILL + Mesa glObjectLabel leak suppression

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -251,15 +251,15 @@ test-integration-tracy: build-tracy
     @chmod +x scripts/test_integration_generic.sh
     @{{distrobox}} ./scripts/test_integration_generic.sh ./build-tracy/app
 
-# Run UI integration test under Valgrind (Minimal scenario, Debug build for symbols)
-test-integration-valgrind: build
+# Run UI integration test under Valgrind (Minimal scenario, no -march=native)
+test-integration-valgrind: build-valgrind
     @{{distrobox}} chmod +x scripts/test_integration_valgrind.sh
-    @{{distrobox}} bash scripts/test_integration_valgrind.sh
+    @{{distrobox}} env VALGRIND_BUILD_DIR=build-valgrind bash scripts/test_integration_valgrind.sh
 
-# Run UI integration test under Valgrind (Full scenario, Debug build for symbols)
-test-integration-valgrind-full: build
+# Run UI integration test under Valgrind (Full scenario, no -march=native)
+test-integration-valgrind-full: build-valgrind
     @{{distrobox}} chmod +x scripts/test_integration_valgrind.sh
-    @{{distrobox}} bash scripts/test_integration_valgrind.sh full
+    @{{distrobox}} env VALGRIND_BUILD_DIR=build-valgrind bash scripts/test_integration_valgrind.sh full
 
 # Run full UI integration test under ASan
 test-integration-asan: asan
@@ -331,9 +331,16 @@ asan:
     @{{distrobox}} cmake -G "Unix Makefiles" -B build-asan -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -DENABLE_UNITY_BUILD=OFF
     @{{distrobox}} cmake --build build-asan --parallel {{nprocs}}
 
+# Build for Valgrind (no -march=native to avoid unsupported GFNI/AVX instructions)
+build-valgrind:
+    @echo "Building for Valgrind (no native arch)..."
+    @mkdir -p build-valgrind
+    @{{distrobox}} cmake -G "Unix Makefiles" -B build-valgrind -DCMAKE_BUILD_TYPE=Debug -DENABLE_NATIVE_ARCH=OFF
+    @{{distrobox}} cmake --build build-valgrind --parallel {{nprocs}}
+
 # Run Valgrind (Default) to detect leaks/errors
-memcheck: build
-    @{{distrobox}} valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose {{build_dir}}/app
+memcheck: build-valgrind
+    @{{distrobox}} valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose build-valgrind/app
 
 # Run AddressSanitizer (ASan) to detect leaks/errors
 memcheck-asan: asan

--- a/scripts/test_integration_valgrind.sh
+++ b/scripts/test_integration_valgrind.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-APP_PATH="./build/app"
+BUILD_DIR="${VALGRIND_BUILD_DIR:-./build}"
+APP_PATH="$BUILD_DIR/app"
 WINDOW_NAME="Icosphere Phong"
 LOG_FILE="valgrind_integration.log"
 SCENARIO="${1:-minimal}"  # "minimal" (default) or "full"

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -47,3 +47,12 @@
    obj:*/libgallium*.so*
    ...
 }
+{
+   mesa_glObjectLabel_strdup
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:strdup
+   ...
+   fun:*renderer_init
+}


### PR DESCRIPTION
## Summary

Valgrind 3.24.0 crashes with SIGILL on GFNI instructions (`GF2P8AFFINEQB`) emitted by `-march=native` in stb_image's `stbi__bitreverse16`. Additionally, Mesa driver leaks 14 bytes per `glObjectLabel` call via internal `strdup`.

### Changes

**Commit 1: Valgrind-compatible build**
- New `build-valgrind` Justfile recipe: cmake with `-DENABLE_NATIVE_ARCH=OFF` → `build-valgrind/` directory
- `test-integration-valgrind`, `test-integration-valgrind-full`, `memcheck` recipes now depend on `build-valgrind`
- `scripts/test_integration_valgrind.sh`: configurable `VALGRIND_BUILD_DIR` env var (defaults to `./build`)

**Commit 2: Mesa driver leak suppression**
- `valgrind.supp`: targeted suppression for `malloc → strdup → ... → *renderer_init` pattern (Mesa `glObjectLabel` internal strdup)

### Testing
- `just build-valgrind`: builds clean, 0 GFNI instructions in binary
- `just test-integration-valgrind`: passes (0 definite leaks after suppression)