### PR TITLE
docs(architecture): add metrics, dependency graph and Phase 10 updates (#254)

### DIFF
--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -183,3 +183,150 @@ target_sources(app PRIVATE
 ```
 
 Chaque module expose son interface via un en-tête dans `include/` avec le préfixe correspondant (`app_ui.h`, `app_input.h`, etc.).
+
+## Métriques & Santé
+
+> Dernière mise à jour : avril 2026 (Phase 10 — Architecture Deepening V)
+
+### Taille du codebase
+
+| Catégorie | Fichiers | LOC total |
+|-----------|----------:|----------:|
+| Sources (`src/*.c`) | 66 | 20 556 |
+| En-têtes (`include/*.h`) | 87 | 7 839 |
+| Tests (`tests/test_*.c`) | 69 | 12 666 |
+| Shaders (`shaders/`) | 60 | — |
+
+### LOC par module (top 15)
+
+| Module | LOC | Notes |
+|--------|----:|-------|
+| `postprocess.c` | 1 634 | Monolithe historique — découpé en 6 UT (voir Découpage PostProcess) |
+| `app_ui.c` | 1 317 | Rendu UI + données de layout (privatisées) |
+| `app_input.c` | 925 | Dispatch entrées clavier/souris |
+| `ui.c` | 879 | Intégration Dear ImGui |
+| `shader.c` | 870 | Compilation & édition de liens shaders |
+| `light_probes.c` | 752 | Grille de sondes lumineuses |
+| `postprocess_presets.c` | 525 | Définitions de presets |
+| `scene_render.c` | 494 | Appels de rendu de la scène |
+| `postprocess_input.c` | 486 | Contrôles clavier post-process |
+| `nbody.c` | 486 | Simulation N-body (CPU + compute) |
+| `scene_init.c` | 476 | Création des ressources scène |
+| `app.c` | 474 | Orchestrateur (boucle principale) |
+| `billboard_sorting.c` | 472 | Tri en profondeur des billboards |
+| `ibl_coordinator.c` | 443 | Machine d'état IBL |
+| `async_loader.c` | 422 | Chargement HDR asynchrone |
+
+**Règle** : les modules > 500 LOC sont candidats à une décomposition ultérieure.
+
+### Fan-out d'includes des en-têtes
+
+| En-tête | #includes | Statut |
+|---------|----------:|--------|
+| `scene.h` | 14 | Agrégat — attendu |
+| `app.h` | 13 | Réduit de 22 (Phase 3) |
+| `postprocess.h` | 11 | Agrégat — attendu |
+| `app_profiling.h` | 7 | Sous-struct — acceptable |
+| `gpu_profiler.h` | 7 | En-tête de domaine |
+| `utils.h` | 7 | Utilitaires divers |
+| `renderer.h` | 0 | Déclarations anticipées uniquement ✅ |
+
+**Principe** : les en-têtes agrégats (`app.h`, `scene.h`, `postprocess.h`) ont naturellement un fan-out élevé. Les en-têtes de modules feuilles doivent rester ≤ 5.
+
+### Couverture de test (LLVM-Cov, avril 2026)
+
+| Métrique | Valeur | Cible |
+|----------|-------:|------:|
+| Lignes | 66,6 % | ≥ 78 % |
+| Fonctions | 83,1 % | ≥ 85 % |
+| Branches | 53,6 % | ≥ 50 % ✅ |
+
+68 tests passent (unitaires + intégration, CTest).
+
+## Graphe de dépendances include
+
+Dépendances des modules principaux (en-têtes projet uniquement, hors système et vendeur) :
+
+```mermaid
+graph TD
+    classDef aggregate fill:#1a1b26,stroke:#e0af68,color:#e0af68,stroke-width:2
+    classDef substruct fill:#1a1b26,stroke:#7aa2f7,color:#7aa2f7
+    classDef leaf fill:#1a1b26,stroke:#9ece6a,color:#9ece6a
+    classDef effect fill:#1a1b26,stroke:#bb9af7,color:#bb9af7
+
+    APP[app.h]:::aggregate
+    SCENE[scene.h]:::aggregate
+    PP[postprocess.h]:::aggregate
+    REND[renderer.h]:::leaf
+
+    %% Sous-structs App
+    APP_PROF[app_profiling.h]:::substruct
+    APP_INP[app_input_state.h]:::substruct
+    APP_WIN[app_window.h]:::substruct
+    APP_UI[app_ui.h]:::substruct
+
+    %% Sous-structs Scene
+    SC_GPU[scene_gpu_resources.h]:::substruct
+    SC_SH[scene_shaders.h]:::substruct
+    SC_CFG[scene_config.h]:::substruct
+    SC_VIS[scene_visuals.h]:::substruct
+    SC_SIM[scene_simulation.h]:::substruct
+    SC_LIT[scene_lighting.h]:::substruct
+
+    %% Sous-headers PostProcess
+    PP_PAR[pp_params.h]:::substruct
+    PP_GPU[pp_gpu_resources.h]:::substruct
+    PP_SHD[pp_shader_state.h]:::substruct
+    PP_RDB[pp_exposure_readback.h]:::substruct
+
+    %% Effets
+    FX_BL[fx_bloom.h]:::effect
+    FX_DOF[fx_dof.h]:::effect
+    FX_AE[fx_auto_exposure.h]:::effect
+    FX_MB[fx_motion_blur.h]:::effect
+    FX_LUT[fx_lut3d.h]:::effect
+    EC[effect_context.h]:::effect
+
+    %% App → dépendances directes
+    APP --> SCENE
+    APP --> PP
+    APP --> APP_UI
+    APP --> APP_WIN
+
+    %% Sous-structs App (possédées, pas incluses par app.h)
+    APP -.->|"possédée"| APP_PROF
+    APP -.->|"possédée"| APP_INP
+
+    %% Scene → sous-structs
+    SCENE --> SC_GPU
+    SCENE --> SC_SH
+    SCENE --> SC_CFG
+    SCENE --> SC_VIS
+    SCENE --> SC_SIM
+    SCENE --> SC_LIT
+
+    %% PostProcess → sous-headers + effets
+    PP --> PP_PAR
+    PP --> PP_GPU
+    PP --> PP_SHD
+    PP --> PP_RDB
+    PP --> FX_BL
+    PP --> FX_DOF
+    PP --> FX_AE
+    PP --> FX_MB
+    PP --> FX_LUT
+
+    %% Découplage des effets
+    FX_BL -.->|"runtime"| EC
+    FX_DOF -.->|"runtime"| EC
+    FX_AE -.->|"runtime"| EC
+    FX_MB -.->|"runtime"| EC
+    FX_LUT -.->|"runtime"| EC
+
+    %% Renderer utilise uniquement des déclarations anticipées
+    REND -.->|"décl. anticipée"| APP
+    REND -.->|"décl. anticipée"| SCENE
+    REND -.->|"décl. anticipée"| PP
+```
+
+**Légende** : Flèches pleines = dépendance `#include`. Flèches pointillées = déclaration anticipée ou dépendance runtime. Couleurs : 🟡 agrégat, 🔵 sous-struct, 🟢 feuille, 🟣 effet.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,3 +216,150 @@ The `CMakeLists.txt` has been updated to include the new source files. The `app`
 
 - **Compilation**: Parallel compilation is now more effective as changes to UI don't require re-compiling the IBL logic.
 - **Runtime**: Zero overhead, as functions are simply moved into separate translation units. Inlining is still possible for performance-critical functions if they were moved to headers (though not currently required).
+
+## Metrics & Health
+
+> Last updated: April 2026 (Phase 10 — Architecture Deepening V)
+
+### Codebase Size
+
+| Category | Files | Total LOC |
+|----------|------:|----------:|
+| Sources (`src/*.c`) | 66 | 20 556 |
+| Headers (`include/*.h`) | 87 | 7 839 |
+| Tests (`tests/test_*.c`) | 69 | 12 666 |
+| Shaders (`shaders/`) | 60 | — |
+
+### LOC per Module (top 15)
+
+| Module | LOC | Notes |
+|--------|----:|-------|
+| `postprocess.c` | 1 634 | Legacy monolith — split into 6 TUs (see PostProcess TU Split) |
+| `app_ui.c` | 1 317 | UI rendering + layout data (privatized) |
+| `app_input.c` | 925 | Keyboard/mouse input dispatch |
+| `ui.c` | 879 | Dear ImGui integration |
+| `shader.c` | 870 | Shader compilation & linking |
+| `light_probes.c` | 752 | Light probe grid |
+| `postprocess_presets.c` | 525 | Preset definitions |
+| `scene_render.c` | 494 | Scene draw calls |
+| `postprocess_input.c` | 486 | Post-process keyboard controls |
+| `nbody.c` | 486 | N-body simulation (CPU + compute) |
+| `scene_init.c` | 476 | Scene resource creation |
+| `app.c` | 474 | Orchestrator (main loop) |
+| `billboard_sorting.c` | 472 | Billboard depth sort |
+| `ibl_coordinator.c` | 443 | IBL state machine |
+| `async_loader.c` | 422 | Async HDR loading |
+
+**Guideline**: modules > 500 LOC are candidates for further decomposition.
+
+### Header Include Fan-Out
+
+| Header | #includes | Status |
+|--------|----------:|--------|
+| `scene.h` | 14 | Aggregate — expected |
+| `app.h` | 13 | Reduced from 22 (Phase 3) |
+| `postprocess.h` | 11 | Aggregate — expected |
+| `app_profiling.h` | 7 | Sub-struct — acceptable |
+| `gpu_profiler.h` | 7 | Domain header |
+| `utils.h` | 7 | Utility grab-bag |
+| `renderer.h` | 0 | Forward-decl only ✅ |
+
+**Principle**: aggregate headers (`app.h`, `scene.h`, `postprocess.h`) naturally have high fan-out. Leaf module headers should stay ≤ 5.
+
+### Test Coverage (LLVM-Cov, April 2026)
+
+| Metric | Value | Target |
+|--------|------:|-------:|
+| Lines | 66.6% | ≥ 78% |
+| Functions | 83.1% | ≥ 85% |
+| Branches | 53.6% | ≥ 50% ✅ |
+
+68 tests pass (unit + integration, CTest).
+
+## Include-Dependency Graph
+
+Top-level module dependencies (project headers only, excludes system and vendor headers):
+
+```mermaid
+graph TD
+    classDef aggregate fill:#1a1b26,stroke:#e0af68,color:#e0af68,stroke-width:2
+    classDef substruct fill:#1a1b26,stroke:#7aa2f7,color:#7aa2f7
+    classDef leaf fill:#1a1b26,stroke:#9ece6a,color:#9ece6a
+    classDef effect fill:#1a1b26,stroke:#bb9af7,color:#bb9af7
+
+    APP[app.h]:::aggregate
+    SCENE[scene.h]:::aggregate
+    PP[postprocess.h]:::aggregate
+    REND[renderer.h]:::leaf
+
+    %% App sub-structs
+    APP_PROF[app_profiling.h]:::substruct
+    APP_INP[app_input_state.h]:::substruct
+    APP_WIN[app_window.h]:::substruct
+    APP_UI[app_ui.h]:::substruct
+
+    %% Scene sub-structs
+    SC_GPU[scene_gpu_resources.h]:::substruct
+    SC_SH[scene_shaders.h]:::substruct
+    SC_CFG[scene_config.h]:::substruct
+    SC_VIS[scene_visuals.h]:::substruct
+    SC_SIM[scene_simulation.h]:::substruct
+    SC_LIT[scene_lighting.h]:::substruct
+
+    %% PostProcess sub-headers
+    PP_PAR[pp_params.h]:::substruct
+    PP_GPU[pp_gpu_resources.h]:::substruct
+    PP_SHD[pp_shader_state.h]:::substruct
+    PP_RDB[pp_exposure_readback.h]:::substruct
+
+    %% Effects
+    FX_BL[fx_bloom.h]:::effect
+    FX_DOF[fx_dof.h]:::effect
+    FX_AE[fx_auto_exposure.h]:::effect
+    FX_MB[fx_motion_blur.h]:::effect
+    FX_LUT[fx_lut3d.h]:::effect
+    EC[effect_context.h]:::effect
+
+    %% App → direct deps
+    APP --> SCENE
+    APP --> PP
+    APP --> APP_UI
+    APP --> APP_WIN
+
+    %% App sub-structs (owned, not included by app.h)
+    APP -.->|"owned"| APP_PROF
+    APP -.->|"owned"| APP_INP
+
+    %% Scene → sub-structs
+    SCENE --> SC_GPU
+    SCENE --> SC_SH
+    SCENE --> SC_CFG
+    SCENE --> SC_VIS
+    SCENE --> SC_SIM
+    SCENE --> SC_LIT
+
+    %% PostProcess → sub-headers + effects
+    PP --> PP_PAR
+    PP --> PP_GPU
+    PP --> PP_SHD
+    PP --> PP_RDB
+    PP --> FX_BL
+    PP --> FX_DOF
+    PP --> FX_AE
+    PP --> FX_MB
+    PP --> FX_LUT
+
+    %% Effect decoupling
+    FX_BL -.->|"runtime"| EC
+    FX_DOF -.->|"runtime"| EC
+    FX_AE -.->|"runtime"| EC
+    FX_MB -.->|"runtime"| EC
+    FX_LUT -.->|"runtime"| EC
+
+    %% Renderer uses forward-decls only
+    REND -.->|"fwd-decl"| APP
+    REND -.->|"fwd-decl"| SCENE
+    REND -.->|"fwd-decl"| PP
+```
+
+**Legend**: Solid arrows = `#include` dependency. Dashed arrows = forward declaration or runtime-only dependency. Colors: 🟡 aggregate, 🔵 sub-struct, 🟢 leaf, 🟣 effect.


### PR DESCRIPTION
## Summary

Adds quantitative metrics and a visual dependency graph to the architecture documentation.

### Changes

- **Metrics & Health** section in `architecture.md`:
  - Codebase size (66 sources, 87 headers, 69 tests, 60 shaders)
  - LOC per module (top 15, guideline: >500 LOC = decomposition candidate)
  - Header include fan-out table (scene.h: 14, app.h: 13, renderer.h: 0)
  - Test coverage (LLVM-Cov April 2026): 66.6% lines, 83.1% functions, 53.6% branches
- **Mermaid include-dependency graph** for App, Scene, PostProcess, Renderer with sub-struct and effect relationships
- **`architecture.fr.md`** fully synchronized (French translation)
- `mkdocs.yml` unchanged (doc already indexed)

### Acceptance Criteria from #254

- [x] `docs/architecture.md` includes metrics section
- [x] Include-dependency diagram (Mermaid) for App, Scene, PostProcess, Renderer
- [x] `docs/architecture.fr.md` synchronized
- [x] `mkdocs.yml` unchanged (doc already indexed)
- [x] All links valid (no broken refs)

Closes #254