### PR TITLE
fix(rendering): prevent trails and shockwaves from writing to velocity buffer

### DIFF
--- a/docs/motion_blur_analysis.fr.md
+++ b/docs/motion_blur_analysis.fr.md
@@ -61,6 +61,23 @@ vec4 prevClip = previousViewProj * vec4(prevHitPos, 1.0);
 - Les sphères statiques de la grille ont `prev_center == centre actuel` → vélocité objet nulle
 - `SphereInstance` reste à 128 octets (aligné SIMD, validé par `_Static_assert`)
 
+### 🐛 Correction d'artefact des VFX transparents (glColorMaski)
+
+Les passes de rendu transparentes (trails, shockwaves) écrivaient des valeurs indéfinies dans le velocity buffer (color attachment 1) car leurs shaders ne possèdent pas de sortie vélocité. Sur certains GPU (notamment NVidia 950m sous Bazzite), cela causait des artefacts de motion blur visibles — des traînées et du ghosting dans les zones couvertes par les effets transparents.
+
+**Cause racine :** Quand un fragment shader n'écrit pas explicitement dans `gl_FragData[1]` (ou la sortie `layout(location=1)` équivalente), le GPU peut écrire des valeurs parasites ou des registres obsolètes dans cet attachment si l'écriture est activée.
+
+**Correction :** Utiliser `glColorMaski(1, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE)` avant les draw calls des VFX transparents pour désactiver l'écriture dans le velocity buffer, et restaurer avec `glColorMaski(1, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE)` après :
+
+```c
+/* Désactiver l'écriture dans le velocity buffer (Attachment 1) */
+glColorMaski(1, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+/* ... rendu de la géométrie transparente ... */
+glColorMaski(1, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+```
+
+Note : Le renderer de billboards gérait déjà ce cas via `glDisablei(GL_BLEND, 1)` dans `scene_render.c`, mais les trails et shockwaves utilisaient un chemin de rendu différent sans cette protection.
+
 ---
 
 ## 2. Pistes d'Améliorations (Vitesse et Qualité)

--- a/docs/motion_blur_analysis.md
+++ b/docs/motion_blur_analysis.md
@@ -61,6 +61,23 @@ vec4 prevClip = previousViewProj * vec4(prevHitPos, 1.0);
 - Static grid spheres have `prev_center == current center` → zero object velocity
 - `SphereInstance` remains 128 bytes (SIMD-aligned, validated by `_Static_assert`)
 
+### 🐛 Transparent VFX Artifact Fix (glColorMaski)
+
+Transparent rendering passes (trails, shockwaves) were writing undefined values into the velocity buffer (color attachment 1) because their shaders have no velocity output. On some GPUs (notably NVidia 950m under Bazzite), this caused visible motion blur artifacts — streaks and ghosting in areas covered by transparent effects.
+
+**Root cause:** When a fragment shader doesn't explicitly write to `gl_FragData[1]` (or equivalent `layout(location=1)` output), the GPU may write garbage or stale register values to that attachment if writing is enabled.
+
+**Fix:** Use `glColorMaski(1, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE)` before transparent VFX draw calls to disable writing to the velocity buffer, and restore with `glColorMaski(1, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE)` after:
+
+```c
+/* Disable writing to the velocity buffer (Attachment 1) */
+glColorMaski(1, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+/* ... draw transparent geometry ... */
+glColorMaski(1, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+```
+
+Note: The billboard renderer already handled this via `glDisablei(GL_BLEND, 1)` in `scene_render.c`, but trails and shockwaves used a different rendering path without this protection.
+
 ---
 
 ## 2. Improvement Paths (Speed and Quality)

--- a/include/gl_common.h
+++ b/include/gl_common.h
@@ -102,6 +102,8 @@ void glUseProgram(GLuint program);
 void glPopDebugGroup(void);
 void glPushDebugGroup(GLenum source, GLuint id, GLsizei length,
                       const GLchar* message);
+void glColorMaski(GLuint index, GLboolean r, GLboolean g, GLboolean b,
+                  GLboolean a);
 #endif
 
 #ifndef GL_COMMON_NO_GLFW

--- a/src/shockwave.c
+++ b/src/shockwave.c
@@ -195,6 +195,10 @@ void shockwave_draw(const ShockwaveRenderer* renderer, mat4 view, mat4 proj,
 	glDepthMask(GL_FALSE);
 	glDisable(GL_CULL_FACE);
 
+	/* Disable writing to the velocity buffer (Attachment 1) to prevent
+	 * motion blur artifacts */
+	glColorMaski(1, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+
 	glBindVertexArray(renderer->vao);
 
 	for (int i = 0; i < renderer->count; i++) {
@@ -217,6 +221,7 @@ void shockwave_draw(const ShockwaveRenderer* renderer, mat4 view, mat4 proj,
 	}
 
 	glBindVertexArray(0);
+	glColorMaski(1, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	glDepthMask(GL_TRUE);
 	glDisable(GL_BLEND);
 }

--- a/src/trail_renderer.c
+++ b/src/trail_renderer.c
@@ -331,6 +331,10 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 	/* Read depth but don't write — trails are transparent overlay */
 	glDepthMask(GL_FALSE);
 
+	/* Disable writing to the velocity buffer (Attachment 1) to prevent
+	 * motion blur artifacts */
+	glColorMaski(1, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+
 	/* Draw all body trails in a single batched call.
 	 * glMultiDrawArrays draws N independent triangle strips without
 	 * degenerate vertices or per-strip driver overhead. */
@@ -342,6 +346,7 @@ void trail_renderer_draw(TrailRenderer* trail, mat4 view, mat4 proj,
 	}
 
 	/* Restore state */
+	glColorMaski(1, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	glDepthMask(GL_TRUE);
 	glDisable(GL_BLEND);
 	glBindVertexArray(0);

--- a/tests/mocks/glad/glad.h
+++ b/tests/mocks/glad/glad.h
@@ -260,6 +260,8 @@ void glBindImageTexture(GLuint unit, GLuint texture, GLint level,
 void glPushDebugGroup(GLenum source, GLuint id, GLsizei length,
                       const GLchar* message);
 void glPopDebugGroup(void);
+void glColorMaski(GLuint index, GLboolean r, GLboolean g, GLboolean b,
+                  GLboolean a);
 void glObjectLabel(GLenum identifier, GLuint name, GLsizei length,
                    const GLchar* label);
 void glGetActiveUniform(GLuint program, GLuint index, GLsizei bufSize,

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -737,3 +737,13 @@ void glStencilMask(GLuint mask)
 {
 	(void)mask;
 }
+
+void glColorMaski(GLuint index, GLboolean r, GLboolean g, GLboolean b,
+                  GLboolean a)
+{
+	(void)index;
+	(void)r;
+	(void)g;
+	(void)b;
+	(void)a;
+}


### PR DESCRIPTION
Fixes motion blur artifacts caused by transparent VFX modifying the velocity buffer without proper output handling. Adds glColorMaski to disable velocity writing for these passes.