### PR TITLE
refactor(scene): reduce scene.h transitive fan-out (14 → 10 direct includes)

### DIFF
--- a/include/scene.h
+++ b/include/scene.h
@@ -7,11 +7,7 @@
 #include "icosphere.h"
 #include "instanced_rendering.h"
 #include "scene_config.h"
-#include "scene_gpu_resources.h"
 #include "scene_lighting.h"
-#include "scene_shaders.h"
-#include "scene_simulation.h"
-#include "scene_uniforms.h"
 #include "scene_visuals.h"
 #include <cglm/cglm.h>
 
@@ -21,6 +17,9 @@
 
 typedef struct PostProcess PostProcess;
 typedef struct GPUProfiler GPUProfiler;
+typedef struct SceneSimulation SceneSimulation;
+typedef struct SceneShaders SceneShaders;
+typedef struct SceneGPUResources SceneGPUResources;
 
 /**
  * @struct Scene
@@ -43,23 +42,20 @@ typedef struct Scene {
 	int billboard_instance_count; /**< Active billboard count. */
 #endif
 
-	/* --- Domain Sub-Structs --- */
-	SceneVisuals visuals;       /**< Visual effects sub-system. */
-	SceneLighting lighting;     /**< IBL, probes, and materials. */
-	SceneSimulation simulation; /**< N-body simulation sub-system. */
-	SceneGPUResources gpu;      /**< GPU resource handles. */
-	SceneShaders shaders;       /**< Shader pointers. */
-	SceneConfig config;         /**< Render configuration. */
+	/* --- Domain Sub-Structs (opaque, heap-allocated) --- */
+	SceneSimulation* simulation; /**< N-body simulation sub-system. */
+	SceneGPUResources* gpu;      /**< GPU resource handles. */
+	SceneShaders* shaders;       /**< Shader pointers + uniform caches. */
+
+	/* --- Domain Sub-Structs (by-value) --- */
+	SceneVisuals visuals;   /**< Visual effects sub-system. */
+	SceneLighting lighting; /**< IBL, probes, and materials. */
+	SceneConfig config;     /**< Render configuration. */
 
 	/* --- HDR Environment --- */
 	char** hdr_files;      /**< List of found HDR files in assets. */
 	int hdr_count;         /**< Number of available environment maps. */
 	int current_hdr_index; /**< Index of active HDR in file list. */
-
-	/* --- Uniform Caches --- */
-	BillboardUniforms billboard_uniforms; /**< Cached locations. */
-	InstancedUniforms instanced_uniforms; /**< Cached locations. */
-	DebugUniforms debug_uniforms;         /**< Cached locations. */
 
 } Scene;
 

--- a/include/scene_shaders.h
+++ b/include/scene_shaders.h
@@ -3,14 +3,15 @@
 
 /**
  * @file scene_shaders.h
- * @brief Shader pointers extracted from Scene to reduce fan-out.
+ * @brief Shader pointers and uniform caches extracted from Scene.
  */
 
+#include "scene_uniforms.h"
 #include "shader.h"
 
 /**
  * @struct SceneShaders
- * @brief All shader pointers owned by the scene.
+ * @brief All shader pointers and uniform caches owned by the scene.
  */
 typedef struct SceneShaders {
 	Shader* pbr_instanced; /**< Shared PBR shader for opaque geo. */
@@ -21,6 +22,11 @@ typedef struct SceneShaders {
 #ifdef USE_SSBO_RENDERING
 	Shader* pbr_ssbo; /**< Optimized SSBO shader. */
 #endif
+
+	/* --- Uniform Caches --- */
+	BillboardUniforms billboard_uniforms; /**< Cached locations. */
+	InstancedUniforms instanced_uniforms; /**< Cached locations. */
+	DebugUniforms debug_uniforms;         /**< Cached locations. */
 } SceneShaders;
 
 #endif /* SCENE_SHADERS_H */

--- a/src/app.c
+++ b/src/app.c
@@ -13,6 +13,7 @@
 #include "profiler.h"
 #include "renderer.h"
 #include "scene.h"
+#include "scene_gpu_resources.h"
 #include "texture.h"
 #include "tracy_gpu.h"
 #include "window.h"
@@ -121,7 +122,7 @@ int app_init(App* app, int width, int height, const char* title)
 		return 0;
 	}
 	postprocess_set_dummy_textures(&app->postprocess,
-	                               app->scene.gpu.dummy_black_tex);
+	                               app->scene.gpu->dummy_black_tex);
 	postprocess_set_exposure(&app->postprocess,
 	                         app->postprocess.readback.auto_threshold);
 	postprocess_enable(&app->postprocess, POSTFX_FXAA);
@@ -334,14 +335,15 @@ void app_run(App* app)
 
 #ifdef USE_SSBO_RENDERING
 			ssbo_group_bind_mesh(&app->scene.ssbo_group,
-			                     app->scene.gpu.icosphere_vbo,
-			                     app->scene.gpu.icosphere_nbo,
-			                     app->scene.gpu.icosphere_ebo);
+			                     app->scene.gpu->icosphere_vbo,
+			                     app->scene.gpu->icosphere_nbo,
+			                     app->scene.gpu->icosphere_ebo);
 #else
-			instanced_group_bind_mesh(&app->scene.instanced_group,
-			                          app->scene.gpu.icosphere_vbo,
-			                          app->scene.gpu.icosphere_nbo,
-			                          app->scene.gpu.icosphere_ebo);
+			instanced_group_bind_mesh(
+			    &app->scene.instanced_group,
+			    app->scene.gpu->icosphere_vbo,
+			    app->scene.gpu->icosphere_nbo,
+			    app->scene.gpu->icosphere_ebo);
 #endif
 			last_subdiv = app->scene.config.subdivisions;
 			PROFILE_ZONE_END(ico_ctx);
@@ -413,10 +415,10 @@ void app_update(App* app)
 	 * frame as PBO Setup & Map.
 	 */
 	if (app->async_coord.pending_prealloc_w > 0) {
-		app->scene.gpu.recycled_hdr_tex =
+		app->scene.gpu->recycled_hdr_tex =
 		    texture_preallocate_hdr(app->async_coord.pending_prealloc_w,
 		                            app->async_coord.pending_prealloc_h,
-		                            app->scene.gpu.recycled_hdr_tex);
+		                            app->scene.gpu->recycled_hdr_tex);
 		app->async_coord.pending_prealloc_w = 0;
 		app->async_coord.pending_prealloc_h = 0;
 	}
@@ -431,7 +433,7 @@ void app_update(App* app)
 
 	if (app->env_mgr.env_map_loading_step > 0) {
 		env_manager_process_loading_step(
-		    &app->env_mgr, &app->scene.gpu.recycled_hdr_tex,
+		    &app->env_mgr, &app->scene.gpu->recycled_hdr_tex,
 		    &app->scene.lighting.ibl_coord);
 	}
 

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -11,6 +11,7 @@
 #include "postprocess_input.h"
 #include "profiler.h"
 #include "scene.h"
+#include "scene_simulation.h"
 #include "utils.h"
 #include <math.h>
 #include <stb_image_write.h>
@@ -456,7 +457,7 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 	const int ctrl_shift =
 	    (int)((unsigned)GLFW_MOD_SHIFT | (unsigned)GLFW_MOD_CONTROL);
 	if (((unsigned)mods & (unsigned)ctrl_shift) == (unsigned)ctrl_shift) {
-		NBodySim* sim = &ctx->scene->simulation.nbody_sim;
+		NBodySim* sim = &ctx->scene->simulation->nbody_sim;
 		sim->target_time_scale = -sim->target_time_scale;
 		const char* dir =
 		    (sim->target_time_scale < 0.0F) ? "REVERSE" : "FORWARD";
@@ -473,9 +474,9 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 	}
 	scene_toggle_nbody(ctx->scene);
 	LOG_INFO("suckless-ogl.app", "N-Body mode: %s",
-	         ctx->scene->simulation.nbody_mode ? "ON" : "OFF");
+	         ctx->scene->simulation->nbody_mode ? "ON" : "OFF");
 	action_notifier_push(ctx->notifier,
-	                     ctx->scene->simulation.nbody_mode
+	                     ctx->scene->simulation->nbody_mode
 	                         ? "N-Body Gravity: ON"
 	                         : "N-Body Gravity: OFF",
 	                     NOTIF_DUR_LONG);
