### PR TITLE
ci: add dependency metrics gate (fan-out thresholds)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,9 @@ jobs:
           BASE="origin/${{ github.base_ref || 'master' }}"
           make check-nolint CONTAINER_RUN="" NOLINT_BASE_REF="${BASE}"
 
+      - name: Dependency metrics gate
+        run: bash scripts/check_dep_metrics.sh
+
       - name: Run Format & Lint
         run: |
           git config --global --add safe.directory '*'

--- a/Justfile
+++ b/Justfile
@@ -530,6 +530,10 @@ lint-full:
 check-nolint base_ref="origin/master":
     @bash scripts/check_nolint.sh {{base_ref}}
 
+# Check dependency metrics (include fan-out thresholds)
+dep-metrics:
+    @bash scripts/check_dep_metrics.sh
+
 # Trace Performance Analysis
 trace-perf:
     @echo "Analyzing GPU performance (Advanced Analysis)..."

--- a/scripts/check_dep_metrics.sh
+++ b/scripts/check_dep_metrics.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Dependency metrics gate — fails CI if thresholds exceeded
+# Related: https://github.com/yoyonel/suckless-ogl/issues/266
+set -euo pipefail
+
+EDGE_LIMIT=${1:-540}
+HEADER_FAN_LIMIT=${2:-18}
+SOURCE_FAN_LIMIT=${3:-21}
+
+# Count total include edges (only local includes)
+total=0
+for f in src/*.c src/effects/*.c include/*.h include/effects/*.h; do
+    [[ -f "$f" ]] || continue
+    n=$(grep -c '#include "' "$f" 2>/dev/null || true)
+    total=$((total + n))
+done
+
+# Find max header fan-out (all includes)
+max_header=0
+max_header_file=""
+for f in include/*.h include/effects/*.h; do
+    [[ -f "$f" ]] || continue
+    n=$(grep -c '#include' "$f" 2>/dev/null || true)
+    if [[ $n -gt $max_header ]]; then
+        max_header=$n
+        max_header_file="$f"
+    fi
+done
+
+# Find max source fan-out (all includes)
+max_source=0
+max_source_file=""
+for f in src/*.c src/effects/*.c; do
+    [[ -f "$f" ]] || continue
+    n=$(grep -c '#include' "$f" 2>/dev/null || true)
+    if [[ $n -gt $max_source ]]; then
+        max_source=$n
+        max_source_file="$f"
+    fi
+done
+
+echo "=== Dependency Metrics ==="
+echo "Total include edges: $total (limit: $EDGE_LIMIT)"
+echo "Max header fan-out:  $max_header [$max_header_file] (limit: $HEADER_FAN_LIMIT)"
+echo "Max source fan-out:  $max_source [$max_source_file] (limit: $SOURCE_FAN_LIMIT)"
+echo ""
+
+fail=0
+if [[ $total -gt $EDGE_LIMIT ]]; then
+    echo "FAIL: total include edges ($total) exceeds limit ($EDGE_LIMIT)"
+    fail=1
+fi
+if [[ $max_header -gt $HEADER_FAN_LIMIT ]]; then
+    echo "FAIL: header fan-out ($max_header in $max_header_file) exceeds limit ($HEADER_FAN_LIMIT)"
+    fail=1
+fi
+if [[ $max_source -gt $SOURCE_FAN_LIMIT ]]; then
+    echo "FAIL: source fan-out ($max_source in $max_source_file) exceeds limit ($SOURCE_FAN_LIMIT)"
+    fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+    echo "OK: all dependency metrics within thresholds"
+fi
+exit $fail


### PR DESCRIPTION
## Summary

Add a CI gate that enforces dependency fan-out thresholds to prevent regression after the include reduction work (#261-#265).

### What

- **`scripts/check_dep_metrics.sh`** — checks total include edges, max header fan-out, and max source fan-out against configurable limits
- **`just dep-metrics`** — local recipe to run the check
- **CI integration** — blocking step in `lint-and-format` job

### Thresholds

| Metric | Current | Limit |
|--------|---------|-------|
| Total include edges | 521 | ≤540 |
| Max header fan-out | 16 | ≤18 |
| Max source fan-out | 19 | ≤21 |

### Testing

- Script passes on current codebase
- Script correctly fails with tight thresholds
- shellcheck clean

Closes #266