### PR TITLE
Unified Stabilization: N-Body, Rendering & Tracy Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,9 @@ if(ENABLE_CLANG_TIDY AND CLANG_TIDY_CMD)
     set_target_properties(app PROPERTIES C_CLANG_TIDY "${CLANG_TIDY_CMD}")
 endif()
 
+# Force disable fast-math for nbody.c (Numerical stability is critical here)
+set_source_files_properties(src/nbody.c PROPERTIES COMPILE_FLAGS "-fno-fast-math")
+
 # Target properties and includes
 target_include_directories(app PRIVATE
     src

--- a/docs/nbody_precision_fix.fr.md
+++ b/docs/nbody_precision_fix.fr.md
@@ -1,0 +1,38 @@
+# Correction de la Stabilité Numérique N-Body
+
+## Description du Problème
+Une instabilité numérique a été observée dans la simulation N-body, entraînant occasionnellement des valeurs `NaN` (Not a Number) dans les vitesses des corps ou des trajectoires erratiques. Ces problèmes provenaient principalement des effets secondaires des optimisations de calculs flottants et de vecteurs de vitesse initiale non normalisés.
+
+## Causes Techniques
+
+### 1. Optimisations Fast-Math
+Les compilateurs utilisent souvent `-ffast-math` ou des optimisations agressives similaires pour améliorer les performances. Cependant, ces optimisations :
+- Sacrifient la conformité stricte à la norme IEEE 754.
+- Permettent la réassociation d'opérations mathématiques (ex: `(a + b) + c` devient `a + (b + c)`), ce qui peut entraîner une perte de précision significative dans les simulations physiques itératives.
+- Supposent qu'aucune valeur `NaN` ou `Inf` n'existe, ce qui conduit à un comportement indéfini lorsqu'elles surviennent (ex: lors de rencontres rapprochées entre corps où les forces sont extrêmement élevées).
+
+### 2. Directions de Vitesse non Normalisées
+Lors de l'initialisation dans `nbody_init_preset`, la vitesse orbitale était calculée en mettant à l'échelle un vecteur de direction (`orb->vel_dir`). Si ce vecteur n'était pas de longueur unitaire, la vitesse résultante était incorrectement mise à l'échelle, ce qui pouvait entraîner des vitesses extrêmes et une divergence immédiate de la simulation.
+
+## Solution
+
+### Désactivation de Fast-Math pour la Physique
+Le cœur de la simulation dans `src/nbody.c` désactive désormais explicitement les optimisations fast-math via un pragma du compilateur :
+```c
+#pragma GCC optimize ("no-fast-math")
+```
+Cela garantit que l'intégrateur Velocity Verlet conserve une précision maximale et gère correctement les cas limites numériques (comme les petites distances ou les NaNs) selon les règles standard des virgules flottantes.
+
+### Normalisation de la Direction de Vitesse
+La logique d'initialisation garantit désormais que le vecteur de direction de la vitesse est normalisé avant d'être mis à l'échelle par la vitesse orbitale :
+```c
+vec3 normalized_vel_dir;
+glm_vec3_copy((float*)orb->vel_dir, normalized_vel_dir);
+glm_vec3_normalize(normalized_vel_dir);
+
+vec3 vel = {normalized_vel_dir[0] * spd, normalized_vel_dir[1] * spd,
+            normalized_vel_dir[2] * spd};
+```
+
+### Détection de NaN
+Un contrôle de diagnostic a été ajouté à l'étape d'intégration pour afficher un avertissement si la vitesse d'un corps devient `NaN`, facilitant ainsi le débogage de futurs problèmes de stabilité.

--- a/docs/nbody_precision_fix.md
+++ b/docs/nbody_precision_fix.md
@@ -1,0 +1,38 @@
+# N-Body Numerical Stability Fix
+
+## Problem Description
+Numerical instability was observed in the N-body simulation, occasionally leading to `NaN` (Not a Number) values in body velocities or highly erratic trajectories. These issues typically stemmed from floating-point optimization side effects and unnormalized initial velocity vectors.
+
+## Technical Causes
+
+### 1. Fast-Math Optimizations
+Compilers often use `-ffast-math` or similar aggressive optimizations to improve performance. However, these optimizations:
+- Sacrifice strict IEEE 754 compliance.
+- Allow reassociation of mathematical operations (e.g., `(a + b) + c` becomes `a + (b + c)`), which can lead to significant precision loss in iterative physics simulations.
+- Assume no `NaN` or `Inf` values exist, leading to undefined behavior when they do occur (e.g., during close body encounters where forces are extremely high).
+
+### 2. Unnormalized Velocity Directions
+During initialization in `nbody_init_preset`, the orbital velocity was calculated by scaling a direction vector (`orb->vel_dir`). If this vector was not unit length, the resulting velocity would be incorrectly scaled, potentially leading to extreme speeds and immediate simulation divergence.
+
+## Solution
+
+### Disabling Fast-Math for Physics
+The simulation core in `src/nbody.c` now explicitly disables fast-math optimizations using a compiler pragma:
+```c
+#pragma GCC optimize ("no-fast-math")
+```
+This ensures that the Velocity Verlet integrator maintains maximum precision and handles numerical edge cases (like small distances or NaNs) correctly according to standard floating-point rules.
+
+### Velocity Direction Normalization
+The initialization logic now ensures that the velocity direction vector is normalized before being scaled by the orbital speed:
+```c
+vec3 normalized_vel_dir;
+glm_vec3_copy((float*)orb->vel_dir, normalized_vel_dir);
+glm_vec3_normalize(normalized_vel_dir);
+
+vec3 vel = {normalized_vel_dir[0] * spd, normalized_vel_dir[1] * spd,
+            normalized_vel_dir[2] * spd};
+```
+
+### NaN Detection
+A diagnostic check has been added to the integration step to print a warning if a body's velocity becomes `NaN`, allowing for easier debugging of future stability issues.

--- a/include/tracy_gpu.h
+++ b/include/tracy_gpu.h
@@ -1,6 +1,8 @@
 #ifndef TRACY_GPU_H
 #define TRACY_GPU_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -213,6 +213,7 @@ nav:
   - Technical Docs System: documentation_system.md
   - Doxygen Customization: doxygen_customization.md
 - Technical Notes:
+  - N-Body Precision Fix: nbody_precision_fix.md
   - Async Loader Deadlock Fix: fix_async_loader_deadlock.md
   - Bazzite Lint Path Fix: fix_lint_bazzite_paths.md
   - PR Evaluation (Shader Security): pr_evaluation_report.md

--- a/scripts/integration_scenarios.sh
+++ b/scripts/integration_scenarios.sh
@@ -4,7 +4,11 @@
 # GLFW maps keys by physical position (US QWERTY), not by keysym.
 # xdotool resolves keysym names to keycodes, so on non-US layouts
 # we must use the layout-specific keysym for the correct physical key.
-_layout=$(setxkbmap -query 2>/dev/null | awk '/layout/{print $2}')
+if command -v setxkbmap >/dev/null 2>&1; then
+    _layout=$(setxkbmap -query 2>/dev/null | awk '/layout/{print $2}')
+else
+    _layout=""
+fi
 case "$_layout" in
     fr)
         # AZERTY: physical key positions differ from US QWERTY.

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -1,4 +1,3 @@
-#pragma GCC optimize("no-fast-math")
 #include "nbody.h"
 
 #include "utils.h"
