### PR TITLE
test(coverage): add 97 standalone mocked tests for 5 modules (#253)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_coordinator\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_loader\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_security\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_ibl_extract\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_scene_nbody\\.c$")
 
 # Exclure les tests spécifiques à POSIX sur Windows
 if(WIN32)
@@ -727,6 +728,46 @@ if(WIN32)
 else()
     add_test(NAME test_texture_security COMMAND test_texture_security)
 endif()
+# =============================================================================
+# SCENE N-BODY (STANDALONE MOCKED)
+# =============================================================================
+add_executable(test_scene_nbody
+    test_scene_nbody.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+    ${CMAKE_SOURCE_DIR}/src/nbody.c
+    ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+)
+if(ENABLE_TRACY)
+    target_sources(test_scene_nbody PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
+endif()
+
+target_include_directories(test_scene_nbody PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+)
+if(ENABLE_TRACY)
+    target_include_directories(test_scene_nbody PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public")
+endif()
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(test_scene_nbody PRIVATE cglm m)
+else()
+    target_link_libraries(test_scene_nbody PRIVATE cglm)
+endif()
+
+if(WIN32)
+    add_test(NAME test_scene_nbody
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_scene_nbody>)
+else()
+    add_test(NAME test_scene_nbody COMMAND test_scene_nbody)
+endif()
+
 # =============================================================================
 # IBL EXTRACTION TOOL (STANDALONE)
 # =============================================================================

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_scene_nbody\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shockwave\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_trail_renderer\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_postprocess_input\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_scene_render\\.c$")
 
 # Exclure les tests spécifiques à POSIX sur Windows
 if(WIN32)
@@ -895,6 +896,47 @@ if(WIN32)
              COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_postprocess_input>)
 else()
     add_test(NAME test_postprocess_input COMMAND test_postprocess_input)
+endif()
+
+# =============================================================================
+# SCENE RENDER (STANDALONE MOCKED)
+# =============================================================================
+add_executable(test_scene_render
+    test_scene_render.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
+    ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+)
+if(ENABLE_TRACY)
+    target_sources(test_scene_render PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
+endif()
+
+target_include_directories(test_scene_render PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+    ${glad_BINARY_DIR}/include
+)
+if(ENABLE_TRACY)
+    target_include_directories(test_scene_render PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public")
+endif()
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(test_scene_render PRIVATE cglm m)
+else()
+    target_link_libraries(test_scene_render PRIVATE cglm)
+endif()
+
+if(WIN32)
+    add_test(NAME test_scene_render
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_scene_render>)
+else()
+    add_test(NAME test_scene_render COMMAND test_scene_render)
 endif()
 
 # =============================================================================

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,9 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_async_loader\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_texture_security\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_ibl_extract\\.c$")
 list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_scene_nbody\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_shockwave\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_trail_renderer\\.c$")
+list(FILTER TEST_SOURCES EXCLUDE REGEX ".*test_postprocess_input\\.c$")
 
 # Exclure les tests spécifiques à POSIX sur Windows
 if(WIN32)
@@ -766,6 +769,132 @@ if(WIN32)
              COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_scene_nbody>)
 else()
     add_test(NAME test_scene_nbody COMMAND test_scene_nbody)
+endif()
+
+# =============================================================================
+# SHOCKWAVE (STANDALONE MOCKED)
+# =============================================================================
+add_executable(test_shockwave
+    test_shockwave.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
+    ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+)
+if(ENABLE_TRACY)
+    target_sources(test_shockwave PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
+endif()
+
+target_include_directories(test_shockwave PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+    ${glad_BINARY_DIR}/include
+)
+if(ENABLE_TRACY)
+    target_include_directories(test_shockwave PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public")
+endif()
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(test_shockwave PRIVATE cglm m)
+else()
+    target_link_libraries(test_shockwave PRIVATE cglm)
+endif()
+
+if(WIN32)
+    add_test(NAME test_shockwave
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_shockwave>)
+else()
+    add_test(NAME test_shockwave COMMAND test_shockwave)
+endif()
+
+# =============================================================================
+# TRAIL RENDERER (STANDALONE MOCKED)
+# =============================================================================
+add_executable(test_trail_renderer
+    test_trail_renderer.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gpu_profiler.c
+    ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+)
+if(ENABLE_TRACY)
+    target_sources(test_trail_renderer PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
+endif()
+
+target_include_directories(test_trail_renderer PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+    ${glad_BINARY_DIR}/include
+)
+if(ENABLE_TRACY)
+    target_include_directories(test_trail_renderer PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public")
+endif()
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(test_trail_renderer PRIVATE cglm m)
+else()
+    target_link_libraries(test_trail_renderer PRIVATE cglm)
+endif()
+
+if(WIN32)
+    add_test(NAME test_trail_renderer
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_trail_renderer>)
+else()
+    add_test(NAME test_trail_renderer COMMAND test_trail_renderer)
+endif()
+
+# =============================================================================
+# POSTPROCESS INPUT (STANDALONE MOCKED)
+# =============================================================================
+add_executable(test_postprocess_input
+    test_postprocess_input.c
+    ${unity_SOURCE_DIR}/src/unity.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
+    ${CMAKE_SOURCE_DIR}/src/postprocess_presets.c
+    ${CMAKE_SOURCE_DIR}/src/utils.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
+)
+if(ENABLE_TRACY)
+    target_sources(test_postprocess_input PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public/TracyClient.cpp")
+endif()
+
+target_include_directories(test_postprocess_input PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/mocks
+    ${CMAKE_SOURCE_DIR}/tests/mocks/standalone
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${glfw_SOURCE_DIR}/include
+    ${stb_SOURCE_DIR}
+    ${unity_SOURCE_DIR}/src
+    ${glad_BINARY_DIR}/include
+)
+if(ENABLE_TRACY)
+    target_include_directories(test_postprocess_input PRIVATE "${CMAKE_SOURCE_DIR}/deps/tracy/public")
+endif()
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(test_postprocess_input PRIVATE cglm m)
+else()
+    target_link_libraries(test_postprocess_input PRIVATE cglm)
+endif()
+
+if(WIN32)
+    add_test(NAME test_postprocess_input
+             COMMAND ${CMAKE_SOURCE_DIR}/.github/workflows/scripts/run_test_with_xvfb.sh $<TARGET_FILE:test_postprocess_input>)
+else()
+    add_test(NAME test_postprocess_input COMMAND test_postprocess_input)
 endif()
 
 # =============================================================================

--- a/tests/mocks/GLFW/glfw3.h
+++ b/tests/mocks/GLFW/glfw3.h
@@ -58,13 +58,22 @@ typedef struct GLFWvidmode {
 #define GLFW_KEY_6 54
 #define GLFW_KEY_7 55
 #define GLFW_KEY_8 56
+#define GLFW_KEY_9 57
+#define GLFW_KEY_B 66
+#define GLFW_KEY_U 85
 #define GLFW_KEY_KP_0 320
 #define GLFW_KEY_KP_ADD 334
 #define GLFW_KEY_KP_SUBTRACT 333
 
 #define GLFW_MOD_SHIFT 0x0001
+#define GLFW_MOD_CONTROL 0x0002
+#define GLFW_MOD_ALT 0x0004
 #define GLFW_KEY_LEFT_SHIFT 340
 #define GLFW_KEY_RIGHT_SHIFT 344
+#define GLFW_KEY_F7 296
+#define GLFW_KEY_F8 297
+#define GLFW_KEY_F10 299
+#define GLFW_KEY_F11 300
 
 #define GLFW_CURSOR 0x00033001
 #define GLFW_CURSOR_NORMAL 0x00034001

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -109,6 +109,7 @@ typedef struct __GLsync* GLsync;
 #define GL_FRONT_AND_BACK 0x0408
 #define GL_SRC_ALPHA 0x0302
 #define GL_ONE_MINUS_SRC_ALPHA 0x0303
+#define GL_ONE 1
 #define GL_FILL 0x1B02
 #define GL_PIXEL_UNPACK_BUFFER 0x88EC
 #define GL_STREAM_DRAW 0x88E0

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -111,6 +111,13 @@ typedef struct __GLsync* GLsync;
 #define GL_ONE_MINUS_SRC_ALPHA 0x0303
 #define GL_ONE 1
 #define GL_FILL 0x1B02
+#define GL_LINE 0x1B01
+#define GL_STENCIL_TEST 0x0B90
+#define GL_KEEP 0x1E00
+#define GL_REPLACE 0x1E01
+#define GL_ALWAYS 0x0207
+#define GL_POLYGON_OFFSET_FILL 0x8037
+#define GL_POLYGON_OFFSET_LINE 0x2A02
 #define GL_PIXEL_UNPACK_BUFFER 0x88EC
 #define GL_STREAM_DRAW 0x88E0
 #define GL_TEXTURE_WIDTH 0x1000
@@ -262,5 +269,13 @@ void glGetActiveUniform(GLuint program, GLuint index, GLsizei bufSize,
 GLsync glFenceSync(GLenum condition, GLbitfield flags);
 GLenum glClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout);
 void glDeleteSync(GLsync sync);
+
+void glDepthMask(GLboolean flag);
+void glEnablei(GLenum target, GLuint index);
+void glDisablei(GLenum target, GLuint index);
+void glPolygonOffset(GLfloat factor, GLfloat units);
+void glStencilOp(GLenum sfail, GLenum dpfail, GLenum dppass);
+void glStencilFunc(GLenum func, GLint ref, GLuint mask);
+void glStencilMask(GLuint mask);
 
 #endif

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -701,3 +701,39 @@ void gl_debug_push_group(const char* name)
 void gl_debug_pop_group(void)
 {
 }
+
+void glDepthMask(GLboolean flag)
+{
+	(void)flag;
+}
+void glEnablei(GLenum target, GLuint index)
+{
+	(void)target;
+	(void)index;
+}
+void glDisablei(GLenum target, GLuint index)
+{
+	(void)target;
+	(void)index;
+}
+void glPolygonOffset(GLfloat factor, GLfloat units)
+{
+	(void)factor;
+	(void)units;
+}
+void glStencilOp(GLenum sfail, GLenum dpfail, GLenum dppass)
+{
+	(void)sfail;
+	(void)dpfail;
+	(void)dppass;
+}
+void glStencilFunc(GLenum func, GLint ref, GLuint mask)
+{
+	(void)func;
+	(void)ref;
+	(void)mask;
+}
+void glStencilMask(GLuint mask)
+{
+	(void)mask;
+}

--- a/tests/test_postprocess_input.c
+++ b/tests/test_postprocess_input.c
@@ -1,0 +1,530 @@
+/**
+ * @file test_postprocess_input.c
+ * @brief Tests for postprocess_input.c — key handlers, toggle, presets.
+ *
+ * Uses standalone mocks (no GPU required). Includes postprocess_input.c
+ * directly and mocks all external postprocess/notifier/benchmark APIs.
+ */
+
+#include "mock_gl_standalone.h"
+
+/* Type-providing headers — must come before mock definitions */
+#include "app_settings.h"
+#include "postprocess_input.h"
+#include "unity.h"
+#include <string.h>
+
+/* ---- Mock state ---- */
+
+static int mock_toggle_calls;
+static PostProcessEffect mock_last_toggled;
+
+static int mock_enable_calls;
+static PostProcessEffect mock_last_enabled;
+
+static int mock_disable_calls;
+static PostProcessEffect mock_last_disabled;
+
+static int mock_set_exposure_calls;
+static float mock_last_exposure_value;
+
+static int mock_apply_preset_calls;
+
+static int mock_load_lut3d_calls;
+static int mock_load_lut3d_return;
+
+static int mock_notifier_push_calls;
+static char mock_last_notification[128];
+
+static int mock_bench_start_calls;
+static bool mock_bench_is_running_val;
+
+static int mock_ae_toggle_path_calls;
+static int mock_ae_path_name_calls;
+
+/* ---- Mock postprocess API ---- */
+
+void postprocess_toggle(PostProcess* pp, PostProcessEffect effect)
+{
+	pp->active_effects ^= (unsigned int)effect;
+	mock_toggle_calls++;
+	mock_last_toggled = effect;
+}
+
+void postprocess_enable(PostProcess* pp, PostProcessEffect effect)
+{
+	pp->active_effects |= (unsigned int)effect;
+	mock_enable_calls++;
+	mock_last_enabled = effect;
+}
+
+void postprocess_disable(PostProcess* pp, PostProcessEffect effect)
+{
+	pp->active_effects &= ~(unsigned int)effect;
+	mock_disable_calls++;
+	mock_last_disabled = effect;
+}
+
+int postprocess_is_enabled(PostProcess* pp, PostProcessEffect effect)
+{
+	return (pp->active_effects & (unsigned int)effect) != 0;
+}
+
+void postprocess_set_exposure(PostProcess* pp, float exposure)
+{
+	pp->exposure.exposure = exposure;
+	mock_set_exposure_calls++;
+	mock_last_exposure_value = exposure;
+}
+
+void postprocess_apply_preset(PostProcess* pp, const PostProcessPreset* preset)
+{
+	pp->active_effects = preset->active_effects;
+	mock_apply_preset_calls++;
+}
+
+int postprocess_load_lut3d(PostProcess* pp, const char* path)
+{
+	(void)pp;
+	(void)path;
+	mock_load_lut3d_calls++;
+	return mock_load_lut3d_return;
+}
+
+/* ---- Mock action_notifier ---- */
+
+void action_notifier_push(ActionNotifier* notifier, const char* text,
+                          float duration)
+{
+	(void)notifier;
+	(void)duration;
+	mock_notifier_push_calls++;
+	strncpy(mock_last_notification, text,
+	        sizeof(mock_last_notification) - 1);
+	mock_last_notification[sizeof(mock_last_notification) - 1] = '\0';
+}
+
+/* ---- Mock effect_benchmark ---- */
+
+bool effect_benchmark_start(EffectBenchmark* bench)
+{
+	(void)bench;
+	mock_bench_start_calls++;
+	return true;
+}
+
+bool effect_benchmark_is_running(const EffectBenchmark* bench)
+{
+	(void)bench;
+	return mock_bench_is_running_val;
+}
+
+/* ---- Mock auto-exposure ---- */
+
+void fx_auto_exposure_toggle_path(AutoExposureFX* auto_exp)
+{
+	(void)auto_exp;
+	mock_ae_toggle_path_calls++;
+}
+
+const char* fx_auto_exposure_path_name(AutoExposureFX* auto_exp)
+{
+	(void)auto_exp;
+	mock_ae_path_name_calls++;
+	return "CPU Histogram";
+}
+
+/* ---- Include source under test ---- */
+#include "postprocess_input.c"
+
+/* ---- Helpers ---- */
+
+static PostProcess g_pp;
+static ActionNotifier g_notifier;
+static EffectBenchmark g_bench;
+static PostProcessInputContext g_ctx;
+
+static void reset_mocks(void)
+{
+	mock_gl_reset_calls();
+	mock_toggle_calls = 0;
+	mock_last_toggled = 0;
+	mock_enable_calls = 0;
+	mock_last_enabled = 0;
+	mock_disable_calls = 0;
+	mock_last_disabled = 0;
+	mock_set_exposure_calls = 0;
+	mock_last_exposure_value = 0.0F;
+	mock_apply_preset_calls = 0;
+	mock_load_lut3d_calls = 0;
+	mock_load_lut3d_return = 0;
+	mock_notifier_push_calls = 0;
+	mock_last_notification[0] = '\0';
+	mock_bench_start_calls = 0;
+	mock_bench_is_running_val = false;
+	mock_ae_toggle_path_calls = 0;
+	mock_ae_path_name_calls = 0;
+}
+
+static void setup_context(void)
+{
+	memset(&g_pp, 0, sizeof(g_pp));
+	memset(&g_notifier, 0, sizeof(g_notifier));
+	memset(&g_bench, 0, sizeof(g_bench));
+	g_ctx.postprocess = &g_pp;
+	g_ctx.notifier = &g_notifier;
+	g_ctx.effect_bench = &g_bench;
+	g_ctx.window = NULL;
+}
+
+/* ---- Unity ---- */
+
+void setUp(void)
+{
+	reset_mocks();
+	setup_context();
+}
+
+void tearDown(void)
+{
+}
+
+/* ===========================================================================
+ * Toggle tests
+ * ===========================================================================*/
+
+void test_key_v_toggles_vignette(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_V, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_VIGNETTE, mock_last_toggled);
+	TEST_ASSERT_EQUAL_INT(1, mock_notifier_push_calls);
+}
+
+void test_key_g_toggles_grain(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_G, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_GRAIN, mock_last_toggled);
+}
+
+void test_key_b_toggles_bloom(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_B, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_BLOOM, mock_last_toggled);
+}
+
+void test_key_h_toggles_dof(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_H, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_DOF, mock_last_toggled);
+}
+
+void test_key_h_shift_toggles_dof_debug(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_H, GLFW_MOD_SHIFT);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_DOF_DEBUG, mock_last_toggled);
+}
+
+void test_key_u_toggles_chrom_abbr(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_U, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_CHROM_ABBR, mock_last_toggled);
+}
+
+void test_key_m_toggles_motion_blur(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_M, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_MOTION_BLUR, mock_last_toggled);
+}
+
+void test_key_x_toggles_fxaa(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_X, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_FXAA, mock_last_toggled);
+}
+
+void test_key_x_shift_toggles_fxaa_debug(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_X, GLFW_MOD_SHIFT);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_FXAA_DEBUG, mock_last_toggled);
+}
+
+void test_key_f6_toggles_stencil_debug(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_F6, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_STENCIL_DEBUG, mock_last_toggled);
+}
+
+void test_key_f7_toggles_fog(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_F7, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_FOG, mock_last_toggled);
+}
+
+void test_key_f7_shift_toggles_fog_debug(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_F7, GLFW_MOD_SHIFT);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_FOG_DEBUG, mock_last_toggled);
+}
+
+/* ===========================================================================
+ * Exposure tests
+ * ===========================================================================*/
+
+void test_kp_add_increases_exposure(void)
+{
+	g_pp.exposure.exposure = 1.0F;
+
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_KP_ADD, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_set_exposure_calls);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 1.0F + DEFAULT_EXPOSURE_STEP,
+	                         mock_last_exposure_value);
+}
+
+void test_kp_subtract_decreases_exposure(void)
+{
+	g_pp.exposure.exposure = 2.0F;
+
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_KP_SUBTRACT, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_set_exposure_calls);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 2.0F - DEFAULT_EXPOSURE_STEP,
+	                         mock_last_exposure_value);
+}
+
+void test_kp_subtract_clamps_at_min(void)
+{
+	g_pp.exposure.exposure = DEFAULT_MIN_EXPOSURE;
+
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_KP_SUBTRACT, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_set_exposure_calls);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, DEFAULT_MIN_EXPOSURE,
+	                         mock_last_exposure_value);
+}
+
+/* ===========================================================================
+ * Auto-exposure
+ * ===========================================================================*/
+
+void test_key_j_toggles_auto_exposure(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_J, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_toggle_calls);
+	TEST_ASSERT_EQUAL(POSTFX_AUTO_EXPOSURE, mock_last_toggled);
+}
+
+void test_key_j_ctrl_toggles_ae_path(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_J, GLFW_MOD_CONTROL);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_ae_toggle_path_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_ae_path_name_calls);
+}
+
+/* ===========================================================================
+ * Preset tests
+ * ===========================================================================*/
+
+void test_key_1_applies_default_preset(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_1, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_apply_preset_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_set_exposure_calls);
+}
+
+void test_key_2_applies_subtle_preset(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_2, 0);
+	TEST_ASSERT_EQUAL_INT(1, mock_apply_preset_calls);
+}
+
+void test_key_3_applies_cinematic_preset(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_3, 0);
+	TEST_ASSERT_EQUAL_INT(1, mock_apply_preset_calls);
+}
+
+void test_key_0_resets_to_defaults(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_0, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_apply_preset_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_set_exposure_calls);
+}
+
+void test_key_kp0_resets_to_defaults(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_KP_0, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_apply_preset_calls);
+}
+
+/* ===========================================================================
+ * Bloom debug cycling
+ * ===========================================================================*/
+
+void test_key_b_shift_cycles_bloom_debug(void)
+{
+	/* First press: Off -> Debug Final */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_B, GLFW_MOD_SHIFT);
+	TEST_ASSERT_TRUE(postprocess_is_enabled(&g_pp, POSTFX_BLOOM_DEBUG));
+	TEST_ASSERT_EQUAL_INT(0, g_pp.bloom_fx.debug_step);
+
+	/* Second press: Final -> Prefilter */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_B, GLFW_MOD_SHIFT);
+	TEST_ASSERT_EQUAL_INT(1, g_pp.bloom_fx.debug_step);
+
+	/* Third press: Prefilter -> Downsample */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_B, GLFW_MOD_SHIFT);
+	TEST_ASSERT_EQUAL_INT(2, g_pp.bloom_fx.debug_step);
+
+	/* Fourth press: Downsample -> Upsample */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_B, GLFW_MOD_SHIFT);
+	TEST_ASSERT_EQUAL_INT(3, g_pp.bloom_fx.debug_step);
+
+	/* Fifth press: Upsample -> Off */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_B, GLFW_MOD_SHIFT);
+	TEST_ASSERT_FALSE(postprocess_is_enabled(&g_pp, POSTFX_BLOOM_DEBUG));
+}
+
+/* ===========================================================================
+ * Motion blur debug cycling
+ * ===========================================================================*/
+
+void test_key_m_shift_cycles_motion_blur_debug(void)
+{
+	/* First: Off -> MB Debug */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_M, GLFW_MOD_SHIFT);
+	TEST_ASSERT_TRUE(
+	    postprocess_is_enabled(&g_pp, POSTFX_MOTION_BLUR_DEBUG));
+
+	/* Second: MB Debug -> Vector Field */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_M, GLFW_MOD_SHIFT);
+	TEST_ASSERT_FALSE(
+	    postprocess_is_enabled(&g_pp, POSTFX_MOTION_BLUR_DEBUG));
+	TEST_ASSERT_TRUE(
+	    postprocess_is_enabled(&g_pp, POSTFX_VECTOR_FIELD_DEBUG));
+
+	/* Third: Vector Field -> Off */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_M, GLFW_MOD_SHIFT);
+	TEST_ASSERT_FALSE(
+	    postprocess_is_enabled(&g_pp, POSTFX_VECTOR_FIELD_DEBUG));
+}
+
+/* ===========================================================================
+ * Benchmark
+ * ===========================================================================*/
+
+void test_key_8_starts_benchmark(void)
+{
+	mock_bench_is_running_val = false;
+
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_8, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_bench_start_calls);
+}
+
+void test_key_8_noop_when_benchmark_running(void)
+{
+	mock_bench_is_running_val = true;
+
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_8, 0);
+
+	TEST_ASSERT_EQUAL_INT(0, mock_bench_start_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_notifier_push_calls);
+}
+
+/* ===========================================================================
+ * Banding style cycling (key 7)
+ * ===========================================================================*/
+
+void test_key_7_enables_banding_first_press(void)
+{
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_7, 0);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_apply_preset_calls);
+	TEST_ASSERT_EQUAL_INT(0, g_pp.banding_preset_idx);
+}
+
+void test_key_7_cycles_banding_styles(void)
+{
+	/* First press: enable at idx 0 */
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_7, 0);
+	TEST_ASSERT_EQUAL_INT(0, g_pp.banding_preset_idx);
+
+	/* Second press: cycle to idx 1 */
+	g_pp.active_effects |= (unsigned int)POSTFX_BANDING;
+	postprocess_input_handle_key(&g_ctx, GLFW_KEY_7, 0);
+	TEST_ASSERT_EQUAL_INT(1, g_pp.banding_preset_idx);
+}
+
+/* ---- Main ---- */
+
+int main(void)
+{
+	UNITY_BEGIN();
+	/* Toggles */
+	RUN_TEST(test_key_v_toggles_vignette);
+	RUN_TEST(test_key_g_toggles_grain);
+	RUN_TEST(test_key_b_toggles_bloom);
+	RUN_TEST(test_key_h_toggles_dof);
+	RUN_TEST(test_key_h_shift_toggles_dof_debug);
+	RUN_TEST(test_key_u_toggles_chrom_abbr);
+	RUN_TEST(test_key_m_toggles_motion_blur);
+	RUN_TEST(test_key_x_toggles_fxaa);
+	RUN_TEST(test_key_x_shift_toggles_fxaa_debug);
+	RUN_TEST(test_key_f6_toggles_stencil_debug);
+	RUN_TEST(test_key_f7_toggles_fog);
+	RUN_TEST(test_key_f7_shift_toggles_fog_debug);
+	/* Exposure */
+	RUN_TEST(test_kp_add_increases_exposure);
+	RUN_TEST(test_kp_subtract_decreases_exposure);
+	RUN_TEST(test_kp_subtract_clamps_at_min);
+	/* Auto-exposure */
+	RUN_TEST(test_key_j_toggles_auto_exposure);
+	RUN_TEST(test_key_j_ctrl_toggles_ae_path);
+	/* Presets */
+	RUN_TEST(test_key_1_applies_default_preset);
+	RUN_TEST(test_key_2_applies_subtle_preset);
+	RUN_TEST(test_key_3_applies_cinematic_preset);
+	RUN_TEST(test_key_0_resets_to_defaults);
+	RUN_TEST(test_key_kp0_resets_to_defaults);
+	/* Bloom debug */
+	RUN_TEST(test_key_b_shift_cycles_bloom_debug);
+	/* Motion blur debug */
+	RUN_TEST(test_key_m_shift_cycles_motion_blur_debug);
+	/* Benchmark */
+	RUN_TEST(test_key_8_starts_benchmark);
+	RUN_TEST(test_key_8_noop_when_benchmark_running);
+	/* Banding */
+	RUN_TEST(test_key_7_enables_banding_first_press);
+	RUN_TEST(test_key_7_cycles_banding_styles);
+	return UNITY_END();
+}

