### PR TITLE
refactor(core): reduce include fan-out in app_input.c and app_ui.c

### DIFF
--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -159,6 +159,13 @@ Deux en-têtes de modules transportaient des includes transitifs inutiles, augme
 - **`env_manager.h`** : incluait `postprocess.h` alors qu'il n'utilise que `PostProcess*` dans les signatures de fonctions. Remplacé par une déclaration anticipée `typedef struct PostProcess PostProcess;`. L'include concret reste dans `env_manager.c` qui appelle `postprocess_set_exposure_target()`.
 - **`renderer.h`** : incluait 9 en-têtes projet (`action_notifier.h`, `camera.h`, `effect_benchmark.h`, `env_manager.h`, `gpu_profiler.h`, `gpu_profiler_ui.h`, `postprocess.h`, `scene.h`, `ui.h`) alors que `RenderContext` ne contient que des pointeurs. Tous remplacés par des déclarations anticipées. Seuls `<stdbool.h>` et `<stdint.h>` restent comme includes concrets. Le fichier `.c` inclut les en-têtes complets nécessaires.
 
+### Réduction du fan-out d'includes (app_input.c, app_ui.c)
+
+Les deux fichiers sources avec le plus haut fan-out d'includes ont été allégés en déplaçant la fonction pont `app_input_ctx_from_app()` vers `app.c` et en supprimant les includes inutilisés ou transitivement redondants :
+
+- **`app_input.c`** : 25 → 17 includes. La fonction pont était la seule raison d'inclure `app.h`, `app_profiling.h` et `app_input_state.h`. Son déplacement vers `app.c` (qui inclut déjà ces trois en-têtes) élimine le couplage. Suppressions additionnelles : `window.h` (jamais utilisé), `action_notifier.h`, `app_settings.h`, `nbody.h`, `glad/glad.h`, `GLFW/glfw3.h` (tous disponibles transitivement).
+- **`app_ui.c`** : 23 → 16 includes. Suppression de `stb_image.h` (aucun appel `stbi_*`), `<stdio.h>` et `<stdlib.h>` (aucune utilisation directe), plus 4 en-têtes transitivement redondants (`action_notifier.h`, `adaptive_sampler.h`, `app_binding.h`, `app_settings.h`).
+
 **Principe** : un en-tête qui n'utilise un type qu'à travers un pointeur ou une référence doit faire une déclaration anticipée de ce type, pas inclure sa définition complète. Cela réduit la propagation des includes et accélère les builds incrémentaux.
 
 ## Configuration CMake

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,6 +199,13 @@ Two module headers carried unnecessary transitive includes, increasing coupling 
 - **`env_manager.h`**: Previously included `postprocess.h` even though it only uses `PostProcess*` in function signatures. Replaced with a forward declaration `typedef struct PostProcess PostProcess;`. The concrete include stays in `env_manager.c` which calls `postprocess_set_exposure_target()`.
 - **`renderer.h`**: Previously included 9 project headers (`action_notifier.h`, `camera.h`, `effect_benchmark.h`, `env_manager.h`, `gpu_profiler.h`, `gpu_profiler_ui.h`, `postprocess.h`, `scene.h`, `ui.h`) even though `RenderContext` holds only pointers. All replaced with forward declarations. Only `<stdbool.h>` and `<stdint.h>` remain as concrete includes. The `.c` file includes the full headers it needs.
 
+### Include Fan-Out Reduction (app_input.c, app_ui.c)
+
+The two highest fan-out source files were trimmed by moving the `app_input_ctx_from_app()` bridge function to `app.c` and removing unused/transitively-redundant includes:
+
+- **`app_input.c`**: 25 → 17 includes. The bridge function was the sole reason for including `app.h`, `app_profiling.h`, and `app_input_state.h`. Moving it to `app.c` (which already includes all three) eliminates the coupling. Additional removals: `window.h` (never used), `action_notifier.h`, `app_settings.h`, `nbody.h`, `glad/glad.h`, `GLFW/glfw3.h` (all transitively available through remaining includes).
+- **`app_ui.c`**: 23 → 16 includes. Removed `stb_image.h` (zero `stbi_*` calls), `<stdio.h>` and `<stdlib.h>` (no direct usage), plus 4 transitively-redundant headers (`action_notifier.h`, `adaptive_sampler.h`, `app_binding.h`, `app_settings.h`).
+
 **Principle**: A header that only uses a type through a pointer or reference should forward-declare that type, not include its full definition. This reduces include fan-out and speeds up incremental builds.
 
 ## Build System

--- a/include/app_input.h
+++ b/include/app_input.h
@@ -17,6 +17,7 @@
 #include "gl_common.h"
 
 /* Forward declarations — avoids pulling heavy headers into app_input.h */
+typedef struct App App;
 typedef struct Camera Camera;
 typedef struct Scene Scene;
 typedef struct PostProcess PostProcess;
@@ -143,5 +144,14 @@ void app_toggle_fullscreen(AppInputContext* ctx, GLFWwindow* window);
  * @param filename Output file path (should end in .png).
  */
 void app_save_png_frame(AppInputContext* ctx, const char* filename);
+
+/**
+ * @brief Constructs an AppInputContext from the full App state.
+ *
+ * Bridges between the GLFW user-pointer (App*) and the decoupled
+ * input API (AppInputContext*). Defined in app.c to keep the heavy
+ * App sub-struct includes out of app_input.c.
+ */
+AppInputContext app_input_ctx_from_app(App* app);
 
 #endif /* APP_INPUT_H */

--- a/src/app.c
+++ b/src/app.c
@@ -442,3 +442,33 @@ void app_update(App* app)
 	                              &app->postprocess, app->delta_time,
 	                              app->frame_count);
 }