@@ -316,12 +315,21 @@ static void integrate_step(NBodySim* sim, float delta_time)
 		glm_vec3_add(sim->bodies[i].velocity, avg,
 		             sim->bodies[i].velocity);
 
-		if (isnan(sim->bodies[i].velocity[0])) {
+		if (isnan(sim->bodies[i].velocity[0]) ||
+		    isnan(sim->bodies[i].velocity[1]) ||
+		    isnan(sim->bodies[i].velocity[2]) ||
+		    isnan(sim->bodies[i].position[0]) ||
+		    isnan(sim->bodies[i].position[1]) ||
+		    isnan(sim->bodies[i].position[2])) {
 			printf(
-			    "!!! Body %d velocity became NaN at step! "
-			    "v_prev=%f a_old=%f a_new=%f dt=%f\n",
+			    "!!! Body %d STATE became NaN at step! "
+			    "v=[%f, %f, %f] p=[%f, %f, %f] dt=%f\n",
 			    i, (double)sim->bodies[i].velocity[0],
-			    (double)accel_old[i][0], (double)accel_new[i][0],
+			    (double)sim->bodies[i].velocity[1],
+			    (double)sim->bodies[i].velocity[2],
+			    (double)sim->bodies[i].position[0],
+			    (double)sim->bodies[i].position[1],
+			    (double)sim->bodies[i].position[2],
 			    (double)delta_time);
 		}
 	}