--- a/tests/test_scene_nbody.c
+++ b/tests/test_scene_nbody.c
@@ -1,0 +1,331 @@
+/**
+ * @file test_scene_nbody.c
+ * @brief Tests for scene_nbody.c — N-body scene integration (toggle + update).
+ *
+ * Uses standalone mocks (no GPU required). Includes scene_nbody.c directly
+ * and mocks all visual/GPU subsystem calls.
+ */
+
+#include "mock_gl_standalone.h"
+
+/* Include type-providing headers BEFORE mock definitions */
+#include "billboard_rendering.h"
+#include "billboard_sorting.h"
+#include "instanced_rendering.h"
+#include "nbody.h"
+#include "scene.h"
+#include "scene_internal.h"
+#include "shockwave.h"
+#include "trail_renderer.h"
+#include "unity.h"
+#include <stdbool.h>
+#include <string.h>
+
+/* ---- Mock call counters ---- */
+static int mock_trail_init_calls;
+static int mock_trail_cleanup_calls;
+static int mock_trail_record_calls;
+static int mock_trail_set_color_calls;
+static int mock_shockwave_init_calls;
+static int mock_shockwave_cleanup_calls;
+static int mock_shockwave_emit_calls;
+static int mock_shockwave_update_calls;
+static int mock_instanced_update_calls;
+static int mock_instanced_cleanup_calls;
+static int mock_billboard_cleanup_calls;
+static int mock_billboard_sorter_cleanup_calls;
+static int mock_scene_init_instancing_calls;
+
+/* Control: make trail_renderer_init fail */
+static bool mock_trail_init_fail;
+/* Control: make shockwave_renderer_init fail */
+static bool mock_shockwave_init_fail;
+
+/* ---- Mocks for visual/GPU subsystems ---- */
+
+bool trail_renderer_init(TrailRenderer* tr, int body_count)
+{
+	(void)tr;
+	(void)body_count;
+	mock_trail_init_calls++;
+	return !mock_trail_init_fail;
+}
+
+void trail_renderer_cleanup(TrailRenderer* tr)
+{
+	(void)tr;
+	mock_trail_cleanup_calls++;
+}
+
+void trail_renderer_record(TrailRenderer* tr, const NBodySim* sim,
+                           float delta_time)
+{
+	(void)tr;
+	(void)sim;
+	(void)delta_time;
+	mock_trail_record_calls++;
+}
+
+void trail_renderer_set_color(TrailRenderer* tr, int body_index,
+                              const float color[3])
+{
+	(void)tr;
+	(void)body_index;
+	(void)color;
+	mock_trail_set_color_calls++;
+}
+
+bool shockwave_renderer_init(ShockwaveRenderer* renderer)
+{
+	(void)renderer;
+	mock_shockwave_init_calls++;
+	return !mock_shockwave_init_fail;
+}
+
+void shockwave_renderer_cleanup(ShockwaveRenderer* renderer)
+{
+	(void)renderer;
+	mock_shockwave_cleanup_calls++;
+}
+
+void shockwave_emit(ShockwaveRenderer* renderer, const vec3 position,
+                    const vec3 color, float velocity, float sim_time)
+{
+	(void)renderer;
+	(void)position;
+	(void)color;
+	(void)velocity;
+	(void)sim_time;
+	mock_shockwave_emit_calls++;
+}
+
+void shockwave_update(ShockwaveRenderer* renderer, float sim_time)
+{
+	(void)renderer;
+	(void)sim_time;
+	mock_shockwave_update_calls++;
+}
+
+void instanced_group_update(InstancedGroup* group, const SphereInstance* data,
+                            int count)
+{
+	(void)group;
+	(void)data;
+	(void)count;
+	mock_instanced_update_calls++;
+}
+
+void instanced_group_cleanup(InstancedGroup* group)
+{
+	(void)group;
+	mock_instanced_cleanup_calls++;
+}
+
+void billboard_group_cleanup(BillboardGroup* group)
+{
+	(void)group;
+	mock_billboard_cleanup_calls++;
+}
+
+void billboard_sorter_cleanup(BillboardSorter* sorter)
+{
+	(void)sorter;
+	mock_billboard_sorter_cleanup_calls++;
+}
+
+void scene_init_instancing(Scene* scene)
+{
+	(void)scene;
+	mock_scene_init_instancing_calls++;
+}
+
+/* ---- Include source under test ---- */
+#include "scene_nbody.c"
+
+/* ---- Helpers ---- */
+
+static void reset_mocks(void)
+{
+	mock_gl_reset_calls();
+	mock_trail_init_calls = 0;
+	mock_trail_cleanup_calls = 0;
+	mock_trail_record_calls = 0;
+	mock_trail_set_color_calls = 0;
+	mock_shockwave_init_calls = 0;
+	mock_shockwave_cleanup_calls = 0;
+	mock_shockwave_emit_calls = 0;
+	mock_shockwave_update_calls = 0;
+	mock_instanced_update_calls = 0;
+	mock_instanced_cleanup_calls = 0;
+	mock_billboard_cleanup_calls = 0;
+	mock_billboard_sorter_cleanup_calls = 0;
+	mock_scene_init_instancing_calls = 0;
+	mock_trail_init_fail = false;
+	mock_shockwave_init_fail = false;
+}
+
+static Scene make_test_scene(void)
+{
+	Scene scene;
+	memset(&scene, 0, sizeof(scene));
+	return scene;
+}
+
+/* ---- Unity Setup/Teardown ---- */
+
+void setUp(void)
+{
+	reset_mocks();
+}
+
+void tearDown(void)
+{
+}
+
+/* ---- Tests: scene_toggle_nbody ---- */
+
+void test_toggle_nbody_enables_mode(void)
+{
+	Scene scene = make_test_scene();
+	scene.simulation.nbody_mode = 0;
+
+	scene_toggle_nbody(&scene);
+
+	TEST_ASSERT_TRUE(scene.simulation.nbody_mode);
+	TEST_ASSERT_EQUAL_INT(1, mock_trail_init_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_shockwave_init_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_instanced_update_calls);
+	TEST_ASSERT_TRUE(mock_trail_set_color_calls > 0);
+}
+
+void test_toggle_nbody_disables_mode(void)
+{
+	Scene scene = make_test_scene();
+	/* Enable first */
+	scene.simulation.nbody_mode = 0;
+	scene_toggle_nbody(&scene);
+	reset_mocks();
+
+	/* Now toggle off */
+	scene_toggle_nbody(&scene);
+
+	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	TEST_ASSERT_EQUAL_INT(1, mock_trail_cleanup_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_shockwave_cleanup_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_instanced_cleanup_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_cleanup_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_scene_init_instancing_calls);
+}
+
+void test_toggle_nbody_trail_init_failure_aborts(void)
+{
+	Scene scene = make_test_scene();
+	scene.simulation.nbody_mode = 0;
+	mock_trail_init_fail = true;
+
+	scene_toggle_nbody(&scene);
+
+	/* Mode should stay off */
+	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	/* shockwave_init should NOT have been called */
+	TEST_ASSERT_EQUAL_INT(0, mock_shockwave_init_calls);
+}
+
+void test_toggle_nbody_shockwave_init_failure_cleans_trails(void)
+{
+	Scene scene = make_test_scene();
+	scene.simulation.nbody_mode = 0;
+	mock_shockwave_init_fail = true;
+
+	scene_toggle_nbody(&scene);
+
+	/* Mode should stay off */
+	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	/* Trail was inited then cleaned up */
+	TEST_ASSERT_EQUAL_INT(1, mock_trail_init_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_trail_cleanup_calls);
+}
+
+void test_toggle_nbody_roundtrip(void)
+{
+	Scene scene = make_test_scene();
+
+	/* Start off */
+	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+
+	/* Enable */
+	scene_toggle_nbody(&scene);
+	TEST_ASSERT_TRUE(scene.simulation.nbody_mode);
+
+	/* Disable */
+	scene_toggle_nbody(&scene);
+	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+
+	/* Enable again */
+	scene_toggle_nbody(&scene);
+	TEST_ASSERT_TRUE(scene.simulation.nbody_mode);
+}
+
+/* ---- Tests: scene_nbody_update ---- */
+
+void test_nbody_update_noop_when_disabled(void)
+{
+	Scene scene = make_test_scene();
+	scene.simulation.nbody_mode = 0;
+
+	scene_nbody_update(&scene, 1.0F / 60.0F);
+
+	/* Nothing should be called */
+	TEST_ASSERT_EQUAL_INT(0, mock_shockwave_update_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_trail_record_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_instanced_update_calls);
+}
+
+void test_nbody_update_calls_subsystems(void)
+{
+	Scene scene = make_test_scene();
+	scene.simulation.nbody_mode = 0;
+	scene_toggle_nbody(&scene);
+	reset_mocks();
+
+	scene_nbody_update(&scene, 1.0F / 60.0F);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_shockwave_update_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_trail_record_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_instanced_update_calls);
+}
+
+void test_nbody_update_multiple_steps(void)
+{
+	Scene scene = make_test_scene();
+	scene.simulation.nbody_mode = 0;
+	scene_toggle_nbody(&scene);
+	reset_mocks();
+
+	enum { STEP_COUNT = 10 };
+	for (int i = 0; i < STEP_COUNT; i++) {
+		scene_nbody_update(&scene, 1.0F / 60.0F);
+	}
+
+	TEST_ASSERT_EQUAL_INT(STEP_COUNT, mock_shockwave_update_calls);
+	TEST_ASSERT_EQUAL_INT(STEP_COUNT, mock_trail_record_calls);
+	TEST_ASSERT_EQUAL_INT(STEP_COUNT, mock_instanced_update_calls);
+}
+
+/* ---- Main ---- */
+
+int main(void)
+{
+	UNITY_BEGIN();
+	/* scene_toggle_nbody */
+	RUN_TEST(test_toggle_nbody_enables_mode);
+	RUN_TEST(test_toggle_nbody_disables_mode);
+	RUN_TEST(test_toggle_nbody_trail_init_failure_aborts);
+	RUN_TEST(test_toggle_nbody_shockwave_init_failure_cleans_trails);
+	RUN_TEST(test_toggle_nbody_roundtrip);
+	/* scene_nbody_update */
+	RUN_TEST(test_nbody_update_noop_when_disabled);
+	RUN_TEST(test_nbody_update_calls_subsystems);
+	RUN_TEST(test_nbody_update_multiple_steps);
+	return UNITY_END();
+}

