### PR TITLE
fix(memory): aligned allocation for SIMD types — Release crash hotfix

### DIFF
--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -4,6 +4,7 @@
 
 #include "log.h"
 #include "perf_timer.h"
+#include "platform/platform_utils.h"
 #include "profiler.h"
 #include "render_utils.h"
 #include "shader.h"
@@ -166,7 +167,7 @@ void light_probe_grid_free_cpu(LightProbeGrid* grid)
 		free(grid->probes);
 	}
 	if (grid->scene_copy) {
-		free(grid->scene_copy);
+		platform_aligned_free(grid->scene_copy);
 	}
 	pthread_mutex_destroy(&grid->mutex);
 	pthread_cond_destroy(&grid->cond);
@@ -358,7 +359,8 @@ static void* light_probe_worker(void* arg)
 		if (local_count > 0 && grid->scene_copy) {
 			size_t data_size =
 			    (size_t)local_count * sizeof(SphereInstance);
-			local_scene = (SphereInstance*)malloc(data_size);
+			local_scene = (SphereInstance*)platform_aligned_alloc(
+			    data_size, SIMD_ALIGNMENT);
 			if (local_scene) {
 				(void)safe_memcpy(local_scene, data_size,
 				                  grid->scene_copy, data_size);
@@ -367,7 +369,7 @@ static void* light_probe_worker(void* arg)
 		pthread_mutex_unlock(&grid->mutex);
 
 		if (!local_scene || local_count <= 0) {
-			free(local_scene);
+			platform_aligned_free(local_scene);
 			continue;
 		}
 
@@ -395,7 +397,7 @@ static void* light_probe_worker(void* arg)
 			}
 		}
 
-		free(local_scene);
+		platform_aligned_free(local_scene);
 		free(cached_scene);
 
 		double worker_ms = perf_timer_elapsed_ms(&worker_timer);
@@ -499,12 +501,13 @@ void light_probe_grid_set_scene(LightProbeGrid* grid, const void* spheres,
 	pthread_mutex_lock(&grid->mutex);
 
 	if (grid->scene_copy) {
-		free(grid->scene_copy);
+		platform_aligned_free(grid->scene_copy);
 	}
 	grid->scene_count = count;
 
 	size_t size = count * sizeof(SphereInstance);
-	grid->scene_copy = (SphereInstance*)malloc(size);
+	grid->scene_copy =
+	    (SphereInstance*)platform_aligned_alloc(size, SIMD_ALIGNMENT);
 	if (grid->scene_copy) {
 		const char* src = (const char*)spheres;
 		for (int i = 0; i < count; i++) {

--- a/src/material.c
+++ b/src/material.c
@@ -2,6 +2,7 @@
 
 #include "io.h"
 #include "log.h"
+#include "platform/platform_utils.h"
 #include "utils.h"
 #include <cJSON.h>
 #include <stdint.h>
@@ -92,7 +93,8 @@ static PBRMaterial* allocate_materials(int count)
 		return NULL;
 	}
 
-	PBRMaterial* materials = malloc(sizeof(PBRMaterial) * size_check);
+	PBRMaterial* materials = platform_aligned_alloc(
+	    sizeof(PBRMaterial) * size_check, SIMD_ALIGNMENT);
 	if (materials == NULL) {
 		LOG_ERROR("material", "Failed to allocate materials array");
 		return NULL;
@@ -167,7 +169,7 @@ MaterialLib* material_load_presets(const char* path)
 	MaterialLib* lib = malloc(sizeof(MaterialLib));
 	if (lib == NULL) {
 		LOG_ERROR("material", "Failed to allocate MaterialLib");
-		free(materials);
+		platform_aligned_free(materials);
 		return NULL;
 	}
 
@@ -185,7 +187,7 @@ void material_free_lib(MaterialLib* lib)
 	}
 
 	if (lib->materials != NULL) {
-		free(lib->materials);
+		platform_aligned_free(lib->materials);
 		lib->materials = NULL;
 	}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -630,6 +630,7 @@ add_executable(test_sh_integration
     ${CMAKE_SOURCE_DIR}/src/render_utils.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
     ${CMAKE_SOURCE_DIR}/src/perf_timer.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_gl_standalone.c
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone/mock_log.c
 )


### PR DESCRIPTION
## Summary

Fixes **SIGSEGV in Release builds** (`-O3 -march=native`) caused by misaligned memory allocation of SIMD-aligned types.

## Root Cause

`SphereInstance` and `PBRMaterial` are annotated with `__attribute__((aligned(64)))` but were allocated via `malloc()`, which only guarantees 16-byte alignment on x86_64. At `-O3` with native arch, the compiler emits AVX aligned loads (`VMOVAPS`) on these structs, crashing with signal 11 on misaligned addresses.

## Fix

Replace `malloc`/`free` with `platform_aligned_alloc`/`platform_aligned_free` for all allocations of SIMD-aligned types:
- `light_probes.c`: `scene_copy` and `local_scene` (`SphereInstance`)
- `material.c`: `materials` array (`PBRMaterial`)

## Validation

- **Before**: `timeout 15 ./build-release/app` → exit 139 (SIGSEGV)
- **After**: `timeout 15 ./build-release/app` → exit 143 (clean timeout)
- All 68 tests pass
- ASan build clean
- Lint/format clean (0 warnings)