@@ -484,7 +485,7 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 
 static void handle_sim_speed_input(AppInputContext* ctx, bool speed_up)
 {
-	NBodySim* sim = &ctx->scene->simulation.nbody_sim;
+	NBodySim* sim = &ctx->scene->simulation->nbody_sim;
 	float mag = fabsf(sim->target_time_scale);
 	float sign = (sim->target_time_scale < 0.0F) ? -1.0F : 1.0F;
 	if (speed_up) {
@@ -507,7 +508,7 @@ static void handle_sim_speed_input(AppInputContext* ctx, bool speed_up)
 
 static void handle_gravity_input(AppInputContext* ctx, bool increase)
 {
-	NBodySim* sim = &ctx->scene->simulation.nbody_sim;
+	NBodySim* sim = &ctx->scene->simulation->nbody_sim;
 	if (increase) {
 		if (sim->gravity == 0.0F) {
 			sim->gravity = GRAVITY_MIN_POSITIVE;

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -7,6 +7,7 @@
 #include "glad/glad.h"
 #include "nbody.h"
 #include "postprocess.h"
+#include "scene_simulation.h"
 #include "texture.h"
 #include "ui.h"
 #include "utils.h"
@@ -1178,11 +1179,11 @@ static void draw_exposure_overlay(const App* app, UILayout* layout)
 static void draw_nbody_overlay(const App* app, UILayout* layout)
 {
 	if (app->overlay.text_overlay_mode < 1 ||
-	    !app->scene.simulation.nbody_mode) {
+	    !app->scene.simulation->nbody_mode) {
 		return;
 	}
 
-	const NBodySim* sim = &app->scene.simulation.nbody_sim;
+	const NBodySim* sim = &app->scene.simulation->nbody_sim;
 	char text[NBODY_TEXT_BUFFER_SIZE];
 
 	/* Kinetic energy + time direction */

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -7,6 +7,8 @@
 #include "log.h"
 #include "postprocess.h"
 #include "scene.h"
+#include "scene_gpu_resources.h"
+#include "scene_shaders.h"
 #include "shader.h"
 #include "texture.h"
 #include "utils.h"
@@ -129,10 +131,10 @@ int env_manager_trigger_transition(EnvManager* mgr, AsyncLoader* loader,
 
 static void capture_snapshot(Scene* scene, int width, int height)
 {
-	if (scene->gpu.transition_snapshot_tex == 0) {
-		glGenTextures(1, &scene->gpu.transition_snapshot_tex);
+	if (scene->gpu->transition_snapshot_tex == 0) {
+		glGenTextures(1, &scene->gpu->transition_snapshot_tex);
 	}
-	glBindTexture(GL_TEXTURE_2D, scene->gpu.transition_snapshot_tex);
+	glBindTexture(GL_TEXTURE_2D, scene->gpu->transition_snapshot_tex);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
 	             GL_UNSIGNED_BYTE, NULL);
 	glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width, height);
@@ -149,26 +151,26 @@ static void finalize_ibl_swap(Scene* scene, PostProcess* postproc,
 	postprocess_set_exposure_target(postproc, threshold);
 
 	/* Recycle the old HDR texture instead of deleting it */
-	if (scene->gpu.hdr_texture) {
-		if (scene->gpu.recycled_hdr_tex) {
+	if (scene->gpu->hdr_texture) {
+		if (scene->gpu->recycled_hdr_tex) {
 			/* If we already have one (weird edge case),
 			 * delete the old one */
-			glDeleteTextures(1, &scene->gpu.recycled_hdr_tex);
+			glDeleteTextures(1, &scene->gpu->recycled_hdr_tex);
 		}
-		scene->gpu.recycled_hdr_tex = scene->gpu.hdr_texture;
-		/* scene->gpu.hdr_texture will be overwritten below */
+		scene->gpu->recycled_hdr_tex = scene->gpu->hdr_texture;
+		/* scene->gpu->hdr_texture will be overwritten below */
 	}
 
-	if (scene->gpu.spec_prefiltered_tex) {
-		glDeleteTextures(1, &scene->gpu.spec_prefiltered_tex);
+	if (scene->gpu->spec_prefiltered_tex) {
+		glDeleteTextures(1, &scene->gpu->spec_prefiltered_tex);
 	}
-	if (scene->gpu.irradiance_tex) {
-		glDeleteTextures(1, &scene->gpu.irradiance_tex);
+	if (scene->gpu->irradiance_tex) {
+		glDeleteTextures(1, &scene->gpu->irradiance_tex);
 	}
 
-	scene->gpu.hdr_texture = hdr_tex;
-	scene->gpu.spec_prefiltered_tex = spec_tex;
-	scene->gpu.irradiance_tex = irr_tex;
+	scene->gpu->hdr_texture = hdr_tex;
+	scene->gpu->spec_prefiltered_tex = spec_tex;
+	scene->gpu->irradiance_tex = irr_tex;
 
 	LOG_INFO("suckless-ogl.env", "[Frame %llu] Environment swap finalized.",
 	         (unsigned long long)frame_count);
@@ -290,27 +292,27 @@ void env_manager_render_overlay(const EnvManager* mgr, const Scene* scene)
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glDisable(GL_DEPTH_TEST);
 
-		shader_use(scene->shaders.debug);
-		shader_set_int(scene->shaders.debug, "u_tex", 0);
-		shader_set_float(scene->shaders.debug, "u_alpha",
+		shader_use(scene->shaders->debug);
+		shader_set_int(scene->shaders->debug, "u_tex", 0);
+		shader_set_float(scene->shaders->debug, "u_alpha",
 		                 mgr->transition_alpha);
-		shader_set_int(scene->shaders.debug, "u_bypass_processing", 1);
-		shader_set_float(scene->shaders.debug, "lod", 0.0F);
+		shader_set_int(scene->shaders->debug, "u_bypass_processing", 1);
+		shader_set_float(scene->shaders->debug, "lod", 0.0F);
 
 		glActiveTexture(GL_TEXTURE0);
 		if (mgr->env_transition_mode == ENV_TRANSITION_CROSSFADE &&
-		    scene->gpu.transition_snapshot_tex != 0 &&
+		    scene->gpu->transition_snapshot_tex != 0 &&
 		    mgr->transition_state == TRANSITION_FADE_IN) {
 			/* Crossfade: Bind snapshot texture */
 			glBindTexture(GL_TEXTURE_2D,
-			              scene->gpu.transition_snapshot_tex);
+			              scene->gpu->transition_snapshot_tex);
 		} else {
 			/* Black Screen / Initial Load: Bind dummy black */
 			glBindTexture(GL_TEXTURE_2D,
-			              scene->gpu.dummy_black_tex);
+			              scene->gpu->dummy_black_tex);
 		}
 
-		glBindVertexArray(scene->gpu.quad_vbo);
+		glBindVertexArray(scene->gpu->quad_vbo);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 		glBindVertexArray(0);
 

--- a/src/scene_cleanup.c
+++ b/src/scene_cleanup.c
@@ -6,6 +6,8 @@
 #include "material.h"
 #include "platform/platform_utils.h"
 #include "scene.h"
+#include "scene_gpu_resources.h"
+#include "scene_shaders.h"
 #include "shader.h"
 #include "skybox.h"
 #include <stdlib.h>
@@ -16,56 +18,56 @@
 
 static void scene_cleanup_pbr_shaders(Scene* scene)
 {
-	SHADER_SAFE_DESTROY(scene->shaders.pbr_instanced);
-	SHADER_SAFE_DESTROY(scene->shaders.pbr_billboard);
+	SHADER_SAFE_DESTROY(scene->shaders->pbr_instanced);
+	SHADER_SAFE_DESTROY(scene->shaders->pbr_billboard);
 #ifdef USE_SSBO_RENDERING
-	SHADER_SAFE_DESTROY(scene->shaders.pbr_ssbo);
+	SHADER_SAFE_DESTROY(scene->shaders->pbr_ssbo);
 #endif
-	GL_SAFE_DELETE_PROGRAM(scene->gpu.spmap_program);
-	GL_SAFE_DELETE_PROGRAM(scene->gpu.irmap_program);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu->spmap_program);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu->irmap_program);
 }
 
 static void scene_cleanup_shaders(Scene* scene)
 {
 	scene_cleanup_pbr_shaders(scene);
 
-	SHADER_SAFE_DESTROY(scene->shaders.debug);
-	SHADER_SAFE_DESTROY(scene->shaders.debug_line);
-	SHADER_SAFE_DESTROY(scene->shaders.skybox);
-	GL_SAFE_DELETE_PROGRAM(scene->gpu.lum_pass1_program);
-	GL_SAFE_DELETE_PROGRAM(scene->gpu.lum_pass2_program);
+	SHADER_SAFE_DESTROY(scene->shaders->debug);
+	SHADER_SAFE_DESTROY(scene->shaders->debug_line);
+	SHADER_SAFE_DESTROY(scene->shaders->skybox);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu->lum_pass1_program);
+	GL_SAFE_DELETE_PROGRAM(scene->gpu->lum_pass2_program);
 }
 
 static void scene_cleanup_geometry_buffers(Scene* scene)
 {
-	GL_SAFE_DELETE_VAO(scene->gpu.icosphere_vao);
-	GL_SAFE_DELETE_BUFFER(scene->gpu.icosphere_vbo);
-	GL_SAFE_DELETE_BUFFER(scene->gpu.icosphere_nbo);
-	GL_SAFE_DELETE_BUFFER(scene->gpu.icosphere_ebo);
+	GL_SAFE_DELETE_VAO(scene->gpu->icosphere_vao);
+	GL_SAFE_DELETE_BUFFER(scene->gpu->icosphere_vbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu->icosphere_nbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu->icosphere_ebo);
 }
 
 static void scene_cleanup_buffers(Scene* scene)
 {
 	scene_cleanup_geometry_buffers(scene);
 
-	GL_SAFE_DELETE_VAO(scene->gpu.empty_vao);
-	GL_SAFE_DELETE_BUFFER(scene->gpu.wire_cube_vbo);
-	GL_SAFE_DELETE_BUFFER(scene->gpu.wire_quad_vbo);
-	GL_SAFE_DELETE_BUFFER(scene->gpu.quad_vbo);
-	GL_SAFE_DELETE_BUFFERS(2, scene->gpu.lum_ssbo);
-	GL_SAFE_DELETE_BUFFER(scene->gpu.billboard_ubo);
+	GL_SAFE_DELETE_VAO(scene->gpu->empty_vao);
+	GL_SAFE_DELETE_BUFFER(scene->gpu->wire_cube_vbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu->wire_quad_vbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu->quad_vbo);
+	GL_SAFE_DELETE_BUFFERS(2, scene->gpu->lum_ssbo);
+	GL_SAFE_DELETE_BUFFER(scene->gpu->billboard_ubo);
 }
 
 static void scene_cleanup_textures(Scene* scene)
 {
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.hdr_texture);
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.recycled_hdr_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.brdf_lut_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.spec_prefiltered_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.irradiance_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.dummy_black_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.dummy_white_tex);
-	GL_SAFE_DELETE_TEXTURE(scene->gpu.transition_snapshot_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->hdr_texture);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->recycled_hdr_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->brdf_lut_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->spec_prefiltered_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->irradiance_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->dummy_black_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->dummy_white_tex);
+	GL_SAFE_DELETE_TEXTURE(scene->gpu->transition_snapshot_tex);
 }
 
 static void scene_cleanup_gpu_resources(Scene* scene)
@@ -117,4 +119,12 @@ void scene_cleanup(Scene* scene)
 		scene->hdr_files = NULL;
 		scene->hdr_count = 0;
 	}
+
+	/* Free opaque sub-structs */
+	free(scene->gpu);
+	scene->gpu = NULL;
+	free(scene->shaders);
+	scene->shaders = NULL;
+	free(scene->simulation);
+	scene->simulation = NULL;
 }

--- a/src/scene_init.c
+++ b/src/scene_init.c
@@ -12,7 +12,10 @@
 #include "platform/platform_utils.h"
 #include "render_utils.h"
 #include "scene.h"
+#include "scene_gpu_resources.h"
 #include "scene_internal.h"
+#include "scene_shaders.h"
+#include "scene_simulation.h"
 #include "shader.h"
 #include "utils.h"
 #include <stdlib.h>
@@ -142,12 +145,12 @@ void scene_init_instancing(Scene* scene)
 #endif
 
 	instanced_group_bind_mesh(
-	    &scene->instanced_group, scene->gpu.icosphere_vbo,
-	    scene->gpu.icosphere_nbo, scene->gpu.icosphere_ebo);
+	    &scene->instanced_group, scene->gpu->icosphere_vbo,
+	    scene->gpu->icosphere_nbo, scene->gpu->icosphere_ebo);
 	billboard_group_init(&scene->billboard_group, data, total_count);
-	billboard_group_prepare(&scene->billboard_group, scene->gpu.quad_vbo,
-	                        scene->gpu.wire_quad_vbo,
-	                        scene->gpu.wire_cube_vbo);
+	billboard_group_prepare(&scene->billboard_group, scene->gpu->quad_vbo,
+	                        scene->gpu->wire_quad_vbo,
+	                        scene->gpu->wire_cube_vbo);
 
 	/* Initialize Light Probe Grid with Scene Data */
 	light_probe_grid_set_scene(&scene->lighting.probe_grid, data,
@@ -203,9 +206,9 @@ static void scene_init_ssbo(Scene* scene)
 	}
 
 	ssbo_group_init(&scene->ssbo_group, data, total_count);
-	ssbo_group_bind_mesh(&scene->ssbo_group, scene->gpu.icosphere_vbo,
-	                     scene->gpu.icosphere_nbo,
-	                     scene->gpu.icosphere_ebo);
+	ssbo_group_bind_mesh(&scene->ssbo_group, scene->gpu->icosphere_vbo,
+	                     scene->gpu->icosphere_nbo,
+	                     scene->gpu->icosphere_ebo);
 
 	/* Initialize Light Probe Grid with Scene Data (SSBO Mode) */
 	light_probe_grid_set_scene(&scene->lighting.probe_grid, data,
@@ -234,24 +237,24 @@ static void scene_init_state(Scene* scene)
 	scene->config.sorting_mode = SORTING_MODE_GPU_BITONIC;
 	scene->config.gi_mode = GI_MODE_OFF;
 	scene->config.show_probe_grid = 0;
-	scene->gpu.billboard_ubo_ptr = NULL;
+	scene->gpu->billboard_ubo_ptr = NULL;
 
 	scene->billboard_sorter = (BillboardSorter){0};
 
-	scene->gpu.dummy_black_tex =
+	scene->gpu->dummy_black_tex =
 	    render_utils_create_color_texture(0.0F, 0.0F, 0.0F, 0.0F);
-	scene->gpu.dummy_white_tex =
+	scene->gpu->dummy_white_tex =
 	    render_utils_create_color_texture(1.0F, 1.0F, 1.0F, 1.0F);
 
-	scene->gpu.brdf_lut_tex = build_brdf_lut_map(BRDF_LUT_MAP_SIZE);
-	scene->gpu.hdr_texture = 0;
-	scene->gpu.recycled_hdr_tex = 0;
-	scene->gpu.spec_prefiltered_tex = 0;
-	scene->gpu.irradiance_tex = 0;
-	scene->gpu.transition_snapshot_tex = 0;
+	scene->gpu->brdf_lut_tex = build_brdf_lut_map(BRDF_LUT_MAP_SIZE);
+	scene->gpu->hdr_texture = 0;
+	scene->gpu->recycled_hdr_tex = 0;
+	scene->gpu->spec_prefiltered_tex = 0;
+	scene->gpu->irradiance_tex = 0;
+	scene->gpu->transition_snapshot_tex = 0;
 
 	for (int i = 0; i < IBL_TEXTURE_COUNT; i++) {
-		scene->gpu.bound_ibl_textures[i] = 0;
+		scene->gpu->bound_ibl_textures[i] = 0;
 	}
 
 	scene_scan_hdr_files(scene);
@@ -261,21 +264,21 @@ static void scene_init_state(Scene* scene)
 
 static int scene_init_core_shaders(Scene* scene)
 {
-	scene->shaders.skybox =
+	scene->shaders->skybox =
 	    shader_load("shaders/background.vert", "shaders/background.frag");
-	if (!scene->shaders.skybox) {
+	if (!scene->shaders->skybox) {
 		return 0;
 	}
 
-	scene->shaders.debug =
+	scene->shaders->debug =
 	    shader_load("shaders/debug_tex.vert", "shaders/debug_tex.frag");
-	if (!scene->shaders.debug) {
+	if (!scene->shaders->debug) {
 		return 0;
 	}
 
-	scene->shaders.debug_line =
+	scene->shaders->debug_line =
 	    shader_load("shaders/debug_line.vert", "shaders/debug_line.frag");
-	if (!scene->shaders.debug_line) {
+	if (!scene->shaders->debug_line) {
 		return 0;
 	}
 	return 1;
@@ -283,39 +286,40 @@ static int scene_init_core_shaders(Scene* scene)
 
 static int scene_init_billboard_shader(Scene* scene)
 {
-	scene->shaders.pbr_billboard = shader_load(
+	scene->shaders->pbr_billboard = shader_load(
 	    "shaders/pbr_ibl_billboard.vert", "shaders/pbr_ibl_billboard.frag");
-	if (!scene->shaders.pbr_billboard) {
+	if (!scene->shaders->pbr_billboard) {
 		return 0;
 	}
 
 	/* Create UBO for billboard per-frame uniforms (binding = 1) */
-	glGenBuffers(1, &scene->gpu.billboard_ubo);
-	glBindBuffer(GL_UNIFORM_BUFFER, scene->gpu.billboard_ubo);
+	glGenBuffers(1, &scene->gpu->billboard_ubo);
+	glBindBuffer(GL_UNIFORM_BUFFER, scene->gpu->billboard_ubo);
 	GLbitfield flags = (GLbitfield)GL_MAP_WRITE_BIT |
 	                   (GLbitfield)GL_MAP_PERSISTENT_BIT |
 	                   (GLbitfield)GL_MAP_COHERENT_BIT;
 	glBufferStorage(GL_UNIFORM_BUFFER, sizeof(BillboardUBO), NULL, flags);
-	scene->gpu.billboard_ubo_ptr =
+	scene->gpu->billboard_ubo_ptr =
 	    glMapBufferRange(GL_UNIFORM_BUFFER, 0, sizeof(BillboardUBO), flags);
-	glBindBufferBase(GL_UNIFORM_BUFFER, 1, scene->gpu.billboard_ubo);
+	glBindBufferBase(GL_UNIFORM_BUFFER, 1, scene->gpu->billboard_ubo);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 	/* Set Billboard SH Sampler Indices (units 8-14) */
 	{
-		shader_use(scene->shaders.pbr_billboard);
+		shader_use(scene->shaders->pbr_billboard);
 		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 			enum { MAX_UNIFORM_NAME_LEN = 32 };
 			char name[MAX_UNIFORM_NAME_LEN];
 			(void)safe_snprintf(name, sizeof(name), "u_SHTexture%d",
 			                    i);
-			scene->billboard_uniforms.sh_textures[i] =
+			scene->shaders->billboard_uniforms.sh_textures[i] =
 			    shader_get_uniform_location(
-			        scene->shaders.pbr_billboard, name);
-			if (scene->billboard_uniforms.sh_textures[i] != -1) {
-				glUniform1i(
-				    scene->billboard_uniforms.sh_textures[i],
-				    TEXTURE_UNIT_SH_START + i);
+			        scene->shaders->pbr_billboard, name);
+			if (scene->shaders->billboard_uniforms.sh_textures[i] !=
+			    -1) {
+				glUniform1i(scene->shaders->billboard_uniforms
+				                .sh_textures[i],
+				            TEXTURE_UNIT_SH_START + i);
 			}
 		}
 	}
@@ -324,24 +328,24 @@ static int scene_init_billboard_shader(Scene* scene)
 
 static int scene_init_compute_resources(Scene* scene)
 {
-	scene->gpu.spmap_program =
+	scene->gpu->spmap_program =
 	    shader_load_compute("shaders/IBL/spmap.glsl");
-	scene->gpu.irmap_program =
+	scene->gpu->irmap_program =
 	    shader_load_compute("shaders/IBL/irmap.glsl");
-	scene->gpu.lum_pass1_program =
+	scene->gpu->lum_pass1_program =
 	    shader_load_compute("shaders/IBL/luminance_reduce_pass1.glsl");
-	scene->gpu.lum_pass2_program =
+	scene->gpu->lum_pass2_program =
 	    shader_load_compute("shaders/IBL/luminance_reduce_pass2.glsl");
 
-	if (!scene->gpu.spmap_program || !scene->gpu.irmap_program ||
-	    !scene->gpu.lum_pass1_program || !scene->gpu.lum_pass2_program) {
+	if (!scene->gpu->spmap_program || !scene->gpu->irmap_program ||
+	    !scene->gpu->lum_pass1_program || !scene->gpu->lum_pass2_program) {
 		return 0;
 	}
 
-	ibl_coordinator_init(&scene->lighting.ibl_coord,
-	                     scene->gpu.spmap_program, scene->gpu.irmap_program,
-	                     scene->gpu.lum_pass1_program,
-	                     scene->gpu.lum_pass2_program);
+	ibl_coordinator_init(
+	    &scene->lighting.ibl_coord, scene->gpu->spmap_program,
+	    scene->gpu->irmap_program, scene->gpu->lum_pass1_program,
+	    scene->gpu->lum_pass2_program);
 	return 1;
 }
 
@@ -349,45 +353,45 @@ static int scene_init_instanced_shader(Scene* scene, Shader** out_shader)
 {
 #ifdef USE_SSBO_RENDERING
 	scene_init_ssbo(scene);
-	scene->shaders.pbr_ssbo = shader_load("shaders/pbr_ibl_ssbo.vert",
-	                                      "shaders/pbr_ibl_instanced.frag");
-	if (!scene->shaders.pbr_ssbo) {
+	scene->shaders->pbr_ssbo = shader_load(
+	    "shaders/pbr_ibl_ssbo.vert", "shaders/pbr_ibl_instanced.frag");
+	if (!scene->shaders->pbr_ssbo) {
 		return 0;
 	}
-	*out_shader = scene->shaders.pbr_ssbo;
+	*out_shader = scene->shaders->pbr_ssbo;
 #else
 	scene_init_instancing(scene);
-	scene->shaders.pbr_instanced = shader_load(
+	scene->shaders->pbr_instanced = shader_load(
 	    "shaders/pbr_ibl_instanced.vert", "shaders/pbr_ibl_instanced.frag");
-	if (!scene->shaders.pbr_instanced) {
+	if (!scene->shaders->pbr_instanced) {
 		return 0;
 	}
-	*out_shader = scene->shaders.pbr_instanced;
+	*out_shader = scene->shaders->pbr_instanced;
 #endif
 
-	scene->instanced_uniforms.debug_mode =
+	scene->shaders->instanced_uniforms.debug_mode =
 	    shader_get_uniform_location(*out_shader, "debugMode");
-	scene->instanced_uniforms.cam_pos =
+	scene->shaders->instanced_uniforms.cam_pos =
 	    shader_get_uniform_location(*out_shader, "camPos");
-	scene->instanced_uniforms.projection =
+	scene->shaders->instanced_uniforms.projection =
 	    shader_get_uniform_location(*out_shader, "projection");
-	scene->instanced_uniforms.view =
+	scene->shaders->instanced_uniforms.view =
 	    shader_get_uniform_location(*out_shader, "view");
-	scene->instanced_uniforms.previous_view_proj =
+	scene->shaders->instanced_uniforms.previous_view_proj =
 	    shader_get_uniform_location(*out_shader, "previousViewProj");
-	scene->instanced_uniforms.u_specular_aa_enabled =
+	scene->shaders->instanced_uniforms.u_specular_aa_enabled =
 	    shader_get_uniform_location(*out_shader, "u_specularAAEnabled");
-	scene->instanced_uniforms.u_aa_mode =
+	scene->shaders->instanced_uniforms.u_aa_mode =
 	    shader_get_uniform_location(*out_shader, "u_aaMode");
 
 	/* Probe Grid Uniforms */
-	scene->instanced_uniforms.probe_grid_min =
+	scene->shaders->instanced_uniforms.probe_grid_min =
 	    shader_get_uniform_location(*out_shader, "u_ProbeGridMin");
-	scene->instanced_uniforms.probe_grid_max =
+	scene->shaders->instanced_uniforms.probe_grid_max =
 	    shader_get_uniform_location(*out_shader, "u_ProbeGridMax");
-	scene->instanced_uniforms.probe_grid_dim =
+	scene->shaders->instanced_uniforms.probe_grid_dim =
 	    shader_get_uniform_location(*out_shader, "u_ProbeGridDim");
-	scene->instanced_uniforms.gi_mode =
+	scene->shaders->instanced_uniforms.gi_mode =
 	    shader_get_uniform_location(*out_shader, "u_GIMode");
 
 	/* Set Instanced SH Sampler Indices (units 8-14) */
@@ -398,12 +402,13 @@ static int scene_init_instanced_shader(Scene* scene, Shader** out_shader)
 			char name[MAX_UNIFORM_NAME_LEN];
 			(void)safe_snprintf(name, sizeof(name), "u_SHTexture%d",
 			                    i);
-			scene->instanced_uniforms.sh_textures[i] =
+			scene->shaders->instanced_uniforms.sh_textures[i] =
 			    shader_get_uniform_location(*out_shader, name);
-			if (scene->instanced_uniforms.sh_textures[i] != -1) {
-				glUniform1i(
-				    scene->instanced_uniforms.sh_textures[i],
-				    TEXTURE_UNIT_SH_START + i);
+			if (scene->shaders->instanced_uniforms.sh_textures[i] !=
+			    -1) {
+				glUniform1i(scene->shaders->instanced_uniforms
+				                .sh_textures[i],
+				            TEXTURE_UNIT_SH_START + i);
 			}
 		}
 	}
@@ -412,28 +417,37 @@ static int scene_init_instanced_shader(Scene* scene, Shader** out_shader)
 
 int scene_init(Scene* scene)
 {
+	/* Allocate opaque sub-structs */
+	scene->gpu = calloc(1, sizeof(SceneGPUResources));
+	scene->shaders = calloc(1, sizeof(SceneShaders));
+	scene->simulation = calloc(1, sizeof(SceneSimulation));
+	if (!scene->gpu || !scene->shaders || !scene->simulation) {
+		LOG_ERROR("Scene", "Failed to allocate scene sub-structs");
+		return 0;
+	}
+
 	scene_init_state(scene);
 
 	if (!scene_init_core_shaders(scene)) {
 		return 0;
 	}
 
-	render_utils_create_empty_vao(&scene->gpu.empty_vao);
+	render_utils_create_empty_vao(&scene->gpu->empty_vao);
 
 	if (!scene_init_billboard_shader(scene)) {
 		return 0;
 	}
 
-	render_utils_create_quad_vbo(&scene->gpu.quad_vbo);
-	render_utils_create_wire_cube_vbo(&scene->gpu.wire_cube_vbo);
-	render_utils_create_wire_quad_vbo(&scene->gpu.wire_quad_vbo);
-	skybox_init(&scene->visuals.skybox, scene->shaders.skybox);
+	render_utils_create_quad_vbo(&scene->gpu->quad_vbo);
+	render_utils_create_wire_cube_vbo(&scene->gpu->wire_cube_vbo);
+	render_utils_create_wire_quad_vbo(&scene->gpu->wire_quad_vbo);
+	skybox_init(&scene->visuals.skybox, scene->shaders->skybox);
 	icosphere_init(&scene->geometry);
 
-	glGenVertexArrays(1, &scene->gpu.icosphere_vao);
-	glGenBuffers(1, &scene->gpu.icosphere_vbo);
-	glGenBuffers(1, &scene->gpu.icosphere_nbo);
-	glGenBuffers(1, &scene->gpu.icosphere_ebo);
+	glGenVertexArrays(1, &scene->gpu->icosphere_vao);
+	glGenBuffers(1, &scene->gpu->icosphere_vbo);
+	glGenBuffers(1, &scene->gpu->icosphere_nbo);
+	glGenBuffers(1, &scene->gpu->icosphere_ebo);
 
 	scene->lighting.material_lib =
 	    material_load_presets("assets/materials/pbr_materials.json");
@@ -459,18 +473,20 @@ int scene_init(Scene* scene)
 		return 0;
 	}
 
-	scene->debug_uniforms.projection = shader_get_uniform_location(
-	    scene->shaders.debug_line, "projection");
-	scene->debug_uniforms.view =
-	    shader_get_uniform_location(scene->shaders.debug_line, "view");
-	scene->debug_uniforms.u_stippled = shader_get_uniform_location(
-	    scene->shaders.debug_line, "u_stippled");
-	scene->debug_uniforms.u_billboard_mode = shader_get_uniform_location(
-	    scene->shaders.debug_line, "u_billboardMode");
-	scene->debug_uniforms.u_use_instance_col = shader_get_uniform_location(
-	    scene->shaders.debug_line, "u_useInstanceColor");
-	scene->debug_uniforms.u_color =
-	    shader_get_uniform_location(scene->shaders.debug_line, "u_color");
+	scene->shaders->debug_uniforms.projection = shader_get_uniform_location(
+	    scene->shaders->debug_line, "projection");
+	scene->shaders->debug_uniforms.view =
+	    shader_get_uniform_location(scene->shaders->debug_line, "view");
+	scene->shaders->debug_uniforms.u_stippled = shader_get_uniform_location(
+	    scene->shaders->debug_line, "u_stippled");
+	scene->shaders->debug_uniforms.u_billboard_mode =
+	    shader_get_uniform_location(scene->shaders->debug_line,
+	                                "u_billboardMode");
+	scene->shaders->debug_uniforms.u_use_instance_col =
+	    shader_get_uniform_location(scene->shaders->debug_line,
+	                                "u_useInstanceColor");
+	scene->shaders->debug_uniforms.u_color =
+	    shader_get_uniform_location(scene->shaders->debug_line, "u_color");
 
 	return 1;
 }

--- a/src/scene_nbody.c
+++ b/src/scene_nbody.c
@@ -7,29 +7,30 @@
 #include "profiler.h"
 #include "scene.h"
 #include "scene_internal.h"
+#include "scene_simulation.h"
 #include "shockwave.h"
 #include "trail_renderer.h"
 #include "utils.h"
 
 void scene_toggle_nbody(Scene* scene)
 {
-	scene->simulation.nbody_mode = !scene->simulation.nbody_mode;
+	scene->simulation->nbody_mode = !scene->simulation->nbody_mode;
 
-	if (scene->simulation.nbody_mode) {
+	if (scene->simulation->nbody_mode) {
 		/* Initialize simulation and trails */
-		nbody_init_preset(&scene->simulation.nbody_sim);
+		nbody_init_preset(&scene->simulation->nbody_sim);
 
-		int count = nbody_get_count(&scene->simulation.nbody_sim);
+		int count = nbody_get_count(&scene->simulation->nbody_sim);
 		if (!trail_renderer_init(&scene->visuals.trail_renderer,
 		                         count)) {
-			scene->simulation.nbody_mode = 0;
+			scene->simulation->nbody_mode = 0;
 			return;
 		}
 
 		if (!shockwave_renderer_init(
 		        &scene->visuals.shockwave_renderer)) {
 			trail_renderer_cleanup(&scene->visuals.trail_renderer);
-			scene->simulation.nbody_mode = 0;
+			scene->simulation->nbody_mode = 0;
 			return;
 		}
 
@@ -37,12 +38,12 @@ void scene_toggle_nbody(Scene* scene)
 		for (int i = 0; i < count; i++) {
 			trail_renderer_set_color(
 			    &scene->visuals.trail_renderer, i,
-			    scene->simulation.nbody_sim.bodies[i].albedo);
+			    scene->simulation->nbody_sim.bodies[i].albedo);
 		}
 
 		/* Write initial SphereInstance data and upload to GPU */
 		SphereInstance instances[NBODY_MAX_BODIES];
-		nbody_write_instances(&scene->simulation.nbody_sim, instances);
+		nbody_write_instances(&scene->simulation->nbody_sim, instances);
 		instanced_group_update(&scene->instanced_group, instances,
 		                       count);
 
@@ -76,47 +77,48 @@ void scene_toggle_nbody(Scene* scene)
 
 void scene_nbody_update(Scene* scene, float delta_time)
 {
-	if (!scene->simulation.nbody_mode) {
+	if (!scene->simulation->nbody_mode) {
 		return;
 	}
 
 	/* Smooth time-scale transition (decelerate → pause → reverse) */
-	nbody_update_time_scale(&scene->simulation.nbody_sim, delta_time);
+	nbody_update_time_scale(&scene->simulation->nbody_sim, delta_time);
 
 	/* Advance physics (Velocity Verlet, O(N²) gravity) */
 	{
 		PROFILE_ZONE(verlet_ctx, "NBody Verlet");
-		nbody_step(&scene->simulation.nbody_sim, delta_time);
+		nbody_step(&scene->simulation->nbody_sim, delta_time);
 		PROFILE_ZONE_END(verlet_ctx);
 	}
 
 	/* Forward confinement impacts to shockwave VFX */
-	for (int i = 1; i < scene->simulation.nbody_sim.body_count; i++) {
+	for (int i = 1; i < scene->simulation->nbody_sim.body_count; i++) {
 		const NBodyImpact* imp =
-		    &scene->simulation.nbody_sim.impacts[i];
+		    &scene->simulation->nbody_sim.impacts[i];
 		if (imp->active) {
 			shockwave_emit(&scene->visuals.shockwave_renderer,
 			               imp->position, imp->color, imp->velocity,
-			               scene->simulation.nbody_sim.sim_time);
+			               scene->simulation->nbody_sim.sim_time);
 		}
 	}
 	shockwave_update(&scene->visuals.shockwave_renderer,
-	                 scene->simulation.nbody_sim.sim_time);
+	                 scene->simulation->nbody_sim.sim_time);
 
 	/* Record trail positions into ring buffers */
 	{
 		PROFILE_ZONE(trail_ctx, "NBody Trail Sample");
 		trail_renderer_record(&scene->visuals.trail_renderer,
-		                      &scene->simulation.nbody_sim, delta_time);
+		                      &scene->simulation->nbody_sim,
+		                      delta_time);
 		PROFILE_ZONE_END(trail_ctx);
 	}
 
 	/* Build SphereInstance data and upload to GPU */
-	int count = nbody_get_count(&scene->simulation.nbody_sim);
+	int count = nbody_get_count(&scene->simulation->nbody_sim);
 	SphereInstance instances[NBODY_MAX_BODIES];
 	{
 		PROFILE_ZONE(inst_ctx, "NBody Instance Build");
-		nbody_write_instances(&scene->simulation.nbody_sim, instances);
+		nbody_write_instances(&scene->simulation->nbody_sim, instances);
 		PROFILE_ZONE_END(inst_ctx);
 	}
 	{

--- a/src/scene_render.c
+++ b/src/scene_render.c
@@ -7,6 +7,9 @@
 #include "light_probes.h"
 #include "profiler.h"
 #include "scene.h"
+#include "scene_gpu_resources.h"
+#include "scene_shaders.h"
+#include "scene_simulation.h"
 #include "shader.h"
 #include "shockwave.h"
 #include "skybox.h"
@@ -31,20 +34,20 @@ const char* aa_mode_to_string(AAMode mode)
 
 void scene_update_gpu_buffers(Scene* scene)
 {
-	glBindVertexArray(scene->gpu.icosphere_vao);
-	glBindBuffer(GL_ARRAY_BUFFER, scene->gpu.icosphere_vbo);
+	glBindVertexArray(scene->gpu->icosphere_vao);
+	glBindBuffer(GL_ARRAY_BUFFER, scene->gpu->icosphere_vbo);
 	glBufferData(GL_ARRAY_BUFFER,
 	             (GLsizeiptr)(scene->geometry.vertices.size * sizeof(vec3)),
 	             scene->geometry.vertices.data, GL_STATIC_DRAW);
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(vec3), (void*)0);
 	glEnableVertexAttribArray(0);
-	glBindBuffer(GL_ARRAY_BUFFER, scene->gpu.icosphere_nbo);
+	glBindBuffer(GL_ARRAY_BUFFER, scene->gpu->icosphere_nbo);
 	glBufferData(GL_ARRAY_BUFFER,
 	             (GLsizeiptr)(scene->geometry.normals.size * sizeof(vec3)),
 	             scene->geometry.normals.data, GL_STATIC_DRAW);
 	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(vec3), (void*)0);
 	glEnableVertexAttribArray(1);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, scene->gpu.icosphere_ebo);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, scene->gpu->icosphere_ebo);
 	glBufferData(
 	    GL_ELEMENT_ARRAY_BUFFER,
 	    (GLsizeiptr)(scene->geometry.indices.size * sizeof(unsigned int)),
@@ -62,37 +65,37 @@ static void scene_bind_probe_textures(Scene* scene)
 {
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 		GLuint tex = scene->lighting.probe_grid.sh_textures[i];
-		if (tex != scene->gpu.bound_sh_textures[i]) {
+		if (tex != scene->gpu->bound_sh_textures[i]) {
 			glActiveTexture(
 			    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_SH_START + i));
 			glBindTexture(GL_TEXTURE_3D, tex);
-			scene->gpu.bound_sh_textures[i] = tex;
+			scene->gpu->bound_sh_textures[i] = tex;
 		}
 	}
 
-	if (scene->lighting.probe_grid.ssbo != scene->gpu.bound_probe_ssbo) {
+	if (scene->lighting.probe_grid.ssbo != scene->gpu->bound_probe_ssbo) {
 		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3,
 		                 scene->lighting.probe_grid.ssbo);
-		scene->gpu.bound_probe_ssbo = scene->lighting.probe_grid.ssbo;
+		scene->gpu->bound_probe_ssbo = scene->lighting.probe_grid.ssbo;
 	}
 }
 
 static void scene_bind_ibl_textures(Scene* scene)
 {
 	GLuint textures[IBL_TEXTURE_COUNT] = {
-	    scene->gpu.irradiance_tex ? scene->gpu.irradiance_tex
-	                              : scene->gpu.dummy_black_tex,
-	    scene->gpu.spec_prefiltered_tex ? scene->gpu.spec_prefiltered_tex
-	                                    : scene->gpu.dummy_black_tex,
-	    scene->gpu.brdf_lut_tex ? scene->gpu.brdf_lut_tex
-	                            : scene->gpu.dummy_black_tex};
+	    scene->gpu->irradiance_tex ? scene->gpu->irradiance_tex
+	                               : scene->gpu->dummy_black_tex,
+	    scene->gpu->spec_prefiltered_tex ? scene->gpu->spec_prefiltered_tex
+	                                     : scene->gpu->dummy_black_tex,
+	    scene->gpu->brdf_lut_tex ? scene->gpu->brdf_lut_tex
+	                             : scene->gpu->dummy_black_tex};
 
 	for (int i = 0; i < IBL_TEXTURE_COUNT; i++) {
-		if (textures[i] != scene->gpu.bound_ibl_textures[i]) {
+		if (textures[i] != scene->gpu->bound_ibl_textures[i]) {
 			glActiveTexture(
 			    (GLenum)(GL_TEXTURE0 + TEXTURE_UNIT_IBL_START + i));
 			glBindTexture(GL_TEXTURE_2D, textures[i]);
-			scene->gpu.bound_ibl_textures[i] = textures[i];
+			scene->gpu->bound_ibl_textures[i] = textures[i];
 		}
 	}
 }
@@ -101,7 +104,7 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
                                     vec3 camera_pos, mat4 previous_view_proj,
                                     int width, int height)
 {
-	Shader* current_shader = scene->shaders.pbr_billboard;
+	Shader* current_shader = scene->shaders->pbr_billboard;
 	shader_use(current_shader);
 
 	scene_bind_ibl_textures(scene);
@@ -128,8 +131,8 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		ubo.probe_grid_dim[2] = scene->lighting.probe_grid.grid_dim[2];
 		ubo.aa_mode = scene->config.aa_mode;
 
-		if (scene->gpu.billboard_ubo_ptr) {
-			*(BillboardUBO*)scene->gpu.billboard_ubo_ptr = ubo;
+		if (scene->gpu->billboard_ubo_ptr) {
+			*(BillboardUBO*)scene->gpu->billboard_ubo_ptr = ubo;
 		}
 	}
 
@@ -150,10 +153,11 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		glEnable(GL_DEPTH_TEST);
 		glDepthMask(GL_FALSE);
 
-		shader_use(scene->shaders.debug_line);
-		shader_set_mat4_loc(scene->debug_uniforms.projection,
+		shader_use(scene->shaders->debug_line);
+		shader_set_mat4_loc(scene->shaders->debug_uniforms.projection,
 		                    (float*)proj);
-		shader_set_mat4_loc(scene->debug_uniforms.view, (float*)view);
+		shader_set_mat4_loc(scene->shaders->debug_uniforms.view,
+		                    (float*)view);
 
 		/* 0. Transparent Fill (Instance Albedo) */
 		/* Push fill back to avoid z-fighting with outlines */
@@ -164,12 +168,16 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		/* Disable stipple, Enable Billboard Mode, Enable Instance Color
 		 */
-		shader_set_int_loc(scene->debug_uniforms.u_stippled, 0);
-		shader_set_int_loc(scene->debug_uniforms.u_billboard_mode, 1);
-		shader_set_int_loc(scene->debug_uniforms.u_use_instance_col, 1);
+		shader_set_int_loc(scene->shaders->debug_uniforms.u_stippled,
+		                   0);
+		shader_set_int_loc(
+		    scene->shaders->debug_uniforms.u_billboard_mode, 1);
+		shader_set_int_loc(
+		    scene->shaders->debug_uniforms.u_use_instance_col, 1);
 		/* Alpha 0.10 for transparency */
 		float color_fill[4] = {1.0F, 1.0F, 1.0F, debug_fill_alpha};
-		shader_set_vec4_loc(scene->debug_uniforms.u_color, color_fill);
+		shader_set_vec4_loc(scene->shaders->debug_uniforms.u_color,
+		                    color_fill);
 		billboard_group_draw_debug_fill(&scene->billboard_group);
 		glDisable(GL_BLEND);
 		glDisable(GL_POLYGON_OFFSET_FILL);
@@ -181,19 +189,26 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 
 		/* Disable stipple, Enable Billboard Mode, Disable Instance
 		 * Color */
-		shader_set_int_loc(scene->debug_uniforms.u_stippled, 0);
-		shader_set_int_loc(scene->debug_uniforms.u_billboard_mode, 1);
-		shader_set_int_loc(scene->debug_uniforms.u_use_instance_col, 0);
+		shader_set_int_loc(scene->shaders->debug_uniforms.u_stippled,
+		                   0);
+		shader_set_int_loc(
+		    scene->shaders->debug_uniforms.u_billboard_mode, 1);
+		shader_set_int_loc(
+		    scene->shaders->debug_uniforms.u_use_instance_col, 0);
 		float color_quad[4] = {0.0F, 1.0F, 0.0F, 1.0F};
-		shader_set_vec4_loc(scene->debug_uniforms.u_color, color_quad);
+		shader_set_vec4_loc(scene->shaders->debug_uniforms.u_color,
+		                    color_quad);
 		billboard_group_draw_debug_quads(&scene->billboard_group);
 
 		/* 2. Bounding Box (Dotted/Stippled Red/Yellow) */
 		/* Enable stipple, Disable Billboard Mode */
-		shader_set_int_loc(scene->debug_uniforms.u_stippled, 1);
-		shader_set_int_loc(scene->debug_uniforms.u_billboard_mode, 0);
+		shader_set_int_loc(scene->shaders->debug_uniforms.u_stippled,
+		                   1);
+		shader_set_int_loc(
+		    scene->shaders->debug_uniforms.u_billboard_mode, 0);
 		float color_box[4] = {1.0F, 1.0F, 0.0F, debug_box_alpha};
-		shader_set_vec4_loc(scene->debug_uniforms.u_color, color_box);
+		shader_set_vec4_loc(scene->shaders->debug_uniforms.u_color,
+		                    color_box);
 		billboard_group_draw_debug_boxes(&scene->billboard_group);
 
 		glDisable(GL_POLYGON_OFFSET_LINE);
@@ -209,45 +224,50 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 {
 	Shader* current_shader = NULL;
 #ifdef USE_SSBO_RENDERING
-	current_shader = scene->shaders.pbr_ssbo;
+	current_shader = scene->shaders->pbr_ssbo;
 #else
-	current_shader = scene->shaders.pbr_instanced;
+	current_shader = scene->shaders->pbr_instanced;
 #endif
 
 	shader_use(current_shader);
 
 	scene_bind_ibl_textures(scene);
 
-	shader_set_int_loc(scene->instanced_uniforms.debug_mode,
+	shader_set_int_loc(scene->shaders->instanced_uniforms.debug_mode,
 	                   scene->config.pbr_debug_mode);
-	shader_set_vec3_loc(scene->instanced_uniforms.cam_pos, camera_pos);
-	shader_set_mat4_loc(scene->instanced_uniforms.projection, (float*)proj);
-	shader_set_mat4_loc(scene->instanced_uniforms.view, (float*)view);
-	shader_set_mat4_loc(scene->instanced_uniforms.previous_view_proj,
-	                    (float*)previous_view_proj);
+	shader_set_vec3_loc(scene->shaders->instanced_uniforms.cam_pos,
+	                    camera_pos);
+	shader_set_mat4_loc(scene->shaders->instanced_uniforms.projection,
+	                    (float*)proj);
+	shader_set_mat4_loc(scene->shaders->instanced_uniforms.view,
+	                    (float*)view);
+	shader_set_mat4_loc(
+	    scene->shaders->instanced_uniforms.previous_view_proj,
+	    (float*)previous_view_proj);
 
-	if (scene->instanced_uniforms.u_specular_aa_enabled != -1) {
-		glUniform1i(scene->instanced_uniforms.u_specular_aa_enabled,
-		            scene->config.specular_aa_enabled);
+	if (scene->shaders->instanced_uniforms.u_specular_aa_enabled != -1) {
+		glUniform1i(
+		    scene->shaders->instanced_uniforms.u_specular_aa_enabled,
+		    scene->config.specular_aa_enabled);
 	}
-	if (scene->instanced_uniforms.u_aa_mode != -1) {
-		glUniform1i(scene->instanced_uniforms.u_aa_mode,
+	if (scene->shaders->instanced_uniforms.u_aa_mode != -1) {
+		glUniform1i(scene->shaders->instanced_uniforms.u_aa_mode,
 		            scene->config.aa_mode);
 	}
 
 	/* Probe Grid spatial bounds and GI Toggle */
-	shader_set_vec3_loc(scene->instanced_uniforms.probe_grid_min,
+	shader_set_vec3_loc(scene->shaders->instanced_uniforms.probe_grid_min,
 	                    scene->lighting.probe_grid.aabb_min);
-	shader_set_vec3_loc(scene->instanced_uniforms.probe_grid_max,
+	shader_set_vec3_loc(scene->shaders->instanced_uniforms.probe_grid_max,
 	                    scene->lighting.probe_grid.aabb_max);
 
-	if (scene->instanced_uniforms.probe_grid_dim != -1) {
-		glUniform3i(scene->instanced_uniforms.probe_grid_dim,
+	if (scene->shaders->instanced_uniforms.probe_grid_dim != -1) {
+		glUniform3i(scene->shaders->instanced_uniforms.probe_grid_dim,
 		            scene->lighting.probe_grid.grid_dim[0],
 		            scene->lighting.probe_grid.grid_dim[1],
 		            scene->lighting.probe_grid.grid_dim[2]);
 	}
-	shader_set_int_loc(scene->instanced_uniforms.gi_mode,
+	shader_set_int_loc(scene->shaders->instanced_uniforms.gi_mode,
 	                   (int)scene->config.gi_mode);
 
 	scene_bind_probe_textures(scene);
@@ -287,7 +307,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 		 * via glBindTexture(GL_TEXTURE_3D, 0) — invalidate cache
 		 * so scene_bind_probe_textures() will re-bind. */
 		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
-			scene->gpu.bound_sh_textures[i] = 0;
+			scene->gpu->bound_sh_textures[i] = 0;
 		}
 		PROFILE_ZONE_END(gi_sync_ctx);
 	}
@@ -299,9 +319,9 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 		gl_debug_push_group("Skybox_Pass");
 		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 		glDisable(GL_DEPTH_TEST);
-		skybox_render(&scene->visuals.skybox, scene->shaders.skybox,
-		              scene->gpu.hdr_texture,
-		              scene->gpu.dummy_black_tex, inv_view_proj,
+		skybox_render(&scene->visuals.skybox, scene->shaders->skybox,
+		              scene->gpu->hdr_texture,
+		              scene->gpu->dummy_black_tex, inv_view_proj,
 		              scene->config.env_lod);
 		glEnable(GL_DEPTH_TEST);
 		gl_debug_pop_group();
@@ -459,7 +479,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 	/* --- N-Body orbital trails (rendered after spheres, into HDR FBO) ---
 	 */
-	if (scene->simulation.nbody_mode) {
+	if (scene->simulation->nbody_mode) {
 		GPU_STAGE_PROFILER(profiler, "NBody Trails",
 		                   GPU_PROFILER_NBODY_COLOR);
 		gl_debug_push_group("NBody_Trails");
@@ -478,7 +498,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			}
 			shockwave_draw(&scene->visuals.shockwave_renderer, view,
 			               proj, camera_pos,
-			               scene->simulation.nbody_sim.sim_time,
+			               scene->simulation->nbody_sim.sim_time,
 			               width, height);
 			if (scene->config.wireframe) {
 				glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -7,6 +7,7 @@
 #include "postprocess_presets.h"
 #include "renderer.h"
 #include "scene.h"
+#include "scene_gpu_resources.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
 #include <math.h>
@@ -186,7 +187,7 @@ void setUp(void)
 		int timeout = POLL_TIMEOUT_ITERATIONS;
 		double last_time = glfwGetTime();
 		while (
-		    (g_test_app.scene.gpu.hdr_texture == 0 ||
+		    (g_test_app.scene.gpu->hdr_texture == 0 ||
 		     g_test_app.env_mgr.transition_state != TRANSITION_IDLE) &&
 		    timeout-- > 0) {
 			double current_time = glfwGetTime();
@@ -200,8 +201,9 @@ void setUp(void)
 		}
 
 		// Cache the loaded texture for subsequent tests
-		if (g_test_app.scene.gpu.hdr_texture != 0) {
-			g_cached_hdr_texture = g_test_app.scene.gpu.hdr_texture;
+		if (g_test_app.scene.gpu->hdr_texture != 0) {
+			g_cached_hdr_texture =
+			    g_test_app.scene.gpu->hdr_texture;
 		}
 
 		// Initialize PBOs for async pixel readback (optimization#2)
@@ -225,7 +227,7 @@ void setUp(void)
 		preload_all_references();
 	} else if (g_cached_hdr_texture != 0) {
 		// Reuse cached texture for subsequent tests
-		g_test_app.scene.gpu.hdr_texture = g_cached_hdr_texture;
+		g_test_app.scene.gpu->hdr_texture = g_cached_hdr_texture;
 	}
 }
 

--- a/tests/test_env_transition.c
+++ b/tests/test_env_transition.c
@@ -4,6 +4,7 @@
 #include "app_settings.h"
 #include "env_manager.h"
 #include "scene_gpu_resources.h"
+#include "scene_shaders.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
 #include <stdlib.h>
@@ -40,6 +41,8 @@ void setUp(void)
 		TEST_FAIL_MESSAGE("Failed to initialize GLAD");
 	}
 
+	g_test_app->scene.gpu = calloc(1, sizeof(SceneGPUResources));
+	g_test_app->scene.shaders = calloc(1, sizeof(SceneShaders));
 	g_test_app->width = WINDOW_WIDTH;
 	g_test_app->height = WINDOW_HEIGHT;
 	g_test_app->env_mgr.transition_duration = TRANSITION_DURATION;
@@ -51,6 +54,8 @@ void tearDown(void)
 	if (g_test_app->win.handle) {
 		glfwDestroyWindow(g_test_app->win.handle);
 	}
+	free(g_test_app->scene.gpu);
+	free(g_test_app->scene.shaders);
 	free(g_test_app);
 	glfwTerminate();
 }

--- a/tests/test_env_transition.c
+++ b/tests/test_env_transition.c
@@ -3,6 +3,7 @@
 #include "app.h"
 #include "app_settings.h"
 #include "env_manager.h"
+#include "scene_gpu_resources.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
 #include <stdlib.h>
@@ -93,7 +94,7 @@ void test_transition_crossfade_flow(void)
 	TEST_ASSERT_EQUAL_FLOAT(1.0F, g_test_app->env_mgr.transition_alpha);
 	/* Snapshot texture should have been generated */
 	TEST_ASSERT_NOT_EQUAL(TEXTURE_ID_ZERO,
-	                      g_test_app->scene.gpu.transition_snapshot_tex);
+	                      g_test_app->scene.gpu->transition_snapshot_tex);
 }
 
 /**

--- a/tests/test_scene_nbody.c
+++ b/tests/test_scene_nbody.c
@@ -15,6 +15,7 @@
 #include "nbody.h"
 #include "scene.h"
 #include "scene_internal.h"
+#include "scene_simulation.h"
 #include "shockwave.h"
 #include "trail_renderer.h"
 #include "unity.h"
@@ -164,10 +165,14 @@ static void reset_mocks(void)
 	mock_shockwave_init_fail = false;
 }
 
+static SceneSimulation test_simulation;
+
 static Scene make_test_scene(void)
 {
 	Scene scene;
 	memset(&scene, 0, sizeof(scene));
+	memset(&test_simulation, 0, sizeof(test_simulation));
+	scene.simulation = &test_simulation;
 	return scene;
 }
 
@@ -187,11 +192,11 @@ void tearDown(void)
 void test_toggle_nbody_enables_mode(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation.nbody_mode = 0;
+	scene.simulation->nbody_mode = 0;
 
 	scene_toggle_nbody(&scene);
 
-	TEST_ASSERT_TRUE(scene.simulation.nbody_mode);
+	TEST_ASSERT_TRUE(scene.simulation->nbody_mode);
 	TEST_ASSERT_EQUAL_INT(1, mock_trail_init_calls);
 	TEST_ASSERT_EQUAL_INT(1, mock_shockwave_init_calls);
 	TEST_ASSERT_EQUAL_INT(1, mock_instanced_update_calls);
@@ -202,14 +207,14 @@ void test_toggle_nbody_disables_mode(void)
 {
 	Scene scene = make_test_scene();
 	/* Enable first */
-	scene.simulation.nbody_mode = 0;
+	scene.simulation->nbody_mode = 0;
 	scene_toggle_nbody(&scene);
 	reset_mocks();
 
 	/* Now toggle off */
 	scene_toggle_nbody(&scene);
 
-	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	TEST_ASSERT_FALSE(scene.simulation->nbody_mode);
 	TEST_ASSERT_EQUAL_INT(1, mock_trail_cleanup_calls);
 	TEST_ASSERT_EQUAL_INT(1, mock_shockwave_cleanup_calls);
 	TEST_ASSERT_EQUAL_INT(1, mock_instanced_cleanup_calls);
@@ -220,13 +225,13 @@ void test_toggle_nbody_disables_mode(void)
 void test_toggle_nbody_trail_init_failure_aborts(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation.nbody_mode = 0;
+	scene.simulation->nbody_mode = 0;
 	mock_trail_init_fail = true;
 
 	scene_toggle_nbody(&scene);
 
 	/* Mode should stay off */
-	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	TEST_ASSERT_FALSE(scene.simulation->nbody_mode);
 	/* shockwave_init should NOT have been called */
 	TEST_ASSERT_EQUAL_INT(0, mock_shockwave_init_calls);
 }
@@ -234,13 +239,13 @@ void test_toggle_nbody_trail_init_failure_aborts(void)
 void test_toggle_nbody_shockwave_init_failure_cleans_trails(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation.nbody_mode = 0;
+	scene.simulation->nbody_mode = 0;
 	mock_shockwave_init_fail = true;
 
 	scene_toggle_nbody(&scene);
 
 	/* Mode should stay off */
-	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	TEST_ASSERT_FALSE(scene.simulation->nbody_mode);
 	/* Trail was inited then cleaned up */
 	TEST_ASSERT_EQUAL_INT(1, mock_trail_init_calls);
 	TEST_ASSERT_EQUAL_INT(1, mock_trail_cleanup_calls);
@@ -251,19 +256,19 @@ void test_toggle_nbody_roundtrip(void)
 	Scene scene = make_test_scene();
 
 	/* Start off */
-	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	TEST_ASSERT_FALSE(scene.simulation->nbody_mode);
 
 	/* Enable */
 	scene_toggle_nbody(&scene);
-	TEST_ASSERT_TRUE(scene.simulation.nbody_mode);
+	TEST_ASSERT_TRUE(scene.simulation->nbody_mode);
 
 	/* Disable */
 	scene_toggle_nbody(&scene);
-	TEST_ASSERT_FALSE(scene.simulation.nbody_mode);
+	TEST_ASSERT_FALSE(scene.simulation->nbody_mode);
 
 	/* Enable again */
 	scene_toggle_nbody(&scene);
-	TEST_ASSERT_TRUE(scene.simulation.nbody_mode);
+	TEST_ASSERT_TRUE(scene.simulation->nbody_mode);
 }
 
 /* ---- Tests: scene_nbody_update ---- */
@@ -271,7 +276,7 @@ void test_toggle_nbody_roundtrip(void)
 void test_nbody_update_noop_when_disabled(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation.nbody_mode = 0;
+	scene.simulation->nbody_mode = 0;
 
 	scene_nbody_update(&scene, 1.0F / 60.0F);
 
@@ -284,7 +289,7 @@ void test_nbody_update_noop_when_disabled(void)
 void test_nbody_update_calls_subsystems(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation.nbody_mode = 0;
+	scene.simulation->nbody_mode = 0;
 	scene_toggle_nbody(&scene);
 	reset_mocks();
 
@@ -298,7 +303,7 @@ void test_nbody_update_calls_subsystems(void)
 void test_nbody_update_multiple_steps(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation.nbody_mode = 0;
+	scene.simulation->nbody_mode = 0;
 	scene_toggle_nbody(&scene);
 	reset_mocks();
 

--- a/tests/test_scene_render.c
+++ b/tests/test_scene_render.c
@@ -15,6 +15,9 @@
 #include "instanced_rendering.h"
 #include "light_probes.h"
 #include "scene.h"
+#include "scene_gpu_resources.h"
+#include "scene_shaders.h"
+#include "scene_simulation.h"
 #include "scene_uniforms.h"
 #include "shockwave.h"
 #include "skybox.h"
@@ -249,10 +252,20 @@ static void reset_counters(void)
 	mock_billboard_sort_gpu_calls = 0;
 }
 
+static SceneGPUResources test_gpu;
+static SceneShaders test_shaders;
+static SceneSimulation test_simulation;
+
 static Scene make_scene(void)
 {
 	Scene s;
 	memset(&s, 0, sizeof(s));
+	memset(&test_gpu, 0, sizeof(test_gpu));
+	memset(&test_shaders, 0, sizeof(test_shaders));
+	memset(&test_simulation, 0, sizeof(test_simulation));
+	s.gpu = &test_gpu;
+	s.shaders = &test_shaders;
+	s.simulation = &test_simulation;
 	return s;
 }
 
@@ -284,10 +297,10 @@ void test_aa_mode_unknown(void)
 void test_update_gpu_buffers_binds_vao(void)
 {
 	Scene s = make_scene();
-	s.gpu.icosphere_vao = 10;
-	s.gpu.icosphere_vbo = 20;
-	s.gpu.icosphere_nbo = 30;
-	s.gpu.icosphere_ebo = 40;
+	s.gpu->icosphere_vao = 10;
+	s.gpu->icosphere_vbo = 20;
+	s.gpu->icosphere_nbo = 30;
+	s.gpu->icosphere_ebo = 40;
 	s.geometry.vertices.size = 8;
 	s.geometry.normals.size = 8;
 	s.geometry.indices.size = 12;
@@ -304,51 +317,51 @@ void test_update_gpu_buffers_binds_vao(void)
 void test_bind_ibl_textures_caches(void)
 {
 	Scene s = make_scene();
-	s.gpu.irradiance_tex = 100;
-	s.gpu.spec_prefiltered_tex = 200;
-	s.gpu.brdf_lut_tex = 300;
-	s.gpu.dummy_black_tex = 1;
-	memset(s.gpu.bound_ibl_textures, 0, sizeof(s.gpu.bound_ibl_textures));
+	s.gpu->irradiance_tex = 100;
+	s.gpu->spec_prefiltered_tex = 200;
+	s.gpu->brdf_lut_tex = 300;
+	s.gpu->dummy_black_tex = 1;
+	memset(s.gpu->bound_ibl_textures, 0, sizeof(s.gpu->bound_ibl_textures));
 
 	scene_bind_ibl_textures(&s);
 
-	TEST_ASSERT_EQUAL_UINT(100, s.gpu.bound_ibl_textures[0]);
-	TEST_ASSERT_EQUAL_UINT(200, s.gpu.bound_ibl_textures[1]);
-	TEST_ASSERT_EQUAL_UINT(300, s.gpu.bound_ibl_textures[2]);
+	TEST_ASSERT_EQUAL_UINT(100, s.gpu->bound_ibl_textures[0]);
+	TEST_ASSERT_EQUAL_UINT(200, s.gpu->bound_ibl_textures[1]);
+	TEST_ASSERT_EQUAL_UINT(300, s.gpu->bound_ibl_textures[2]);
 }
 
 void test_bind_ibl_textures_skips_when_cached(void)
 {
 	Scene s = make_scene();
-	s.gpu.irradiance_tex = 100;
-	s.gpu.spec_prefiltered_tex = 200;
-	s.gpu.brdf_lut_tex = 300;
-	s.gpu.dummy_black_tex = 1;
-	s.gpu.bound_ibl_textures[0] = 100;
-	s.gpu.bound_ibl_textures[1] = 200;
-	s.gpu.bound_ibl_textures[2] = 300;
+	s.gpu->irradiance_tex = 100;
+	s.gpu->spec_prefiltered_tex = 200;
+	s.gpu->brdf_lut_tex = 300;
+	s.gpu->dummy_black_tex = 1;
+	s.gpu->bound_ibl_textures[0] = 100;
+	s.gpu->bound_ibl_textures[1] = 200;
+	s.gpu->bound_ibl_textures[2] = 300;
 
 	reset_counters();
 	scene_bind_ibl_textures(&s);
 
 	/* Cache hit: no glBindTexture calls expected (counter unchanged) */
-	TEST_ASSERT_EQUAL_UINT(100, s.gpu.bound_ibl_textures[0]);
+	TEST_ASSERT_EQUAL_UINT(100, s.gpu->bound_ibl_textures[0]);
 }
 
 void test_bind_ibl_textures_uses_dummy_when_zero(void)
 {
 	Scene s = make_scene();
-	s.gpu.irradiance_tex = 0;
-	s.gpu.spec_prefiltered_tex = 0;
-	s.gpu.brdf_lut_tex = 0;
-	s.gpu.dummy_black_tex = 5;
-	memset(s.gpu.bound_ibl_textures, 0, sizeof(s.gpu.bound_ibl_textures));
+	s.gpu->irradiance_tex = 0;
+	s.gpu->spec_prefiltered_tex = 0;
+	s.gpu->brdf_lut_tex = 0;
+	s.gpu->dummy_black_tex = 5;
+	memset(s.gpu->bound_ibl_textures, 0, sizeof(s.gpu->bound_ibl_textures));
 
 	scene_bind_ibl_textures(&s);
 
-	TEST_ASSERT_EQUAL_UINT(5, s.gpu.bound_ibl_textures[0]);
-	TEST_ASSERT_EQUAL_UINT(5, s.gpu.bound_ibl_textures[1]);
-	TEST_ASSERT_EQUAL_UINT(5, s.gpu.bound_ibl_textures[2]);
+	TEST_ASSERT_EQUAL_UINT(5, s.gpu->bound_ibl_textures[0]);
+	TEST_ASSERT_EQUAL_UINT(5, s.gpu->bound_ibl_textures[1]);
+	TEST_ASSERT_EQUAL_UINT(5, s.gpu->bound_ibl_textures[2]);
 }
 
 /* ======================================================================
@@ -360,18 +373,18 @@ void test_bind_probe_textures_updates_cache(void)
 	Scene s = make_scene();
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 		s.lighting.probe_grid.sh_textures[i] = (GLuint)(10 + i);
-		s.gpu.bound_sh_textures[i] = 0;
+		s.gpu->bound_sh_textures[i] = 0;
 	}
 	s.lighting.probe_grid.ssbo = 42;
-	s.gpu.bound_probe_ssbo = 0;
+	s.gpu->bound_probe_ssbo = 0;
 
 	scene_bind_probe_textures(&s);
 
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 		TEST_ASSERT_EQUAL_UINT((GLuint)(10 + i),
-		                       s.gpu.bound_sh_textures[i]);
+		                       s.gpu->bound_sh_textures[i]);
 	}
-	TEST_ASSERT_EQUAL_UINT(42, s.gpu.bound_probe_ssbo);
+	TEST_ASSERT_EQUAL_UINT(42, s.gpu->bound_probe_ssbo);
 }
 
 void test_bind_probe_textures_skips_when_cached(void)
@@ -379,16 +392,16 @@ void test_bind_probe_textures_skips_when_cached(void)
 	Scene s = make_scene();
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 		s.lighting.probe_grid.sh_textures[i] = (GLuint)(10 + i);
-		s.gpu.bound_sh_textures[i] = (GLuint)(10 + i);
+		s.gpu->bound_sh_textures[i] = (GLuint)(10 + i);
 	}
 	s.lighting.probe_grid.ssbo = 42;
-	s.gpu.bound_probe_ssbo = 42;
+	s.gpu->bound_probe_ssbo = 42;
 
 	reset_counters();
 	scene_bind_probe_textures(&s);
 
 	/* Nothing changed */
-	TEST_ASSERT_EQUAL_UINT(42, s.gpu.bound_probe_ssbo);
+	TEST_ASSERT_EQUAL_UINT(42, s.gpu->bound_probe_ssbo);
 }
 
 /* ======================================================================
@@ -412,7 +425,7 @@ void test_render_instanced_no_envmap_no_nbody(void)
 	s.config.wireframe = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -442,7 +455,7 @@ void test_render_instanced_wireframe(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -466,7 +479,7 @@ void test_render_billboard_mode(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -491,7 +504,7 @@ void test_render_nbody_draws_trails_and_shockwave(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 1;
+	s.simulation->nbody_mode = 1;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -516,7 +529,7 @@ void test_render_nbody_wireframe_shockwave(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 1;
+	s.simulation->nbody_mode = 1;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -541,7 +554,7 @@ void test_render_gi_mode_triggers_probe_sync(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_3D_TEX;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -549,7 +562,7 @@ void test_render_gi_mode_triggers_probe_sync(void)
 	TEST_ASSERT_EQUAL_INT(1, mock_probe_sync_calls);
 	/* Verify SH cache was invalidated */
 	for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
-		TEST_ASSERT_EQUAL_UINT(0, s.gpu.bound_sh_textures[i]);
+		TEST_ASSERT_EQUAL_UINT(0, s.gpu->bound_sh_textures[i]);
 	}
 }
 
@@ -569,7 +582,7 @@ void test_render_show_probe_grid_triggers_sync_and_debug(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 1;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -595,7 +608,7 @@ void test_render_envmap_draws_skybox(void)
 	s.config.show_envmap = 1;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -620,7 +633,7 @@ void test_render_billboard_wireframe_draws_debug(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -648,7 +661,7 @@ void test_render_billboard_sort_cpu(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -673,7 +686,7 @@ void test_render_billboard_sort_radix(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -698,7 +711,7 @@ void test_render_billboard_sort_gpu(void)
 	s.config.show_envmap = 0;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = 0;
-	s.simulation.nbody_mode = 0;
+	s.simulation->nbody_mode = 0;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -779,9 +792,9 @@ void test_render_instanced_sets_uniforms(void)
 	glm_mat4_identity(view);
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
-	s.instanced_uniforms.u_specular_aa_enabled = 5;
-	s.instanced_uniforms.u_aa_mode = 6;
-	s.instanced_uniforms.probe_grid_dim = 7;
+	s.shaders->instanced_uniforms.u_specular_aa_enabled = 5;
+	s.shaders->instanced_uniforms.u_aa_mode = 6;
+	s.shaders->instanced_uniforms.probe_grid_dim = 7;
 
 	reset_counters();
 	scene_render_instanced(&s, view, proj, cam, prev_vp);
@@ -799,9 +812,9 @@ void test_render_instanced_skips_negative_uniform_locs(void)
 	glm_mat4_identity(view);
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
-	s.instanced_uniforms.u_specular_aa_enabled = -1;
-	s.instanced_uniforms.u_aa_mode = -1;
-	s.instanced_uniforms.probe_grid_dim = -1;
+	s.shaders->instanced_uniforms.u_specular_aa_enabled = -1;
+	s.shaders->instanced_uniforms.u_aa_mode = -1;
+	s.shaders->instanced_uniforms.probe_grid_dim = -1;
 
 	reset_counters();
 	scene_render_instanced(&s, view, proj, cam, prev_vp);


### PR DESCRIPTION
## Summary

Reduces `scene.h` direct includes from 14 to 10 by converting 3 heavy sub-structs to opaque heap-allocated pointers.

### Changes

- **`include/scene.h`**: Remove 4 includes (`scene_gpu_resources.h`, `scene_shaders.h`, `scene_simulation.h`, `scene_uniforms.h`); add forward declarations + opaque pointers
- **`include/scene_shaders.h`**: Absorb `BillboardUniforms`, `InstancedUniforms`, `DebugUniforms` (moved from Scene)
- **`src/scene_init.c`**: Heap-allocate sub-structs via `calloc`
- **`src/scene_cleanup.c`**: Free sub-structs
- **`src/scene_render.c`, `src/scene_nbody.c`, `src/env_manager.c`, `src/app.c`, `src/app_input.c`, `src/app_ui.c`**: Mechanical `.` → `->` conversions + explicit includes
- **Tests**: Adapt `test_scene_render`, `test_scene_nbody`, `test_app`, `test_env_transition` to use pointer members

### Fan-out Analysis

| Before | After | Removed |
|--------|-------|---------|
| 14 direct includes | 10 direct includes | `scene_gpu_resources.h`, `scene_shaders.h`, `scene_simulation.h`, `scene_uniforms.h` |

Remaining 10 includes are structurally required (by-value members in Scene struct).

### Testing

- Build: 0 errors, 0 warnings
- Tests: all pass (unit + integration)
- Format + Lint: clean
- Functional: validated with full integration test

Closes #263