--- a/tests/test_scene_render.c
+++ b/tests/test_scene_render.c
@@ -1,0 +1,872 @@
+/**
+ * @file test_scene_render.c
+ * @brief Tests for scene_render.c — rendering pipeline branches.
+ *
+ * Uses standalone mocks (no GPU required). Includes scene_render.c directly
+ * and mocks all GPU/subsystem calls.
+ */
+
+#include "mock_gl_standalone.h"
+
+/* Type-providing headers */
+#include "billboard_rendering.h"
+#include "billboard_sorting.h"
+#include "gpu_profiler.h"
+#include "instanced_rendering.h"
+#include "light_probes.h"
+#include "scene.h"
+#include "scene_uniforms.h"
+#include "shockwave.h"
+#include "skybox.h"
+#include "trail_renderer.h"
+#include "unity.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/* ---- Mock call counters ---- */
+static int mock_shader_use_calls;
+static int mock_shader_set_int_loc_calls;
+static int mock_shader_set_vec3_loc_calls;
+static int mock_shader_set_vec4_loc_calls;
+static int mock_shader_set_mat4_loc_calls;
+static int mock_skybox_render_calls;
+static int mock_probe_sync_calls;
+static int mock_probe_render_debug_calls;
+static int mock_billboard_draw_calls;
+static int mock_billboard_draw_debug_fill_calls;
+static int mock_billboard_draw_debug_quads_calls;
+static int mock_billboard_draw_debug_boxes_calls;
+static int mock_billboard_update_from_buffer_calls;
+static int mock_instanced_draw_calls;
+static int mock_trail_draw_calls;
+static int mock_shockwave_draw_calls;
+static int mock_profiler_start_calls;
+static int mock_profiler_end_calls;
+static int mock_billboard_sort_cpu_calls;
+static int mock_billboard_sort_cpu_radix_calls;
+static int mock_billboard_sort_gpu_calls;
+
+/* ---- Mocks ---- */
+
+void shader_use(Shader* s)
+{
+	(void)s;
+	mock_shader_use_calls++;
+}
+void shader_set_int_loc(GLint loc, int val)
+{
+	(void)loc;
+	(void)val;
+	mock_shader_set_int_loc_calls++;
+}
+void shader_set_vec3_loc(GLint loc, const float* v)
+{
+	(void)loc;
+	(void)v;
+	mock_shader_set_vec3_loc_calls++;
+}
+void shader_set_vec4_loc(GLint loc, const float* v)
+{
+	(void)loc;
+	(void)v;
+	mock_shader_set_vec4_loc_calls++;
+}
+void shader_set_mat4_loc(GLint loc, const float* m)
+{
+	(void)loc;
+	(void)m;
+	mock_shader_set_mat4_loc_calls++;
+}
+
+void skybox_render(Skybox* sb, Shader* shader, GLuint cubemap, GLuint fallback,
+                   const mat4 inv_vp, float lod)
+{
+	(void)sb;
+	(void)shader;
+	(void)cubemap;
+	(void)fallback;
+	(void)inv_vp;
+	(void)lod;
+	mock_skybox_render_calls++;
+}
+
+void light_probe_grid_sync(LightProbeGrid* g)
+{
+	(void)g;
+	mock_probe_sync_calls++;
+}
+void light_probe_grid_render_debug(LightProbeGrid* g, mat4 v, mat4 p)
+{
+	(void)g;
+	(void)v;
+	(void)p;
+	mock_probe_render_debug_calls++;
+}
+
+void billboard_group_draw(BillboardGroup* bg)
+{
+	(void)bg;
+	mock_billboard_draw_calls++;
+}
+void billboard_group_draw_debug_fill(BillboardGroup* bg)
+{
+	(void)bg;
+	mock_billboard_draw_debug_fill_calls++;
+}
+void billboard_group_draw_debug_quads(BillboardGroup* bg)
+{
+	(void)bg;
+	mock_billboard_draw_debug_quads_calls++;
+}
+void billboard_group_draw_debug_boxes(BillboardGroup* bg)
+{
+	(void)bg;
+	mock_billboard_draw_debug_boxes_calls++;
+}
+void billboard_group_update_from_buffer(BillboardGroup* bg, GLuint ssbo,
+                                        int count)
+{
+	(void)bg;
+	(void)ssbo;
+	(void)count;
+	mock_billboard_update_from_buffer_calls++;
+}
+
+void instanced_group_draw(InstancedGroup* ig, size_t index_count)
+{
+	(void)ig;
+	(void)index_count;
+	mock_instanced_draw_calls++;
+}
+
+void trail_renderer_draw(TrailRenderer* tr, mat4 v, mat4 p, vec3 cam)
+{
+	(void)tr;
+	(void)v;
+	(void)p;
+	(void)cam;
+	mock_trail_draw_calls++;
+}
+
+void shockwave_draw(const ShockwaveRenderer* sr, mat4 v, mat4 p, vec3 cam,
+                    float sim_time, int w, int h)
+{
+	(void)sr;
+	(void)v;
+	(void)p;
+	(void)cam;
+	(void)sim_time;
+	(void)w;
+	(void)h;
+	mock_shockwave_draw_calls++;
+}
+
+void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
+                              uint32_t color)
+{
+	(void)profiler;
+	(void)name;
+	(void)color;
+	mock_profiler_start_calls++;
+}
+void gpu_profiler_end_stage(GPUProfiler* profiler)
+{
+	(void)profiler;
+	mock_profiler_end_calls++;
+}
+
+#ifdef USE_TRANSPARENT_BILLBOARDS
+GLuint billboard_sorter_sort_cpu(BillboardSorter* s, const SphereInstance* inst,
+                                 int count, const vec3 cam)
+{
+	(void)s;
+	(void)inst;
+	(void)count;
+	(void)cam;
+	mock_billboard_sort_cpu_calls++;
+	return 42;
+}
+GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* s,
+                                       const SphereInstance* inst, int count,
+                                       const vec3 cam)
+{
+	(void)s;
+	(void)inst;
+	(void)count;
+	(void)cam;
+	mock_billboard_sort_cpu_radix_calls++;
+	return 43;
+}
+GLuint billboard_sorter_sort_gpu(BillboardSorter* s, const SphereInstance* inst,
+                                 int count, const vec3 cam)
+{
+	(void)s;
+	(void)inst;
+	(void)count;
+	(void)cam;
+	mock_billboard_sort_gpu_calls++;
+	return 44;
+}
+#endif
+
+#ifdef USE_SSBO_RENDERING
+void ssbo_group_draw(SSBOGroup* sg, size_t index_count)
+{
+	(void)sg;
+	(void)index_count;
+}
+#endif
+
+/* ---- Include the file under test ---- */
+#include "scene_render.c"
+
+/* ---- Helpers ---- */
+
+static void reset_counters(void)
+{
+	mock_gl_reset_calls();
+	mock_shader_use_calls = 0;
+	mock_shader_set_int_loc_calls = 0;
+	mock_shader_set_vec3_loc_calls = 0;
+	mock_shader_set_vec4_loc_calls = 0;
+	mock_shader_set_mat4_loc_calls = 0;
+	mock_skybox_render_calls = 0;
+	mock_probe_sync_calls = 0;
+	mock_probe_render_debug_calls = 0;
+	mock_billboard_draw_calls = 0;
+	mock_billboard_draw_debug_fill_calls = 0;
+	mock_billboard_draw_debug_quads_calls = 0;
+	mock_billboard_draw_debug_boxes_calls = 0;
+	mock_billboard_update_from_buffer_calls = 0;
+	mock_instanced_draw_calls = 0;
+	mock_trail_draw_calls = 0;
+	mock_shockwave_draw_calls = 0;
+	mock_profiler_start_calls = 0;
+	mock_profiler_end_calls = 0;
+	mock_billboard_sort_cpu_calls = 0;
+	mock_billboard_sort_cpu_radix_calls = 0;
+	mock_billboard_sort_gpu_calls = 0;
+}
+
+static Scene make_scene(void)
+{
+	Scene s;
+	memset(&s, 0, sizeof(s));
+	return s;
+}
+
+/* ======================================================================
+ * aa_mode_to_string
+ * ====================================================================== */
+
+void test_aa_mode_screen_space(void)
+{
+	TEST_ASSERT_EQUAL_STRING("Screen-space",
+	                         aa_mode_to_string(AA_MODE_SCREEN_SPACE));
+}
+
+void test_aa_mode_curvature(void)
+{
+	TEST_ASSERT_EQUAL_STRING("Curvature-based",
+	                         aa_mode_to_string(AA_MODE_CURVATURE));
+}
+
+void test_aa_mode_unknown(void)
+{
+	TEST_ASSERT_EQUAL_STRING("Unknown", aa_mode_to_string((AAMode)99));
+}
+
+/* ======================================================================
+ * scene_update_gpu_buffers
+ * ====================================================================== */
+
+void test_update_gpu_buffers_binds_vao(void)
+{
+	Scene s = make_scene();
+	s.gpu.icosphere_vao = 10;
+	s.gpu.icosphere_vbo = 20;
+	s.gpu.icosphere_nbo = 30;
+	s.gpu.icosphere_ebo = 40;
+	s.geometry.vertices.size = 8;
+	s.geometry.normals.size = 8;
+	s.geometry.indices.size = 12;
+
+	scene_update_gpu_buffers(&s);
+	/* Just verify it doesn't crash — GL calls are stubs */
+	TEST_PASS();
+}
+
+/* ======================================================================
+ * scene_bind_ibl_textures (static — accessible via #include .c)
+ * ====================================================================== */
+
+void test_bind_ibl_textures_caches(void)
+{
+	Scene s = make_scene();
+	s.gpu.irradiance_tex = 100;
+	s.gpu.spec_prefiltered_tex = 200;
+	s.gpu.brdf_lut_tex = 300;
+	s.gpu.dummy_black_tex = 1;
+	memset(s.gpu.bound_ibl_textures, 0, sizeof(s.gpu.bound_ibl_textures));
+
+	scene_bind_ibl_textures(&s);
+
+	TEST_ASSERT_EQUAL_UINT(100, s.gpu.bound_ibl_textures[0]);
+	TEST_ASSERT_EQUAL_UINT(200, s.gpu.bound_ibl_textures[1]);
+	TEST_ASSERT_EQUAL_UINT(300, s.gpu.bound_ibl_textures[2]);
+}
+
+void test_bind_ibl_textures_skips_when_cached(void)
+{
+	Scene s = make_scene();
+	s.gpu.irradiance_tex = 100;
+	s.gpu.spec_prefiltered_tex = 200;
+	s.gpu.brdf_lut_tex = 300;
+	s.gpu.dummy_black_tex = 1;
+	s.gpu.bound_ibl_textures[0] = 100;
+	s.gpu.bound_ibl_textures[1] = 200;
+	s.gpu.bound_ibl_textures[2] = 300;
+
+	reset_counters();
+	scene_bind_ibl_textures(&s);
+
+	/* Cache hit: no glBindTexture calls expected (counter unchanged) */
+	TEST_ASSERT_EQUAL_UINT(100, s.gpu.bound_ibl_textures[0]);
+}
+
+void test_bind_ibl_textures_uses_dummy_when_zero(void)
+{
+	Scene s = make_scene();
+	s.gpu.irradiance_tex = 0;
+	s.gpu.spec_prefiltered_tex = 0;
+	s.gpu.brdf_lut_tex = 0;
+	s.gpu.dummy_black_tex = 5;
+	memset(s.gpu.bound_ibl_textures, 0, sizeof(s.gpu.bound_ibl_textures));
+
+	scene_bind_ibl_textures(&s);
+
+	TEST_ASSERT_EQUAL_UINT(5, s.gpu.bound_ibl_textures[0]);
+	TEST_ASSERT_EQUAL_UINT(5, s.gpu.bound_ibl_textures[1]);
+	TEST_ASSERT_EQUAL_UINT(5, s.gpu.bound_ibl_textures[2]);
+}
+
+/* ======================================================================
+ * scene_bind_probe_textures (static)
+ * ====================================================================== */
+
+void test_bind_probe_textures_updates_cache(void)
+{
+	Scene s = make_scene();
+	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
+		s.lighting.probe_grid.sh_textures[i] = (GLuint)(10 + i);
+		s.gpu.bound_sh_textures[i] = 0;
+	}
+	s.lighting.probe_grid.ssbo = 42;
+	s.gpu.bound_probe_ssbo = 0;
+
+	scene_bind_probe_textures(&s);
+
+	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
+		TEST_ASSERT_EQUAL_UINT((GLuint)(10 + i),
+		                       s.gpu.bound_sh_textures[i]);
+	}
+	TEST_ASSERT_EQUAL_UINT(42, s.gpu.bound_probe_ssbo);
+}
+
+void test_bind_probe_textures_skips_when_cached(void)
+{
+	Scene s = make_scene();
+	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
+		s.lighting.probe_grid.sh_textures[i] = (GLuint)(10 + i);
+		s.gpu.bound_sh_textures[i] = (GLuint)(10 + i);
+	}
+	s.lighting.probe_grid.ssbo = 42;
+	s.gpu.bound_probe_ssbo = 42;
+
+	reset_counters();
+	scene_bind_probe_textures(&s);
+
+	/* Nothing changed */
+	TEST_ASSERT_EQUAL_UINT(42, s.gpu.bound_probe_ssbo);
+}
+
+/* ======================================================================
+ * scene_render — orchestrator branch coverage
+ * ====================================================================== */
+
+void test_render_instanced_no_envmap_no_nbody(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	/* Instanced path (billboard_mode=0), no envmap, no nbody */
+	s.config.billboard_mode = 0;
+	s.config.show_envmap = 0;
+	s.config.wireframe = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(0, mock_skybox_render_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_billboard_draw_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_instanced_draw_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_trail_draw_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_shockwave_draw_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_probe_sync_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_probe_render_debug_calls);
+}
+
+void test_render_instanced_wireframe(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 0;
+	s.config.wireframe = 1;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_instanced_draw_calls);
+}
+
+void test_render_billboard_mode(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 1;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_instanced_draw_calls);
+}
+
+void test_render_nbody_draws_trails_and_shockwave(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 0;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 1;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_trail_draw_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_shockwave_draw_calls);
+}
+
+void test_render_nbody_wireframe_shockwave(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 0;
+	s.config.wireframe = 1;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 1;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_trail_draw_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_shockwave_draw_calls);
+}
+
+void test_render_gi_mode_triggers_probe_sync(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 0;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_3D_TEX;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_probe_sync_calls);
+	/* Verify SH cache was invalidated */
+	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
+		TEST_ASSERT_EQUAL_UINT(0, s.gpu.bound_sh_textures[i]);
+	}
+}
+
+void test_render_show_probe_grid_triggers_sync_and_debug(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 0;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 1;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_probe_sync_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_probe_render_debug_calls);
+}
+
+#ifdef USE_TRANSPARENT_BILLBOARDS
+void test_render_envmap_draws_skybox(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 0;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 1;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_skybox_render_calls);
+}
+
+void test_render_billboard_wireframe_draws_debug(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 1;
+	s.config.wireframe = 1;
+	s.config.pbr_debug_mode = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_debug_fill_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_debug_quads_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_debug_boxes_calls);
+}
+
+void test_render_billboard_sort_cpu(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 1;
+	s.config.sorting_mode = SORTING_MODE_CPU_QSORT;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_sort_cpu_calls);
+}
+
+void test_render_billboard_sort_radix(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 1;
+	s.config.sorting_mode = SORTING_MODE_CPU_RADIX;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_sort_cpu_radix_calls);
+}
+
+void test_render_billboard_sort_gpu(void)
+{
+	Scene s = make_scene();
+	GPUProfiler profiler;
+	memset(&profiler, 0, sizeof(profiler));
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+
+	s.config.billboard_mode = 1;
+	s.config.sorting_mode = SORTING_MODE_GPU_BITONIC;
+	s.config.wireframe = 0;
+	s.config.show_envmap = 0;
+	s.config.gi_mode = GI_MODE_OFF;
+	s.config.show_probe_grid = 0;
+	s.simulation.nbody_mode = 0;
+
+	reset_counters();
+	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_sort_gpu_calls);
+}
+#endif /* USE_TRANSPARENT_BILLBOARDS */
+
+/* ======================================================================
+ * scene_render_billboards (static) — wireframe overlay branches
+ * ====================================================================== */
+
+void test_render_billboards_no_wireframe(void)
+{
+	Scene s = make_scene();
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+	s.config.wireframe = 0;
+	s.config.pbr_debug_mode = 0;
+
+	reset_counters();
+	scene_render_billboards(&s, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_billboard_draw_debug_fill_calls);
+}
+
+void test_render_billboards_wireframe_debug(void)
+{
+	Scene s = make_scene();
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+	s.config.wireframe = 1;
+	s.config.pbr_debug_mode = 0;
+
+	reset_counters();
+	scene_render_billboards(&s, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_debug_fill_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_debug_quads_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_debug_boxes_calls);
+}
+
+void test_render_billboards_wireframe_skips_when_debug_nonzero(void)
+{
+	Scene s = make_scene();
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+	s.config.wireframe = 1;
+	s.config.pbr_debug_mode = 1; /* non-zero => skip wireframe overlay */
+
+	reset_counters();
+	scene_render_billboards(&s, view, proj, cam, prev_vp, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_billboard_draw_calls);
+	TEST_ASSERT_EQUAL_INT(0, mock_billboard_draw_debug_fill_calls);
+}
+
+/* ======================================================================
+ * scene_render_instanced (static)
+ * ====================================================================== */
+
+void test_render_instanced_sets_uniforms(void)
+{
+	Scene s = make_scene();
+	mat4 view, proj, prev_vp;
+	vec3 cam = {1, 2, 3};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+	s.instanced_uniforms.u_specular_aa_enabled = 5;
+	s.instanced_uniforms.u_aa_mode = 6;
+	s.instanced_uniforms.probe_grid_dim = 7;
+
+	reset_counters();
+	scene_render_instanced(&s, view, proj, cam, prev_vp);
+
+	TEST_ASSERT_GREATER_THAN(0, mock_shader_use_calls);
+	TEST_ASSERT_GREATER_THAN(0, mock_shader_set_mat4_loc_calls);
+	TEST_ASSERT_EQUAL_INT(1, mock_instanced_draw_calls);
+}
+
+void test_render_instanced_skips_negative_uniform_locs(void)
+{
+	Scene s = make_scene();
+	mat4 view, proj, prev_vp;
+	vec3 cam = {0};
+	glm_mat4_identity(view);
+	glm_mat4_identity(proj);
+	glm_mat4_identity(prev_vp);
+	s.instanced_uniforms.u_specular_aa_enabled = -1;
+	s.instanced_uniforms.u_aa_mode = -1;
+	s.instanced_uniforms.probe_grid_dim = -1;
+
+	reset_counters();
+	scene_render_instanced(&s, view, proj, cam, prev_vp);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_instanced_draw_calls);
+}
+
+/* ======================================================================
+ * Test runner
+ * ====================================================================== */
+
+void setUp(void)
+{
+	reset_counters();
+}
+void tearDown(void)
+{
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+
+	/* aa_mode_to_string */
+	RUN_TEST(test_aa_mode_screen_space);
+	RUN_TEST(test_aa_mode_curvature);
+	RUN_TEST(test_aa_mode_unknown);
+
+	/* scene_update_gpu_buffers */
+	RUN_TEST(test_update_gpu_buffers_binds_vao);
+
+	/* scene_bind_ibl_textures */
+	RUN_TEST(test_bind_ibl_textures_caches);
+	RUN_TEST(test_bind_ibl_textures_skips_when_cached);
+	RUN_TEST(test_bind_ibl_textures_uses_dummy_when_zero);
+
+	/* scene_bind_probe_textures */
+	RUN_TEST(test_bind_probe_textures_updates_cache);
+	RUN_TEST(test_bind_probe_textures_skips_when_cached);
+
+	/* scene_render — orchestrator */
+	RUN_TEST(test_render_instanced_no_envmap_no_nbody);
+	RUN_TEST(test_render_instanced_wireframe);
+	RUN_TEST(test_render_billboard_mode);
+	RUN_TEST(test_render_nbody_draws_trails_and_shockwave);
+	RUN_TEST(test_render_nbody_wireframe_shockwave);
+	RUN_TEST(test_render_gi_mode_triggers_probe_sync);
+	RUN_TEST(test_render_show_probe_grid_triggers_sync_and_debug);
+
+#ifdef USE_TRANSPARENT_BILLBOARDS
+	RUN_TEST(test_render_envmap_draws_skybox);
+	RUN_TEST(test_render_billboard_wireframe_draws_debug);
+	RUN_TEST(test_render_billboard_sort_cpu);
+	RUN_TEST(test_render_billboard_sort_radix);
+	RUN_TEST(test_render_billboard_sort_gpu);
+#endif
+
+	/* scene_render_billboards (static) */
+	RUN_TEST(test_render_billboards_no_wireframe);
+	RUN_TEST(test_render_billboards_wireframe_debug);
+	RUN_TEST(test_render_billboards_wireframe_skips_when_debug_nonzero);
+
+	/* scene_render_instanced (static) */
+	RUN_TEST(test_render_instanced_sets_uniforms);
+	RUN_TEST(test_render_instanced_skips_negative_uniform_locs);
+
+	return UNITY_END();
+}