--- a/src/nbody.c
+++ b/src/nbody.c
@@ -1,3 +1,4 @@
+#pragma GCC optimize("no-fast-math")
 #include "nbody.h"
 
 #include "utils.h"
@@ -122,8 +123,13 @@ void nbody_init_preset(NBodySim* sim)
 		                sim->gravity, CENTRAL_STAR_MASS, orb->orbit_r,
 		                CENTRAL_STAR_RADIUS, orb->body_r) *
 		            orb->ecc;
-		vec3 vel = {orb->vel_dir[0] * spd, orb->vel_dir[1] * spd,
-		            orb->vel_dir[2] * spd};
+		vec3 normalized_vel_dir;
+		glm_vec3_copy((float*)orb->vel_dir, normalized_vel_dir);
+		glm_vec3_normalize(normalized_vel_dir);
+
+		vec3 vel = {normalized_vel_dir[0] * spd,
+		            normalized_vel_dir[1] * spd,
+		            normalized_vel_dir[2] * spd};
 		add_body(sim, orb->pos, vel, orb->mass, orb->body_r,
 		         orb->albedo, orb->metallic, orb->roughness);
 	}
@@ -309,6 +315,15 @@ static void integrate_step(NBodySim* sim, float delta_time)
 		glm_vec3_scale(avg, HALF * delta_time, avg);
 		glm_vec3_add(sim->bodies[i].velocity, avg,
 		             sim->bodies[i].velocity);
+
+		if (isnan(sim->bodies[i].velocity[0])) {
+			printf(
+			    "!!! Body %d velocity became NaN at step! "
+			    "v_prev=%f a_old=%f a_new=%f dt=%f\n",
+			    i, (double)sim->bodies[i].velocity[0],
+			    (double)accel_old[i][0], (double)accel_new[i][0],
+			    (double)delta_time);
+		}
 	}
 
 	/* Radial damping in the confinement zone — proportional to overshoot.

--- a/src/scene_render.c
+++ b/src/scene_render.c
@@ -479,6 +479,9 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 
 	/* --- N-Body orbital trails (rendered after spheres, into HDR FBO) ---
 	 */
+	/* Disable writing to velocity buffer for transparent VFX overlays */
+	glColorMaski(1, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+
 	if (scene->simulation->nbody_mode) {
 		GPU_STAGE_PROFILER(profiler, "NBody Trails",
 		                   GPU_PROFILER_NBODY_COLOR);
@@ -511,4 +514,7 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 		light_probe_grid_render_debug(&scene->lighting.probe_grid, view,
 		                              proj);
 	}
+
+	/* Restore velocity buffer writes */
+	glColorMaski(1, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 }

--- a/src/tracy_gpu.cpp
+++ b/src/tracy_gpu.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "tracy_gpu.h"
 
 #ifdef TRACY_ENABLE


### PR DESCRIPTION
This PR unifies all recent stability and rendering fixes:
- N-Body: Fixed NaN divergence (normalization + no fast-math)
- Rendering: Fixed velocity buffer pollution (glColorMaski)
- Tracy: Fixed missing includes
- Tests: Fixed mock GL and integration script

Supersedes #273, #274, #275.