### PR TITLE
refactor(headers): replace transitive includes with forward declarations

### DIFF
--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -110,6 +110,15 @@ Les effets de post-traitement (bloom, DoF, auto-exposition, flou de mouvement, L
 - Cela élimine la dépendance bidirectionnelle : `postprocess.h` → `fx_*.h` (pour l'embedding des structs) reste, mais `fx_*.c` → `postprocess.h` est supprimé.
 - Tous les effets sont désormais entièrement migrés : **bloom**, **DoF**, **auto-exposition**, **flou de mouvement**, **LUT 3D** et **LUT viz**. Plus aucun fichier source d'effet n'inclut `postprocess.h`.
 
+### Nettoyage des dépendances d'en-têtes (env_manager.h, renderer.h)
+
+Deux en-têtes de modules transportaient des includes transitifs inutiles, augmentant le couplage et le coût de recompilation :
+
+- **`env_manager.h`** : incluait `postprocess.h` alors qu'il n'utilise que `PostProcess*` dans les signatures de fonctions. Remplacé par une déclaration anticipée `typedef struct PostProcess PostProcess;`. L'include concret reste dans `env_manager.c` qui appelle `postprocess_set_exposure_target()`.
+- **`renderer.h`** : incluait 9 en-têtes projet (`action_notifier.h`, `camera.h`, `effect_benchmark.h`, `env_manager.h`, `gpu_profiler.h`, `gpu_profiler_ui.h`, `postprocess.h`, `scene.h`, `ui.h`) alors que `RenderContext` ne contient que des pointeurs. Tous remplacés par des déclarations anticipées. Seuls `<stdbool.h>` et `<stdint.h>` restent comme includes concrets. Le fichier `.c` inclut les en-têtes complets nécessaires.
+
+**Principe** : un en-tête qui n'utilise un type qu'à travers un pointeur ou une référence doit faire une déclaration anticipée de ce type, pas inclure sa définition complète. Cela réduit la propagation des includes et accélère les builds incrémentaux.
+
 ## Configuration CMake
 
 Les modules sont compilés séparément et liés à l'exécutable principal :

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,15 @@ Post-processing effects (bloom, DoF, auto-exposure, motion blur, LUT, LUT viz) a
 - This eliminates the bidirectional dependency: `postprocess.h` → `fx_*.h` (for struct embedding) remains, but `fx_*.c` → `postprocess.h` is removed.
 - All effects are now fully migrated: **bloom**, **DoF**, **auto-exposure**, **motion blur**, **LUT 3D**, and **LUT viz**. No effect source file includes `postprocess.h` anymore.
 
+### Header Dependency Cleanup (env_manager.h, renderer.h)
+
+Two module headers carried unnecessary transitive includes, increasing coupling and recompilation cost:
+
+- **`env_manager.h`**: Previously included `postprocess.h` even though it only uses `PostProcess*` in function signatures. Replaced with a forward declaration `typedef struct PostProcess PostProcess;`. The concrete include stays in `env_manager.c` which calls `postprocess_set_exposure_target()`.
+- **`renderer.h`**: Previously included 9 project headers (`action_notifier.h`, `camera.h`, `effect_benchmark.h`, `env_manager.h`, `gpu_profiler.h`, `gpu_profiler_ui.h`, `postprocess.h`, `scene.h`, `ui.h`) even though `RenderContext` holds only pointers. All replaced with forward declarations. Only `<stdbool.h>` and `<stdint.h>` remain as concrete includes. The `.c` file includes the full headers it needs.
+
+**Principle**: A header that only uses a type through a pointer or reference should forward-declare that type, not include its full definition. This reduces include fan-out and speeds up incremental builds.
+
 ## Build System
 
 The `CMakeLists.txt` has been updated to include the new source files. The `app` executable and `test_app` integration test both link against the new modular structure.

--- a/include/env_manager.h
+++ b/include/env_manager.h
@@ -14,10 +14,10 @@
 #include "async_loader.h"
 #include "gl_common.h"
 #include "ibl_coordinator.h"
-#include "postprocess.h"
 
 // Forward declarations
 typedef struct Scene Scene;
+typedef struct PostProcess PostProcess;
 
 /**
  * @struct EnvManager

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -1,16 +1,18 @@
 #ifndef RENDERER_H
 #define RENDERER_H
 
-#include "action_notifier.h"
-#include "camera.h"
-#include "effect_benchmark.h"
-#include "env_manager.h"
-#include "gpu_profiler.h"
-#include "gpu_profiler_ui.h"
-#include "postprocess.h"
-#include "scene.h"
-#include "ui.h"
+#include <stdbool.h>
 #include <stdint.h>
+
+/* Forward declarations — RenderContext holds only pointers. */
+typedef struct Scene Scene;
+typedef struct PostProcess PostProcess;
+typedef struct Camera Camera;
+typedef struct GPUProfiler GPUProfiler;
+typedef struct GPUProfilerUI GPUProfilerUI;
+typedef struct EnvManager EnvManager;
+typedef struct ActionNotifier ActionNotifier;
+typedef struct EffectBenchmark EffectBenchmark;
 
 /**
  * @brief Callback type for rendering the UI overlay.

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,9 +1,16 @@
 #include "renderer.h"
 
+#include "action_notifier.h"
+#include "camera.h"
+#include "effect_benchmark.h"
+#include "env_manager.h"
 #include "gl_common.h"
 #include "gl_debug.h"
 #include "gpu_profiler.h"
+#include "gpu_profiler_ui.h"
+#include "postprocess.h"
 #include "profiler.h"
+#include "scene.h"
 #include <GLFW/glfw3.h>
 
 void renderer_draw_frame(const RenderContext* ctx)


### PR DESCRIPTION
## Summary

Replace unnecessary transitive `#include` directives with forward declarations in two module headers, reducing coupling and recompilation cost.

### Changes

- **`include/env_manager.h`** (#245): Remove `#include "postprocess.h"`, add `typedef struct PostProcess PostProcess;` forward declaration. The concrete include stays in `env_manager.c` which calls `postprocess_set_exposure_target()`.
- **`include/renderer.h`** (#242): Replace 9 project includes (`action_notifier.h`, `camera.h`, `effect_benchmark.h`, `env_manager.h`, `gpu_profiler.h`, `gpu_profiler_ui.h`, `postprocess.h`, `scene.h`, `ui.h`) with 8 forward declarations. Only `<stdbool.h>` and `<stdint.h>` remain as concrete includes.
- **`src/renderer.c`**: Add concrete includes needed after header cleanup.
- **`docs/architecture.md`** + **`docs/architecture.fr.md`**: New "Header Dependency Cleanup" subsection (EN + FR).

### Principle

A header that only uses a type through a pointer should forward-declare that type, not include its full definition. All 14 `RenderContext` fields are pointers.

### Testing

- Build: 0 errors, 0 warnings
- Tests: 63/63 pass
- Format + Lint: clean

Closes #245
Closes #242