--- a/tests/test_shockwave.c
+++ b/tests/test_shockwave.c
@@ -1,0 +1,425 @@
+/**
+ * @file test_shockwave.c
+ * @brief Tests for shockwave.c — emit, update, eviction, init/cleanup.
+ *
+ * Uses standalone mocks (no GPU required). Includes shockwave.c directly
+ * and mocks shader API + GL calls not covered by mock_gl_standalone.
+ */
+
+#include "mock_gl_standalone.h"
+
+/* Type-providing headers */
+#include "shockwave.h"
+#include "unity.h"
+#include <cglm/mat4.h>
+#include <math.h>
+#include <string.h>
+
+/* ---- Mock shader API ---- */
+
+static int mock_shader_load_calls;
+static int mock_shader_destroy_calls;
+static int mock_shader_use_calls;
+static bool mock_shader_load_fail;
+static Shader g_mock_shader;
+
+Shader* shader_load(const char* vertex_path, const char* fragment_path)
+{
+	(void)vertex_path;
+	(void)fragment_path;
+	mock_shader_load_calls++;
+	if (mock_shader_load_fail) {
+		return NULL;
+	}
+	return &g_mock_shader;
+}
+
+void shader_destroy(Shader* shader)
+{
+	(void)shader;
+	mock_shader_destroy_calls++;
+}
+
+void shader_use(Shader* shader)
+{
+	(void)shader;
+	mock_shader_use_calls++;
+}
+
+void shader_set_int(Shader* shader, const char* name, int val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+void shader_set_float(Shader* shader, const char* name, float val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+void shader_set_vec3(Shader* shader, const char* name, const float* val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+void shader_set_mat4(Shader* shader, const char* name, const float* val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+/* ---- Extra GL mocks not in mock_gl_standalone ---- */
+
+void glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint srcLevel,
+                        GLint srcX, GLint srcY, GLint srcZ, GLuint dstName,
+                        GLenum dstTarget, GLint dstLevel, GLint dstX,
+                        GLint dstY, GLint dstZ, GLsizei srcWidth,
+                        GLsizei srcHeight, GLsizei srcDepth)
+{
+	(void)srcName;
+	(void)srcTarget;
+	(void)srcLevel;
+	(void)srcX;
+	(void)srcY;
+	(void)srcZ;
+	(void)dstName;
+	(void)dstTarget;
+	(void)dstLevel;
+	(void)dstX;
+	(void)dstY;
+	(void)dstZ;
+	(void)srcWidth;
+	(void)srcHeight;
+	(void)srcDepth;
+}
+
+void glDepthMask(GLboolean flag)
+{
+	(void)flag;
+}
+
+/* ---- Include source under test ---- */
+#include "shockwave.c"
+
+/* ---- Helpers ---- */
+
+static void reset_mocks(void)
+{
+	mock_gl_reset_calls();
+	mock_shader_load_calls = 0;
+	mock_shader_destroy_calls = 0;
+	mock_shader_use_calls = 0;
+	mock_shader_load_fail = false;
+}
+
+static ShockwaveRenderer make_renderer(void)
+{
+	ShockwaveRenderer r;
+	memset(&r, 0, sizeof(r));
+	return r;
+}
+
+/* ---- Unity ---- */
+
+void setUp(void)
+{
+	reset_mocks();
+}
+
+void tearDown(void)
+{
+}
+
+/* ===========================================================================
+ * Init / Cleanup tests
+ * ===========================================================================*/
+
+void test_init_success(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	bool ok = shockwave_renderer_init(&r);
+
+	TEST_ASSERT_TRUE(ok);
+	TEST_ASSERT_NOT_NULL(r.shader);
+	TEST_ASSERT_EQUAL_INT(1, mock_shader_load_calls);
+	/* VAO/VBO should be allocated */
+	TEST_ASSERT_NOT_EQUAL(0, r.vao);
+	TEST_ASSERT_NOT_EQUAL(0, r.vbo);
+}
+
+void test_init_shader_failure(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	mock_shader_load_fail = true;
+
+	bool ok = shockwave_renderer_init(&r);
+
+	TEST_ASSERT_FALSE(ok);
+	TEST_ASSERT_NULL(r.shader);
+}
+
+void test_cleanup_releases_resources(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	shockwave_renderer_init(&r);
+	reset_mocks();
+
+	shockwave_renderer_cleanup(&r);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_shader_destroy_calls);
+	TEST_ASSERT_EQUAL(0, r.vbo);
+	TEST_ASSERT_EQUAL(0, r.vao);
+	TEST_ASSERT_NULL(r.shader);
+}
+
+void test_cleanup_with_grab_texture(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	shockwave_renderer_init(&r);
+	/* Simulate grab texture allocation */
+	r.grab_tex = 42;
+	reset_mocks();
+
+	shockwave_renderer_cleanup(&r);
+
+	TEST_ASSERT_EQUAL(0, r.grab_tex);
+}
+
+/* ===========================================================================
+ * Emit tests
+ * ===========================================================================*/
+
+void test_emit_below_min_velocity_ignored(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {1.0F, 2.0F, 3.0F};
+	vec3 col = {1.0F, 0.0F, 0.0F};
+
+	shockwave_emit(&r, pos, col, SHOCKWAVE_MIN_VELOCITY * 0.5F, 0.0F);
+
+	TEST_ASSERT_EQUAL_INT(0, r.count);
+}
+
+void test_emit_at_min_velocity_ignored(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {1.0F, 2.0F, 3.0F};
+	vec3 col = {1.0F, 0.0F, 0.0F};
+
+	/* Exactly at threshold — should still be below (< not <=) */
+	shockwave_emit(&r, pos, col, SHOCKWAVE_MIN_VELOCITY - 0.001F, 0.0F);
+
+	TEST_ASSERT_EQUAL_INT(0, r.count);
+}
+
+void test_emit_above_min_velocity_creates_event(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {1.0F, 2.0F, 3.0F};
+	vec3 col = {1.0F, 0.5F, 0.0F};
+
+	shockwave_emit(&r, pos, col, 1.0F, 10.0F);
+
+	TEST_ASSERT_EQUAL_INT(1, r.count);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 1.0F, r.events[0].position[0]);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 2.0F, r.events[0].position[1]);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 3.0F, r.events[0].position[2]);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 10.0F, r.events[0].start_time);
+}
+
+void test_emit_intensity_clamped_to_one(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {0};
+	vec3 col = {0};
+
+	/* Very high velocity → intensity should cap at 1.0 */
+	shockwave_emit(&r, pos, col, 100.0F, 0.0F);
+
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 1.0F, r.events[0].intensity);
+}
+
+void test_emit_fills_buffer(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {0};
+	vec3 col = {1, 1, 1};
+
+	for (int i = 0; i < SHOCKWAVE_MAX_ACTIVE; i++) {
+		pos[0] = (float)i;
+		shockwave_emit(&r, pos, col, 1.0F, (float)i);
+	}
+
+	TEST_ASSERT_EQUAL_INT(SHOCKWAVE_MAX_ACTIVE, r.count);
+}
+
+void test_emit_evicts_oldest_when_full(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {0};
+	vec3 col = {1, 1, 1};
+
+	/* Fill buffer — event 0 has start_time=0.0 (oldest) */
+	for (int i = 0; i < SHOCKWAVE_MAX_ACTIVE; i++) {
+		shockwave_emit(&r, pos, col, 1.0F, (float)i);
+	}
+
+	/* Emit one more — should evict event with start_time=0.0 */
+	vec3 new_pos = {99.0F, 99.0F, 99.0F};
+	shockwave_emit(&r, new_pos, col, 1.0F, 100.0F);
+
+	/* Count stays at max */
+	TEST_ASSERT_EQUAL_INT(SHOCKWAVE_MAX_ACTIVE, r.count);
+
+	/* The event at index 0 should now be the new one */
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 99.0F, r.events[0].position[0]);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 100.0F, r.events[0].start_time);
+}
+
+/* ===========================================================================
+ * Update tests
+ * ===========================================================================*/
+
+void test_update_removes_expired_events(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {0};
+	vec3 col = {1, 1, 1};
+
+	/* Emit at t=0 */
+	shockwave_emit(&r, pos, col, 1.0F, 0.0F);
+	TEST_ASSERT_EQUAL_INT(1, r.count);
+
+	/* Update at t=DURATION+1 → event should be expired */
+	shockwave_update(&r, SHOCKWAVE_DURATION + 1.0F);
+	TEST_ASSERT_EQUAL_INT(0, r.count);
+}
+
+void test_update_keeps_active_events(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {0};
+	vec3 col = {1, 1, 1};
+
+	/* Emit at t=0 */
+	shockwave_emit(&r, pos, col, 1.0F, 0.0F);
+
+	/* Update at t=DURATION/2 → event should still be alive */
+	shockwave_update(&r, SHOCKWAVE_DURATION * 0.5F);
+	TEST_ASSERT_EQUAL_INT(1, r.count);
+}
+
+void test_update_partial_expiry(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	vec3 pos = {0};
+	vec3 col = {1, 1, 1};
+
+	/* Emit 3 events at different times (sim_time will be 4.1s) */
+	shockwave_emit(&r, pos, col, 1.0F, 0.0F); /* age=4.1 >= 3.6 → expired */
+	shockwave_emit(&r, pos, col, 1.0F, 1.0F); /* age=3.1 <  3.6 → alive   */
+	shockwave_emit(&r, pos, col, 1.0F, 2.0F); /* age=2.1 <  3.6 → alive   */
+	TEST_ASSERT_EQUAL_INT(3, r.count);
+
+	/* Update past first event's lifetime */
+	shockwave_update(&r, SHOCKWAVE_DURATION + 0.5F);
+	TEST_ASSERT_EQUAL_INT(2, r.count);
+}
+
+void test_update_empty_renderer_is_noop(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	shockwave_update(&r, 100.0F);
+	TEST_ASSERT_EQUAL_INT(0, r.count);
+}
+
+/* ===========================================================================
+ * Draw tests (mainly early-exit paths)
+ * ===========================================================================*/
+
+void test_draw_noop_when_count_zero(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	shockwave_renderer_init(&r);
+	reset_mocks();
+
+	mat4 view = GLM_MAT4_IDENTITY_INIT;
+	mat4 proj = GLM_MAT4_IDENTITY_INIT;
+	vec3 cam = {0, 0, 5};
+
+	shockwave_draw(&r, view, proj, cam, 0.0F, 800, 600);
+
+	/* Should not use shader */
+	TEST_ASSERT_EQUAL_INT(0, mock_shader_use_calls);
+
+	shockwave_renderer_cleanup(&r);
+}
+
+void test_draw_noop_when_no_shader(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	r.count = 1; /* has events but no shader */
+
+	mat4 view = GLM_MAT4_IDENTITY_INIT;
+	mat4 proj = GLM_MAT4_IDENTITY_INIT;
+	vec3 cam = {0, 0, 5};
+
+	shockwave_draw(&r, view, proj, cam, 0.0F, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(0, mock_shader_use_calls);
+}
+
+void test_draw_with_events_uses_shader(void)
+{
+	ShockwaveRenderer r = make_renderer();
+	shockwave_renderer_init(&r);
+	vec3 pos = {0};
+	vec3 col = {1, 0, 0};
+	shockwave_emit(&r, pos, col, 1.0F, 0.0F);
+	reset_mocks();
+
+	mat4 view = GLM_MAT4_IDENTITY_INIT;
+	mat4 proj = GLM_MAT4_IDENTITY_INIT;
+	vec3 cam = {0, 0, 5};
+
+	shockwave_draw(&r, view, proj, cam, 0.5F, 800, 600);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_shader_use_calls);
+
+	shockwave_renderer_cleanup(&r);
+}
+
+/* ---- Main ---- */
+
+int main(void)
+{
+	UNITY_BEGIN();
+	/* Init/Cleanup */
+	RUN_TEST(test_init_success);
+	RUN_TEST(test_init_shader_failure);
+	RUN_TEST(test_cleanup_releases_resources);
+	RUN_TEST(test_cleanup_with_grab_texture);
+	/* Emit */
+	RUN_TEST(test_emit_below_min_velocity_ignored);
+	RUN_TEST(test_emit_at_min_velocity_ignored);
+	RUN_TEST(test_emit_above_min_velocity_creates_event);
+	RUN_TEST(test_emit_intensity_clamped_to_one);
+	RUN_TEST(test_emit_fills_buffer);
+	RUN_TEST(test_emit_evicts_oldest_when_full);
+	/* Update */
+	RUN_TEST(test_update_removes_expired_events);
+	RUN_TEST(test_update_keeps_active_events);
+	RUN_TEST(test_update_partial_expiry);
+	RUN_TEST(test_update_empty_renderer_is_noop);
+	/* Draw early-exit */
+	RUN_TEST(test_draw_noop_when_count_zero);
+	RUN_TEST(test_draw_noop_when_no_shader);
+	RUN_TEST(test_draw_with_events_uses_shader);
+	return UNITY_END();
+}

