### PR TITLE
Fix Tracy GPU Compilation

### DIFF
--- a/include/tracy_gpu.h
+++ b/include/tracy_gpu.h
@@ -1,6 +1,8 @@
 #ifndef TRACY_GPU_H
 #define TRACY_GPU_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/tracy_gpu.cpp
+++ b/src/tracy_gpu.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "tracy_gpu.h"
 
 #ifdef TRACY_ENABLE


### PR DESCRIPTION
Added missing stdint.h/cstdint includes to tracy_gpu.h and tracy_gpu.cpp to resolve compilation errors with fixed-width integer types.