+AppInputContext app_input_ctx_from_app(App* app)
+{
+	return (AppInputContext){
+	    .window = app->win.handle,
+	    .camera = &app->input->camera,
+	    .scene = &app->scene,
+	    .postprocess = &app->postprocess,
+	    .env_mgr = &app->env_mgr,
+	    .notifier = &app->notifier,
+	    .overlay = &app->overlay,
+	    .timeline_ui = &app->profiling->timeline_ui,
+	    .effect_bench = &app->effect_bench,
+	    .perf_context = &app->profiling->perf_context,
+	    .gamepad = &app->input->gamepad,
+	    .async_loader = app->async_loader,
+	    .width = &app->width,
+	    .height = &app->height,
+	    .camera_enabled = &app->input->camera_enabled,
+	    .is_fullscreen = &app->win.is_fullscreen,
+	    .saved_x = &app->win.saved_x,
+	    .saved_y = &app->win.saved_y,
+	    .saved_width = &app->win.saved_width,
+	    .saved_height = &app->win.saved_height,
+	    .resize_pending = &app->win.resize_pending,
+	    .pending_width = &app->win.pending_width,
+	    .pending_height = &app->win.pending_height,
+	    .perf_mode_active = &app->profiling->perf_mode_active,
+	    .log_gpu_metrics = &app->profiling->log_gpu_metrics,
+	};
+}

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -1,66 +1,21 @@
 #include "app_input.h"
 
-#include "action_notifier.h"
-#include "app.h"
-#include "app_input_state.h"
-#include "app_profiling.h"
-#include "app_settings.h"
 #include "app_ui.h"
 #include "camera.h"
 #include "camera_input.h"
 #include "env_manager.h"
-#include "glad/glad.h"
+#include "gamepad_input.h"
+#include "gpu_profiler_ui.h"
 #include "log.h"
-#include "nbody.h"
 #include "perf_mode.h"
 #include "postprocess_input.h"
 #include "profiler.h"
 #include "scene.h"
 #include "utils.h"
-#include "window.h"
-#include <GLFW/glfw3.h>
 #include <math.h>
 #include <stb_image_write.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-/**
- * @brief Constructs an AppInputContext from the full App state.
- *
- * Used by GLFW callbacks to bridge between the GLFW user-pointer (App*)
- * and the decoupled input API (AppInputContext*).
- */
-static inline AppInputContext app_input_ctx_from_app(App* app)
-{
-	return (AppInputContext){
-	    .window = app->win.handle,
-	    .camera = &app->input->camera,
-	    .scene = &app->scene,
-	    .postprocess = &app->postprocess,
-	    .env_mgr = &app->env_mgr,
-	    .notifier = &app->notifier,
-	    .overlay = &app->overlay,
-	    .timeline_ui = &app->profiling->timeline_ui,
-	    .effect_bench = &app->effect_bench,
-	    .perf_context = &app->profiling->perf_context,
-	    .gamepad = &app->input->gamepad,
-	    .async_loader = app->async_loader,
-	    .width = &app->width,
-	    .height = &app->height,
-	    .camera_enabled = &app->input->camera_enabled,
-	    .is_fullscreen = &app->win.is_fullscreen,
-	    .saved_x = &app->win.saved_x,
-	    .saved_y = &app->win.saved_y,
-	    .saved_width = &app->win.saved_width,
-	    .saved_height = &app->win.saved_height,
-	    .resize_pending = &app->win.resize_pending,
-	    .pending_width = &app->win.pending_width,
-	    .pending_height = &app->win.pending_height,
-	    .perf_mode_active = &app->profiling->perf_mode_active,
-	    .log_gpu_metrics = &app->profiling->log_gpu_metrics,
-	};
-}
 
 enum { PBR_DEBUG_MODE_COUNT = 10 };
 

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -1,12 +1,8 @@
 #include "app_ui.h"
 
-#include "action_notifier.h"
-#include "adaptive_sampler.h"
 #include "app.h"
-#include "app_binding.h"
 #include "app_input_state.h"
 #include "app_profiling.h"
-#include "app_settings.h"
 #include "app_ui_layout.h" /* Private: layout constants, keyboard/gamepad data */
 #include "glad/glad.h"
 #include "nbody.h"
@@ -17,10 +13,7 @@
 #include <GLFW/glfw3.h>
 #include <cglm/types.h>
 #include <math.h>
-#include <stb_image.h>
 #include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 /* --- Forward Declarations (Internal) --- */


### PR DESCRIPTION
## Summary

Reduce include fan-out in the two highest-coupling source files:

| File | Before | After | Removed |
|------|--------|-------|---------|
| `app_input.c` | 25 | 17 | -8 |
| `app_ui.c` | 23 | 16 | -7 |

### Key change

Moved `app_input_ctx_from_app()` bridge function from `app_input.c` to `app.c`. This was the sole reason `app_input.c` included `app.h`, `app_profiling.h`, and `app_input_state.h` — three heavy headers with deep transitive include trees.

### Removals

**app_input.c** (-8): `app.h`, `app_input_state.h`, `app_profiling.h`, `window.h`, `action_notifier.h`, `app_settings.h`, `nbody.h`, `glad/glad.h`, `GLFW/glfw3.h`, `stdio.h` (added `gamepad_input.h`, `gpu_profiler_ui.h`)

**app_ui.c** (-7): `stb_image.h` (unused), `stdio.h` (unused), `stdlib.h` (unused), `action_notifier.h`, `adaptive_sampler.h`, `app_binding.h`, `app_settings.h` (transitively redundant)

Public API unchanged. All 63 tests pass. Architecture docs updated (EN + FR).

Closes #252