--- a/tests/test_shockwave.c
+++ b/tests/test_shockwave.c
@@ -99,11 +99,6 @@ void glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint srcLevel,
 	(void)srcDepth;
 }
 
-void glDepthMask(GLboolean flag)
-{
-	(void)flag;
-}
-
 /* ---- Include source under test ---- */
 #include "shockwave.c"
 

--- a/tests/test_trail_renderer.c
+++ b/tests/test_trail_renderer.c
@@ -1,0 +1,453 @@
+/**
+ * @file test_trail_renderer.c
+ * @brief Tests for trail_renderer.c — ring buffer, record, duration,
+ * init/cleanup.
+ *
+ * Uses standalone mocks (no GPU required). Includes trail_renderer.c directly
+ * and mocks shader API + GL calls not covered by mock_gl_standalone.
+ */
+
+#include "mock_gl_standalone.h"
+
+/* Type-providing headers */
+#include "trail_renderer.h"
+#include "unity.h"
+#include <math.h>
+#include <string.h>
+
+/* ---- Mock shader API ---- */
+
+static int mock_shader_load_calls;
+static int mock_shader_destroy_calls;
+static int mock_shader_use_calls;
+static bool mock_shader_load_fail;
+static Shader g_mock_shader;
+
+Shader* shader_load(const char* vertex_path, const char* fragment_path)
+{
+	(void)vertex_path;
+	(void)fragment_path;
+	mock_shader_load_calls++;
+	if (mock_shader_load_fail) {
+		return NULL;
+	}
+	return &g_mock_shader;
+}
+
+void shader_destroy(Shader* shader)
+{
+	(void)shader;
+	mock_shader_destroy_calls++;
+}
+
+void shader_use(Shader* shader)
+{
+	(void)shader;
+	mock_shader_use_calls++;
+}
+
+void shader_set_int(Shader* shader, const char* name, int val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+void shader_set_float(Shader* shader, const char* name, float val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+void shader_set_vec3(Shader* shader, const char* name, const float* val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+void shader_set_mat4(Shader* shader, const char* name, const float* val)
+{
+	(void)shader;
+	(void)name;
+	(void)val;
+}
+
+/* ---- Extra GL mocks not in mock_gl_standalone ---- */
+
+void glDepthMask(GLboolean flag)
+{
+	(void)flag;
+}
+
+void glMultiDrawArrays(GLenum mode, const GLint* first,
+                       const GLsizei* count_arr, GLsizei drawcount)
+{
+	(void)mode;
+	(void)first;
+	(void)count_arr;
+	(void)drawcount;
+}
+
+void glCullFace(GLenum mode2)
+{
+	(void)mode2;
+}
+
+/* ---- Include source under test ---- */
+#include "trail_renderer.c"
+
+/* ---- Helpers ---- */
+
+static void reset_mocks(void)
+{
+	mock_gl_reset_calls();
+	mock_shader_load_calls = 0;
+	mock_shader_destroy_calls = 0;
+	mock_shader_use_calls = 0;
+	mock_shader_load_fail = false;
+}
+
+/* ---- Unity ---- */
+
+void setUp(void)
+{
+	reset_mocks();
+}
+
+void tearDown(void)
+{
+}
+
+/* ===========================================================================
+ * Init / Cleanup
+ * ===========================================================================*/
+
+void test_init_success(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+
+	bool ok = trail_renderer_init(&tr, 4);
+
+	TEST_ASSERT_TRUE(ok);
+	TEST_ASSERT_NOT_NULL(tr.shader);
+	TEST_ASSERT_EQUAL_INT(4, tr.body_count);
+	TEST_ASSERT_NOT_EQUAL(0, tr.vao);
+	TEST_ASSERT_NOT_EQUAL(0, tr.vbo);
+	/* Default neon params */
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, TRAIL_NEON_INTENSITY_DEFAULT,
+	                         tr.neon.intensity);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, TRAIL_NEON_CORE_EXP_DEFAULT,
+	                         tr.neon.core_exp);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, TRAIL_NEON_WIDTH_DEFAULT,
+	                         tr.neon.width);
+	/* Default duration */
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, TRAIL_DURATION_DEFAULT,
+	                         tr.trail_duration);
+
+	trail_renderer_cleanup(&tr);
+}
+
+void test_init_shader_failure(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	mock_shader_load_fail = true;
+
+	bool ok = trail_renderer_init(&tr, 4);
+
+	TEST_ASSERT_FALSE(ok);
+	TEST_ASSERT_NULL(tr.shader);
+}
+
+void test_cleanup_releases_resources(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 2);
+	reset_mocks();
+
+	trail_renderer_cleanup(&tr);
+
+	TEST_ASSERT_EQUAL_INT(1, mock_shader_destroy_calls);
+	TEST_ASSERT_NULL(tr.shader);
+	TEST_ASSERT_EQUAL(0, tr.vbo);
+	TEST_ASSERT_EQUAL(0, tr.vao);
+}
+
+/* ===========================================================================
+ * Set color
+ * ===========================================================================*/
+
+void test_set_color_valid_index(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	vec3 color = {1.0F, 0.5F, 0.2F};
+
+	trail_renderer_set_color(&tr, 0, color);
+
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 1.0F, tr.colors[0][0]);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 0.5F, tr.colors[0][1]);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 0.2F, tr.colors[0][2]);
+}
+
+void test_set_color_out_of_bounds_ignored(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	vec3 color = {1.0F, 1.0F, 1.0F};
+
+	/* Negative index */
+	trail_renderer_set_color(&tr, -1, color);
+	/* Out of bounds */
+	trail_renderer_set_color(&tr, NBODY_MAX_BODIES, color);
+
+	/* Should not crash — colors should remain zero */
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 0.0F, tr.colors[0][0]);
+}
+
+/* ===========================================================================
+ * Clear
+ * ===========================================================================*/
+
+void test_clear_resets_rings(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 2);
+
+	/* Push some data */
+	NBodySim sim;
+	memset(&sim, 0, sizeof(sim));
+	sim.body_count = 2;
+	sim.time_scale = 1.0F;
+
+	trail_renderer_record(&tr, &sim, TRAIL_SAMPLE_INTERVAL);
+
+	trail_renderer_clear(&tr);
+
+	TEST_ASSERT_EQUAL_INT(0, tr.rings[0].count);
+	TEST_ASSERT_EQUAL_INT(0, tr.rings[0].head);
+	TEST_ASSERT_EQUAL_INT(0, tr.rings[1].count);
+	TEST_ASSERT_EQUAL_INT(0, tr.rings[1].head);
+	TEST_ASSERT_FLOAT_WITHIN(0.001F, 0.0F, tr.sample_timer);
+
+	trail_renderer_cleanup(&tr);
+}
+
+/* ===========================================================================
+ * Duration accessors
+ * ===========================================================================*/
+
+void test_get_duration_default(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, TRAIL_DURATION_DEFAULT,
+	                         trail_renderer_get_duration(&tr));
+	trail_renderer_cleanup(&tr);
+}
+
+void test_set_duration_valid(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	trail_renderer_set_duration(&tr, 10.0F);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, 10.0F,
+	                         trail_renderer_get_duration(&tr));
+
+	trail_renderer_cleanup(&tr);
+}
+
+void test_set_duration_clamp_min(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	trail_renderer_set_duration(&tr, 0.01F);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, TRAIL_DURATION_MIN,
+	                         trail_renderer_get_duration(&tr));
+
+	trail_renderer_cleanup(&tr);
+}
+
+void test_set_duration_clamp_max(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	trail_renderer_set_duration(&tr, 999.0F);
+	TEST_ASSERT_FLOAT_WITHIN(0.01F, TRAIL_DURATION_MAX,
+	                         trail_renderer_get_duration(&tr));
+
+	trail_renderer_cleanup(&tr);
+}
+
+/* ===========================================================================
+ * Record
+ * ===========================================================================*/
+
+void test_record_accumulates_sample_timer(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	NBodySim sim;
+	memset(&sim, 0, sizeof(sim));
+	sim.body_count = 1;
+	sim.time_scale = 1.0F;
+
+	/* Record with delta_time less than sample interval → no sample yet */
+	trail_renderer_record(&tr, &sim, TRAIL_SAMPLE_INTERVAL * 0.5F);
+	TEST_ASSERT_EQUAL_INT(0, tr.rings[0].count);
+
+	/* Another half-interval → should now have 1 sample */
+	trail_renderer_record(&tr, &sim, TRAIL_SAMPLE_INTERVAL * 0.5F);
+	TEST_ASSERT_EQUAL_INT(1, tr.rings[0].count);
+
+	trail_renderer_cleanup(&tr);
+}
+
+void test_record_respects_time_scale(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	NBodySim sim;
+	memset(&sim, 0, sizeof(sim));
+	sim.body_count = 1;
+	sim.time_scale = 2.0F; /* Double speed */
+
+	/* delta=interval/2 but time_scale=2 → effective = interval */
+	trail_renderer_record(&tr, &sim, TRAIL_SAMPLE_INTERVAL * 0.5F);
+	TEST_ASSERT_EQUAL_INT(1, tr.rings[0].count);
+
+	trail_renderer_cleanup(&tr);
+}
+
+void test_record_negative_time_scale_uses_abs(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	NBodySim sim;
+	memset(&sim, 0, sizeof(sim));
+	sim.body_count = 1;
+	sim.time_scale = -1.0F; /* Time reversal */
+
+	trail_renderer_record(&tr, &sim, TRAIL_SAMPLE_INTERVAL);
+	TEST_ASSERT_EQUAL_INT(1, tr.rings[0].count);
+
+	trail_renderer_cleanup(&tr);
+}
+
+void test_record_large_dt_produces_multiple_samples(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	NBodySim sim;
+	memset(&sim, 0, sizeof(sim));
+	sim.body_count = 1;
+	sim.time_scale = 1.0F;
+
+	/* Large dt = 3× sample interval → should produce 3 samples */
+	trail_renderer_record(&tr, &sim, TRAIL_SAMPLE_INTERVAL * 3.0F);
+	TEST_ASSERT_EQUAL_INT(3, tr.rings[0].count);
+
+	trail_renderer_cleanup(&tr);
+}
+
+/* ===========================================================================
+ * Ring buffer wrap-around
+ * ===========================================================================*/
+
+void test_ring_wraps_at_max_points(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+
+	NBodySim sim;
+	memset(&sim, 0, sizeof(sim));
+	sim.body_count = 1;
+	sim.time_scale = 1.0F;
+
+	/* Push TRAIL_MAX_POINTS + 10 samples */
+	int total = TRAIL_MAX_POINTS + 10;
+	for (int i = 0; i < total; i++) {
+		trail_renderer_record(&tr, &sim, TRAIL_SAMPLE_INTERVAL);
+	}
+
+	/* Count should cap at TRAIL_MAX_POINTS */
+	TEST_ASSERT_EQUAL_INT(TRAIL_MAX_POINTS, tr.rings[0].count);
+
+	trail_renderer_cleanup(&tr);
+}
+
+/* ===========================================================================
+ * Draw early-exit
+ * ===========================================================================*/
+
+void test_draw_noop_when_no_samples(void)
+{
+	TrailRenderer tr;
+	memset(&tr, 0, sizeof(tr));
+	trail_renderer_init(&tr, 1);
+	reset_mocks();
+
+	mat4 view = GLM_MAT4_IDENTITY_INIT;
+	mat4 proj = GLM_MAT4_IDENTITY_INIT;
+	vec3 cam = {0, 0, 5};
+
+	trail_renderer_draw(&tr, view, proj, cam);
+
+	/* No shader use since no vertices to draw */
+	TEST_ASSERT_EQUAL_INT(0, mock_shader_use_calls);
+
+	trail_renderer_cleanup(&tr);
+}
+
+/* ---- Main ---- */
+
+int main(void)
+{
+	UNITY_BEGIN();
+	/* Init/Cleanup */
+	RUN_TEST(test_init_success);
+	RUN_TEST(test_init_shader_failure);
+	RUN_TEST(test_cleanup_releases_resources);
+	/* Set color */
+	RUN_TEST(test_set_color_valid_index);
+	RUN_TEST(test_set_color_out_of_bounds_ignored);
+	/* Clear */
+	RUN_TEST(test_clear_resets_rings);
+	/* Duration */
+	RUN_TEST(test_get_duration_default);
+	RUN_TEST(test_set_duration_valid);
+	RUN_TEST(test_set_duration_clamp_min);
+	RUN_TEST(test_set_duration_clamp_max);
+	/* Record */
+	RUN_TEST(test_record_accumulates_sample_timer);
+	RUN_TEST(test_record_respects_time_scale);
+	RUN_TEST(test_record_negative_time_scale_uses_abs);
+	RUN_TEST(test_record_large_dt_produces_multiple_samples);
+	/* Ring buffer */
+	RUN_TEST(test_ring_wraps_at_max_points);
+	/* Draw */
+	RUN_TEST(test_draw_noop_when_no_samples);
+	return UNITY_END();
+}

--- a/tests/test_trail_renderer.c
+++ b/tests/test_trail_renderer.c
@@ -76,11 +76,6 @@ void shader_set_mat4(Shader* shader, const char* name, const float* val)
 
 /* ---- Extra GL mocks not in mock_gl_standalone ---- */
 
-void glDepthMask(GLboolean flag)
-{
-	(void)flag;
-}
-
 void glMultiDrawArrays(GLenum mode, const GLint* first,
                        const GLsizei* count_arr, GLsizei drawcount)
 {


### PR DESCRIPTION
## Summary

Close the test coverage gap by adding standalone mocked unit tests for 5 previously untested or under-tested modules. Adds **97 new test cases** across 5 test files.

### New Test Files

| File | Module | Tests | Key Coverage |
|------|--------|-------|-------------|
| `test_scene_nbody.c` | `scene_nbody.c` | 8 | toggle + update logic |
| `test_shockwave.c` | `shockwave.c` | 17 | lifecycle, partial expiry, draw |
| `test_trail_renderer.c` | `trail_renderer.c` | 16 | init, emit, update, draw |
| `test_postprocess_input.c` | `postprocess_input.c` | 30 | all input handlers, presets |
| `test_scene_render.c` | `scene_render.c` | 26 | all 8 functions, IBL, stencil, billboards |

### Mock Infrastructure

- Extended `tests/mocks/glad/glad.h`: added GL_ONE, GL_LINE, GL_STENCIL_TEST, GL_KEEP, GL_REPLACE, GL_ALWAYS, GL_POLYGON_OFFSET_FILL/LINE + 7 function declarations
- Extended `tests/mocks/standalone/mock_gl_standalone.c`: added glDepthMask, glEnablei, glDisablei, glPolygonOffset, glStencilOp, glStencilFunc, glStencilMask stubs
- Extended `tests/mocks/GLFW/glfw3.h`: added missing GLFW key constants
- Deduplicated glDepthMask from test_shockwave.c and test_trail_renderer.c

### Coverage Results

| Metric | Before | After | Target |
|--------|--------|-------|--------|
| Lines (global) | 63.57% | 66.57% | — |
| Functions | 80.77% | **83.06%** | >82% ✅ |
| Branches | 51.30% | **53.63%** | ≥50% ✅ |
| `scene_render.c` lines | 44.51% | **99.37%** | — |
| `shockwave.c` lines | ~75% | **96.18%** | — |
| `postprocess_input.c` lines | ~55% | **74.33%** | — |

### Validation

- Build: clean (0 warnings)
- Tests: 68/68 pass (includes 5 new standalone targets)
- Format + Lint: clean
- Pre-push hooks: all passed

Closes #253