### PR TITLE
style: enforce SeparateDefinitionBlocks and document coding conventions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,7 @@ ColumnLimit: 80
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
+SeparateDefinitionBlocks: Always
 SortIncludes: true
 IncludeCategories:
   - Regex:           '^<glad/.*'

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,13 @@ format:
 
 format-check:
 	@echo "Checking C and Shader formatting..."
-	@$(DISTROBOX) sh -c "find src include tests shaders -name \"_deps\" -prune -o -name \"*.c\" -print -o -name \"*.h\" -print -o -name \"*.glsl\" -print -o -name \"*.vert\" -print -o -name \"*.frag\" -print | xargs clang-format --dry-run --Werror"
+	@$(DISTROBOX) sh -c "find src include tests shaders -name \"_deps\" -prune -o -name \"*.c\" -print -o -name \"*.h\" -print -o -name \"*.glsl\" -print -o -name \"*.vert\" -print -o -name \"*.frag\" -print | xargs clang-format -i"
+	@if ! git diff --quiet -- src/ include/ tests/ shaders/; then \
+		echo "❌ C/Shader formatting violations:"; \
+		git diff --stat -- src/ include/ tests/ shaders/; \
+		git checkout -- src/ include/ tests/ shaders/; \
+		exit 1; \
+	fi
 	@echo "Checking Python scripts formatting..."
 	@$(TOOL_RUN) ruff format --check scripts/trace_analyze.py .github/workflows/scripts/test_trace_analyze.py
 	@echo "✓ Formatting check passed"

--- a/docs/linting_strategy.fr.md
+++ b/docs/linting_strategy.fr.md
@@ -1,6 +1,75 @@
 # Stratégie de lint et mise en cache
 
-Ce document présente la stratégie d'analyse statique du projet `suckless-ogl` et l'implémentation de son mécanisme de mise en cache haute performance.
+Ce document présente la stratégie d'analyse statique et de formatage du projet `suckless-ogl` et l'implémentation de son mécanisme de mise en cache haute performance.
+
+## Philosophie du style de code
+
+Ce projet suit un style de code fortement inspiré du **noyau Linux** ([`Documentation/process/coding-style.rst`](https://www.kernel.org/doc/html/latest/process/coding-style.html)), adapté pour un moteur de rendu OpenGL en C11.
+
+### Pourquoi le style du noyau Linux ?
+
+Le style du noyau a été conçu pour des bases de code C à grande échelle, maintenues par des milliers de contributeurs pendant des décennies. Ses règles optimisent la **lisibilité à l'échelle**, la **facilité de recherche** (grep-ability) et la **charge cognitive minimale** — les mêmes qualités que nous valorisons dans ce projet.
+
+Autres conventions C notables dont nous nous sommes inspirés :
+
+| Convention | Origine | Point clé |
+|---|---|---|
+| [**Linux kernel coding style**](https://www.kernel.org/doc/html/latest/process/coding-style.html) | Torvalds, communauté kernel | Inspiration principale : tabs-8, accolades, 80 cols, `goto` cleanup, fonctions courtes |
+| [**SEI CERT C**](https://wiki.sei.cmu.edu/confluence/display/c) | Carnegie Mellon SEI | Règles orientées sécurité (MEM, ERR, STR) — appliquées via les checks `clang-tidy cert-*` |
+| [**FreeBSD style(9)**](https://man.freebsd.org/cgi/man.cgi?query=style&sektion=9) | Projet FreeBSD | Proche du style kernel ; explicite sur les lignes vides entre fonctions, `return` sans parenthèses |
+| [**SQLite**](https://www.sqlite.org/codeofethics.html) | D. Richard Hipp | 100% couverture de branches, `goto` cleanup, C autonome — un modèle de qualité |
+| [**id Software**](https://github.com/id-Software/Quake-III-Arena) (Quake/Doom) | John Carmack | C pragmatique pour le graphisme temps réel ; nommage et disposition orientés performance |
+
+### Principes fondamentaux (issus du kernel)
+
+1. **Indentation = 8 espaces (tabulations)** — Force un nesting court ; si 3+ niveaux sont nécessaires, refactorer (kernel §1)
+2. **Limite de 80 colonnes** — Encourage la séparation des expressions complexes et l'extraction de fonctions helpers (kernel §2)
+3. **Accolade ouvrante sur la même ligne** (sauf fonctions) — Style Linux/K&R (kernel §3)
+4. **Une ligne vide entre les définitions de fonctions** — Séparation visuelle ; ne jamais empiler des définitions sans respiration
+5. **Les fonctions doivent être courtes** — Faire une seule chose ; tenir sur un ou deux écrans (kernel §6)
+6. **`goto` pour le cleanup centralisé** — Chemin de sortie unique pour la gestion d'erreurs, pas de `if/else` en cascade (kernel §7). Voir [Pattern goto cleanup](goto_cleanup_pattern.fr.md)
+7. **`snake_case` partout** — Fonctions, variables, membres de struct. `UPPER_CASE` uniquement pour les macros (kernel §4)
+8. **Pas de typedef sur les structs** — Exception : handles opaques et pointeurs de fonctions (kernel §5)
+
+## Formatage du code (Clang-Format)
+
+Tous les fichiers C, en-têtes et GLSL sont formatés avec `clang-format`. La configuration se trouve dans `.clang-format` à la racine du dépôt.
+
+### Référence des règles
+
+Chaque règle est associée à sa justification dans le style kernel :
+
+| Option | Valeur | Référence kernel | Effet |
+|--------|--------|-----------------|-------|
+| `BasedOnStyle` | `Google` | — | Style de base (surchargé ci-dessous pour correspondre aux conventions kernel) |
+| `IndentWidth` | `8` | §1 : « Tabs are 8 characters » | Indentation logique de 8 espaces ; décourage le nesting profond |
+| `UseTab` | `ForIndentation` | §1 : « use tabs » | Tabulations pour l'indentation, espaces pour l'alignement |
+| `BreakBeforeBraces` | `Linux` | §3 : « K&R brace placement » | Accolade ouvrante sur la même ligne ; fonctions sur la ligne suivante |
+| `PointerAlignment` | `Left` | §4 : « declare close to the type » | Style `int* p` (convention C) |
+| `ColumnLimit` | `80` | §2 : « the preferred limit is 80 columns » | Retour à la ligne strict à 80 colonnes |
+| `AllowShortFunctionsOnASingleLine` | `None` | §6 : les fonctions doivent être lisibles | Ne jamais compacter les corps de fonctions sur une seule ligne |
+| `SeparateDefinitionBlocks` | `Always` | §1, FreeBSD style(9) | **Impose une ligne vide entre chaque définition de top-level** (fonctions, structs, enums) |
+| `SortIncludes` | `true` | — | Tri alphabétique des includes (GLAD en priorité via `IncludeCategories`) |
+
+### `SeparateDefinitionBlocks`
+
+Cette règle (disponible depuis clang-format 14) garantit une séparation visuelle cohérente entre les définitions de fonctions, les déclarations de structs et les définitions d'enums. Sans elle, `clang-format` ne touche pas à l'espacement entre les définitions — des corps de fonctions adjacents sans ligne vide passent silencieusement.
+
+Avec `Always`, `clang-format` insère automatiquement une ligne vide là où il en manque une, et supprime les doubles lignes vides superflues.
+
+Le noyau Linux applique cette règle par convention lors des revues de code. Le `style(9)` de FreeBSD l'énonce explicitement : *« Use blank lines to separate logical sections of code, including between function definitions. »* Nous l'automatisons via clang-format.
+
+### Application en CI
+
+Le formatage est appliqué en CI par le job `lint-and-format` :
+
+```yaml
+# .github/workflows/main.yml (extrait)
+make format CONTAINER_RUN=""
+git diff --exit-code || (echo "❌ Format error" && exit 1)
+```
+
+Tout fichier qui serait reformaté par `clang-format` fait échouer le job. Exécutez `just format` localement avant de commiter.
 
 ## Stratégie : Clang-Tidy
 

--- a/docs/linting_strategy.md
+++ b/docs/linting_strategy.md
@@ -1,6 +1,75 @@
 # Linting Strategy and Caching
 
-This document outlines the static analysis strategy for the `suckless-ogl` project and the implementation of its high-performance caching mechanism.
+This document outlines the static analysis and formatting strategy for the `suckless-ogl` project and the implementation of its high-performance caching mechanism.
+
+## Coding Style Philosophy
+
+This project follows a coding style heavily inspired by the **Linux kernel** ([`Documentation/process/coding-style.rst`](https://www.kernel.org/doc/html/latest/process/coding-style.html)), adapted for a C11 OpenGL rendering engine.
+
+### Why the Linux Kernel Style?
+
+The kernel style was designed for large-scale C codebases maintained by thousands of contributors over decades. Its rules optimize for **readability at scale**, **grep-ability**, and **minimal cognitive load** — the same qualities we value in this project.
+
+Other notable C conventions we drew from:
+
+| Convention | Origin | Key Takeaway |
+|---|---|---|
+| [**Linux kernel coding style**](https://www.kernel.org/doc/html/latest/process/coding-style.html) | Torvalds, kernel community | Primary inspiration: tabs-8, braces, 80 cols, `goto` cleanup, short functions |
+| [**SEI CERT C**](https://wiki.sei.cmu.edu/confluence/display/c) | Carnegie Mellon SEI | Security-focused rules (MEM, ERR, STR) — enforced via `clang-tidy cert-*` checks |
+| [**FreeBSD style(9)**](https://man.freebsd.org/cgi/man.cgi?query=style&sektion=9) | FreeBSD project | Close to kernel style; explicit about blank lines between functions, `return` without parens |
+| [**SQLite**](https://www.sqlite.org/codeofethics.html) | D. Richard Hipp | 100% branch coverage, `goto` cleanup, self-contained C — a model for quality |
+| [**id Software**](https://github.com/id-Software/Quake-III-Arena) (Quake/Doom) | John Carmack | Pragmatic C for real-time graphics; performance-aware naming and layout |
+
+### Core Principles (from the Kernel)
+
+1. **Indentation = 8 spaces (tabs)** — Forces short nesting; if you need 3+ levels, refactor (kernel §1)
+2. **80-column limit** — Encourages splitting complex expressions and extracting helpers (kernel §2)
+3. **Opening braces on same line** (except functions) — Linux/K&R brace style (kernel §3)
+4. **One blank line between function definitions** — Visual separation; never stack definitions without breathing room
+5. **Functions should be short** — Do one thing; fit on one or two screenfuls (kernel §6)
+6. **`goto` for centralized cleanup** — Single exit path for error handling, not cascading `if/else` (kernel §7). See [goto cleanup Pattern](goto_cleanup_pattern.md)
+7. **`snake_case` everywhere** — Functions, variables, struct members. `UPPER_CASE` for macros only (kernel §4)
+8. **No typedefs on structs** — Exception: opaque handles and function pointers (kernel §5)
+
+## Code Formatting (Clang-Format)
+
+All C, header, and GLSL files are formatted with `clang-format`. The configuration lives in `.clang-format` at the repository root.
+
+### Rule Reference
+
+Each rule is mapped to its kernel style rationale:
+
+| Option | Value | Kernel Reference | Effect |
+|--------|-------|-----------------|--------|
+| `BasedOnStyle` | `Google` | — | Base style (overridden below to match kernel conventions) |
+| `IndentWidth` | `8` | §1: "Tabs are 8 characters" | 8-space logical indentation; discourages deep nesting |
+| `UseTab` | `ForIndentation` | §1: "use tabs" | Tabs for indentation, spaces for alignment |
+| `BreakBeforeBraces` | `Linux` | §3: "K&R brace placement" | Opening brace on same line; functions on next line |
+| `PointerAlignment` | `Left` | §4: "declare close to the type" | `int* p` style (C convention) |
+| `ColumnLimit` | `80` | §2: "the preferred limit is 80 columns" | Hard wrap at 80 columns |
+| `AllowShortFunctionsOnASingleLine` | `None` | §6: functions should be readable | Never collapse function bodies to a single line |
+| `SeparateDefinitionBlocks` | `Always` | §1, FreeBSD style(9) | **Enforce a blank line between every top-level definition** (functions, structs, enums) |
+| `SortIncludes` | `true` | — | Alphabetical include ordering (GLAD first via `IncludeCategories` priority) |
+
+### `SeparateDefinitionBlocks`
+
+This rule (available since clang-format 14) ensures consistent visual separation between function definitions, struct declarations, and enum definitions. Without it, `clang-format` leaves inter-definition spacing untouched — adjacent function bodies with no blank line in between pass silently.
+
+With `Always`, `clang-format` automatically inserts a blank line wherever one is missing, and removes double blank lines where they are excessive.
+
+The Linux kernel enforces this by convention during code review. FreeBSD's `style(9)` states it explicitly: *"Use blank lines to separate logical sections of code, including between function definitions."* We automate it via clang-format.
+
+### CI Enforcement
+
+Formatting is enforced in CI by the `lint-and-format` job:
+
+```yaml
+# .github/workflows/main.yml (excerpt)
+make format CONTAINER_RUN=""
+git diff --exit-code || (echo "❌ Format error" && exit 1)
+```
+
+Any file that would be reformatted by `clang-format` causes the job to fail. Run `just format` locally before committing.
 
 ## Strategy: Clang-Tidy
 

--- a/include/app_settings.h
+++ b/include/app_settings.h
@@ -86,6 +86,7 @@ enum {
 	/** Starting subdivision level when the app launches. */
 	INITIAL_SUBDIVISIONS = 3
 };
+
 /** @} */
 
 /**
@@ -146,6 +147,7 @@ static const int BRDF_LUT_MAP_SIZE =
     512; /**< Size of the BRDF Lookup Texture (Generated once). */
 static const int DEFAULT_SPECULAR_AA_ENABLED =
     1; /**< Toggle for Curvature-based Specular Anti-Aliasing. */
+
 /* Environment Transition Mode */
 typedef enum {
 	ENV_TRANSITION_CROSSFADE = 0,

--- a/include/app_ui_layout.h
+++ b/include/app_ui_layout.h
@@ -98,6 +98,7 @@ static const float UI_SPINNER_SIZE = 64.0F;
 static const float UI_TEXT_OFFSET_FACTOR = 0.8F;
 static const vec3 UI_SPINNER_COLOR = {90.0F / 255.0F, 111.0F / 255.0F,
                                       185.0F / 255.0F};
+
 enum { UI_LOADING_TEXT_SIZE = 64 };
 
 /* ================================================================

--- a/include/effect_benchmark.h
+++ b/include/effect_benchmark.h
@@ -78,6 +78,7 @@ typedef struct EffectBenchmark {
 		const char* name;
 		unsigned int bit;
 	} effects[BENCH_MAX_EFFECTS];
+
 	int effect_count;
 
 	/* Current sweep position */

--- a/include/light_probes.h
+++ b/include/light_probes.h
@@ -11,6 +11,7 @@ typedef struct SphereInstance SphereInstance;
 /** @brief Number of 3D textures used for packing SH coefficients (7 = 28
  * channels for 9 L2 coeffs) */
 enum { SH_TEXTURE_COUNT = 7 };
+
 /** @brief Starting texture unit for SH 3D textures */
 enum { TEXTURE_UNIT_SH_START = 8 };
 

--- a/include/scene_gpu_resources.h
+++ b/include/scene_gpu_resources.h
@@ -13,6 +13,7 @@
 #include "light_probes.h" /* SH_TEXTURE_COUNT */
 
 enum { IBL_TEXTURE_COUNT = 3 };
+
 enum { TEXTURE_UNIT_IBL_START = 15 };
 
 /**

--- a/include/scene_uniforms.h
+++ b/include/scene_uniforms.h
@@ -56,6 +56,7 @@ typedef struct {
  * @note Must match layout(std140, binding = 1) in billboard_ubo.glsl.
  */
 enum { MAT4_FLOAT_COUNT = 16 };
+
 typedef struct {
 	float projection[MAT4_FLOAT_COUNT]; /**< mat4 projection (offset   0) */
 	float view[MAT4_FLOAT_COUNT];       /**< mat4 view       (offset  64) */

--- a/shaders/background.frag
+++ b/shaders/background.frag
@@ -8,6 +8,7 @@ layout(binding = 0) uniform sampler2D environmentMap;
 layout(location = 4) uniform float blur_lod;
 
 const vec2 invAtan = vec2(0.1591, 0.3183);
+
 vec2 SampleEquirectangular(vec3 v)
 {
 	float phi = (abs(v.z) < 1e-5 && abs(v.x) < 1e-5) ? 0.0 : atan(v.z, v.x);

--- a/src/app.c
+++ b/src/app.c
@@ -492,6 +492,7 @@ void app_update(App* app)
 	                              app->postprocess, app->delta_time,
 	                              app->frame_count);
 }
+
 AppInputContext app_input_ctx_from_app(App* app)
 {
 	return (AppInputContext){

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -361,7 +361,9 @@ static bool handle_f_key_input(AppInputContext* ctx, int key, int mods)
 			if (!check_flag(mods, GLFW_MOD_SHIFT)) {
 				return false;
 			}
+
 			enum { FILENAME_BUF_SIZE = 64 };
+
 			char filename[FILENAME_BUF_SIZE];
 			time_t now = time(NULL);
 			struct tm* time_info = localtime(&now);

--- a/src/billboard_sorting.c
+++ b/src/billboard_sorting.c
@@ -11,16 +11,24 @@
 
 /* Verify that C struct matches the GLSL layout (128 bytes). */
 enum { EXPECTED_SPHERE_INSTANCE_SIZE = 128 };
+
 _Static_assert(sizeof(SphereInstance) == EXPECTED_SPHERE_INSTANCE_SIZE,
                "SphereInstance size must match GLSL std430 layout (128 B)");
 
 enum { WORKGROUP_SIZE = 1024 };
+
 enum { DEFAULT_MIN_CAPACITY = 64 };
+
 enum { MAX_SINGLE_PASS_COUNT = 1024 };
+
 enum { RADIX_BITS_PER_PASS = 8 };
+
 enum { RADIX_BUCKETS = 256 };
+
 enum { RADIX_SHIFT_LIMIT = 32 };
+
 enum { RADIX_MASK = 0xFFU };
+
 static const uint32_t FLOAT_SIGN_MASK = 0x80000000U;
 static const uint32_t FLOAT_COMPLEMENT_MASK = 0xFFFFFFFFU;
 
@@ -307,6 +315,7 @@ GLuint billboard_sorter_sort_gpu(BillboardSorter* sorter,
 
 	return sorter->sorted_instance_ssbo;
 }
+
 static int compare_sphere_entries(const void* lhs, const void* rhs)
 {
 	const BillboardSortEntry* entry_lhs = (const BillboardSortEntry*)lhs;
@@ -375,6 +384,7 @@ static inline uint32_t float_to_sortable_uint(float f_val)
 		float float_val;
 		uint32_t uint_val;
 	} val_conv;
+
 	val_conv.float_val = f_val;
 	uint32_t mask = (val_conv.uint_val & FLOAT_SIGN_MASK)
 	                    ? FLOAT_COMPLEMENT_MASK
@@ -403,6 +413,7 @@ GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* sorter,
 		float depth = glm_vec3_distance2((float*)instances[i].model[3],
 		                                 (float*)camera_pos);
 		sorter->entries[i].original_index = i;
+
 		/* Write sortable key into the depth field via union to avoid
 		 * strict aliasing issues (same approach as
 		 * float_to_sortable_uint). */
@@ -410,6 +421,7 @@ GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* sorter,
 			float f;
 			uint32_t u;
 		} pun;
+
 		pun.u = float_to_sortable_uint(depth);
 		sorter->entries[i].depth = pun.f;
 	}
@@ -426,6 +438,7 @@ GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* sorter,
 				float f;
 				uint32_t u;
 			} pun;
+
 			pun.f = current_in[i].depth;
 			counts[((unsigned int)pun.u >> (unsigned int)shift) &
 			       (unsigned int)RADIX_MASK]++;
@@ -445,6 +458,7 @@ GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* sorter,
 				float f;
 				uint32_t u;
 			} pun;
+
 			pun.f = current_in[i].depth;
 			unsigned int bucket =
 			    ((unsigned int)pun.u >> (unsigned int)shift) &

--- a/src/ibl_coordinator.c
+++ b/src/ibl_coordinator.c
@@ -62,6 +62,7 @@ static int ibl_irradiance_slices(void)
 	}
 	return IBL_IRRADIANCE_HARDWARE_SLICES;
 }
+
 static int ibl_specular_mip0_slices(void)
 {
 	if (is_software_renderer()) {
@@ -69,6 +70,7 @@ static int ibl_specular_mip0_slices(void)
 	}
 	return IBL_SPECULAR_MIP0_HARDWARE_SLICES;
 }
+
 static int ibl_specular_mip1_slices(void)
 {
 	if (is_software_renderer()) {
@@ -76,6 +78,7 @@ static int ibl_specular_mip1_slices(void)
 	}
 	return IBL_SPECULAR_MIP1_HARDWARE_SLICES;
 }
+
 static int ibl_specular_mips_grouping_start(void)
 {
 	if (is_software_renderer()) {

--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -49,12 +49,14 @@
  * Beyond this, form factor < 0.0025 — negligible. */
 #define GI_MAX_DIST_RADII 3.0F
 #define GI_EPSILON 0.000001F
+
 enum {
 	GI_DEBUG_PROBE_VERTICES = 6,
 	GI_WIRE_CUBE_VERTICES = 24,
 	GI_LOG_BUF_SIZE = 128,
 	GI_SMALL_LOG_BUF_SIZE = 64
 };
+
 #define GI_HALF 0.5F
 #define GI_ZERO 0.0F
 

--- a/src/material.c
+++ b/src/material.c
@@ -13,6 +13,7 @@
 // Constantes pour les limites
 
 enum { MAX_MATERIAL_CONFIG_SIZE = 2 * 1024 * 1024 };
+
 // Constantes en enum au lieu de defines
 enum { MAX_MATERIAL_COUNT = 10000, RGB_COMPONENTS = 3 };
 

--- a/src/perf_timer.c
+++ b/src/perf_timer.c
@@ -224,6 +224,7 @@ HybridTimer perf_hybrid_start(void)
 
 	return timer_struct;
 }
+
 /*
  * X-macro: generates the perf_hybrid_stop body parameterized by log level.
  * The log_fn argument is resolved at compile time (LOG_INFO or LOG_DEBUG),

--- a/src/platform/platform_fs.c
+++ b/src/platform/platform_fs.c
@@ -57,6 +57,7 @@ bool platform_dir_list(const char* path, PlatformDirCallback callback,
 #endif
 				// Fallback to stat if d_type is not available
 				enum { MAX_PATH_SIZE = 1024 };
+
 				char full_path[MAX_PATH_SIZE];
 				if (safe_snprintf(full_path, sizeof(full_path),
 				                  "%s/%s", path,

--- a/src/postprocess_apply.c
+++ b/src/postprocess_apply.c
@@ -371,6 +371,7 @@ void postprocess_end(PostProcess* post_processing)
 				float time;
 			} header = {post_processing->active_effects,
 			            post_processing->time};
+
 			glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(header),
 			                &header);
 		}

--- a/src/render_utils.c
+++ b/src/render_utils.c
@@ -126,6 +126,7 @@ void render_utils_create_wire_quad_vbo(GLuint* vbo)
 void render_utils_create_fullscreen_quad(GLuint* vao, GLuint* vbo)
 {
 	enum { TEX_COORD_OFFSET = 8 };
+
 	static const float
 	    screen_quad_vertices[SCREEN_QUAD_VERTEX_COUNT * (2 + 2)] = {
 	        /* positions     texCoords */

--- a/src/scene_init.c
+++ b/src/scene_init.c
@@ -305,6 +305,7 @@ static int scene_init_billboard_shader(Scene* scene)
 		shader_use(scene->shaders->pbr_billboard);
 		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 			enum { MAX_UNIFORM_NAME_LEN = 32 };
+
 			char name[MAX_UNIFORM_NAME_LEN];
 			(void)safe_snprintf(name, sizeof(name), "u_SHTexture%d",
 			                    i);
@@ -395,6 +396,7 @@ static int scene_init_instanced_shader(Scene* scene, Shader** out_shader)
 		shader_use(*out_shader);
 		for (int i = 0; i < SH_TEXTURE_COUNT; i++) {
 			enum { MAX_UNIFORM_NAME_LEN = 32 };
+
 			char name[MAX_UNIFORM_NAME_LEN];
 			(void)safe_snprintf(name, sizeof(name), "u_SHTexture%d",
 			                    i);

--- a/src/sh_math.c
+++ b/src/sh_math.c
@@ -119,4 +119,5 @@ void sh_eval_irradiance(const vec3 normal, const SH9* sh_ptr, vec3 out_color)
 	glm_vec3_muladds((float*)sh_ptr->coeffs[7], A2 * c21, out_color);
 	glm_vec3_muladds((float*)sh_ptr->coeffs[8], A2 * c22, out_color);
 }
+
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/src/shader.c
+++ b/src/shader.c
@@ -58,10 +58,14 @@ typedef struct {
 } IncludeContext;
 
 enum { MAX_INCLUDE_DEPTH = 16 };
+
 /* 16MB limit for shader source to prevent abuse/taint issues */
 enum { MAX_SHADER_SOURCE_SIZE = 16 * 1024 * 1024 };
+
 enum { PATH_BUFFER_SIZE = 256 };
+
 enum { RESOLVED_PATH_BUFFER_SIZE = 512 };
+
 enum { HEADER_TAG_LEN = 7 };
 
 /* Forward declaration */

--- a/src/simd_utils.c
+++ b/src/simd_utils.c
@@ -85,6 +85,7 @@ static uint16_t float_to_half_soft(float value)
 		float f;
 		uint32_t u;
 	} val_union;
+
 	val_union.f = value;
 
 	/* Align sign bit for half (bit 15) */

--- a/src/tracy_manager.c
+++ b/src/tracy_manager.c
@@ -237,26 +237,31 @@ void tracy_manager_async_end(TracyManager* mgr)
 void tracy_manager_init_global(void)
 {
 }
+
 void tracy_manager_init(TracyManager* mgr, int width, int height)
 {
 	(void)mgr;
 	(void)width;
 	(void)height;
 }
+
 void tracy_manager_cleanup(TracyManager* mgr)
 {
 	(void)mgr;
 }
+
 void tracy_manager_update_screenshots(TracyManager* mgr, App* app)
 {
 	(void)mgr;
 	(void)app;
 }
+
 void tracy_manager_async_transition(TracyManager* mgr, AsyncState new_state)
 {
 	(void)mgr;
 	(void)new_state;
 }
+
 void tracy_manager_async_end(TracyManager* mgr)
 {
 	(void)mgr;

--- a/tests/fixtures/includes/invalid.glsl
+++ b/tests/fixtures/includes/invalid.glsl
@@ -1,5 +1,6 @@
 #version 330 core
 @header no_quotes.glsl;
+
 void main()
 {
 }

--- a/tests/fixtures/includes/loop.glsl
+++ b/tests/fixtures/includes/loop.glsl
@@ -1,5 +1,6 @@
 #version 330 core
 @header "loop.glsl";
+
 void main()
 {
 }

--- a/tests/fixtures/includes/test_main.glsl
+++ b/tests/fixtures/includes/test_main.glsl
@@ -1,5 +1,6 @@
 // Main shader
 @header "subdir/helper.glsl";
+
 void main()
 {
 	helper();

--- a/tests/mocks/GLFW/glfw3.h
+++ b/tests/mocks/GLFW/glfw3.h
@@ -3,6 +3,7 @@
 
 typedef void GLFWwindow;
 typedef struct GLFWmonitor GLFWmonitor;
+
 typedef struct GLFWvidmode {
 	int width;
 	int height;

--- a/tests/mocks/standalone/mock_gl_standalone.c
+++ b/tests/mocks/standalone/mock_gl_standalone.c
@@ -32,30 +32,37 @@ GLuint mock_gl_get_generated_buffer_id(void)
 {
 	return g_generated_buffer_id;
 }
+
 GLuint mock_gl_get_generated_vao_id(void)
 {
 	return DEFAULT_VAO_ID;
 }
+
 GLuint mock_gl_get_last_deleted_buffer(void)
 {
 	return g_last_deleted_buffer;
 }
+
 int mock_gl_get_delete_buffer_call_count(void)
 {
 	return g_delete_buffer_call_count;
 }
+
 int mock_gl_get_buffer_data_call_count(void)
 {
 	return g_buffer_data_call_count;
 }
+
 int mock_gl_get_buffer_sub_data_call_count(void)
 {
 	return g_buffer_sub_data_call_count;
 }
+
 GLsizeiptr mock_gl_get_last_buffer_data_size(void)
 {
 	return g_last_buffer_data_size;
 }
+
 GLsizeiptr mock_gl_get_last_buffer_sub_data_size(void)
 {
 	return g_last_buffer_sub_data_size;
@@ -69,27 +76,32 @@ void glActiveTexture(GLenum texture)
 {
 	(void)texture;
 }
+
 void glGenTextures(GLsizei n, GLuint* textures)
 {
 	for (int i = 0; i < n; i++)
 		if (textures)
 			textures[i] = (GLuint)(i + 1);
 }
+
 void glDeleteTextures(GLsizei n, const GLuint* textures)
 {
 	(void)n;
 	(void)textures;
 }
+
 void glBindTexture(GLenum target, GLuint texture)
 {
 	(void)target;
 	(void)texture;
 }
+
 void glPixelStorei(GLenum pname, GLint param)
 {
 	(void)pname;
 	(void)param;
 }
+
 void glTexStorage2D(GLenum target, GLsizei levels, GLenum internalformat,
                     GLsizei width, GLsizei height)
 {
@@ -99,6 +111,7 @@ void glTexStorage2D(GLenum target, GLsizei levels, GLenum internalformat,
 	(void)width;
 	(void)height;
 }
+
 void glTexImage2D(GLenum target, GLint level, GLint internalformat,
                   GLsizei width, GLsizei height, GLint border, GLenum format,
                   GLenum type, const void* pixels)
@@ -113,6 +126,7 @@ void glTexImage2D(GLenum target, GLint level, GLint internalformat,
 	(void)type;
 	(void)pixels;
 }
+
 void glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                      GLsizei width, GLsizei height, GLenum format, GLenum type,
                      const void* pixels)
@@ -127,6 +141,7 @@ void glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
 	(void)type;
 	(void)pixels;
 }
+
 void glTexImage3D(GLenum target, GLint level, GLint internalformat,
                   GLsizei width, GLsizei height, GLsizei depth, GLint border,
                   GLenum format, GLenum type, const void* pixels)
@@ -142,6 +157,7 @@ void glTexImage3D(GLenum target, GLint level, GLint internalformat,
 	(void)type;
 	(void)pixels;
 }
+
 void glTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                      GLint zoffset, GLsizei width, GLsizei height,
                      GLsizei depth, GLenum format, GLenum type,
@@ -159,25 +175,30 @@ void glTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
 	(void)type;
 	(void)pixels;
 }
+
 void glTexParameteri(GLenum target, GLenum pname, GLint param)
 {
 	(void)target;
 	(void)pname;
 	(void)param;
 }
+
 void glGenerateMipmap(GLenum target)
 {
 	(void)target;
 }
+
 GLenum glGetError(void)
 {
 	return 0;
 }
+
 const GLchar* glGetString(GLenum name)
 {
 	(void)name;
 	return "Mock GL";
 }
+
 void glGetIntegerv(GLenum pname, GLint* data)
 {
 	if (data) {
@@ -189,6 +210,7 @@ void glGetIntegerv(GLenum pname, GLint* data)
 		}
 	}
 }
+
 void glGetTexLevelParameteriv(GLenum target, GLint level, GLenum pname,
                               GLint* params)
 {
@@ -205,11 +227,13 @@ void glGenBuffers(GLsizei n, GLuint* buffers)
 	if (buffers)
 		*buffers = g_generated_buffer_id;
 }
+
 void glBindBuffer(GLenum target, GLuint buffer)
 {
 	(void)target;
 	(void)buffer;
 }
+
 void glBufferData(GLenum target, GLsizeiptr size, const void* data,
                   GLenum usage)
 {
@@ -219,6 +243,7 @@ void glBufferData(GLenum target, GLsizeiptr size, const void* data,
 	g_buffer_data_call_count++;
 	g_last_buffer_data_size = size;
 }
+
 void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
                      const void* data)
 {
@@ -228,6 +253,7 @@ void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
 	g_buffer_sub_data_call_count++;
 	g_last_buffer_sub_data_size = size;
 }
+
 void glDeleteBuffers(GLsizei n, const GLuint* buffers)
 {
 	if (buffers) {
@@ -236,6 +262,7 @@ void glDeleteBuffers(GLsizei n, const GLuint* buffers)
 	}
 	(void)n;
 }
+
 void glBufferStorage(GLenum target, GLsizeiptr size, const void* data,
                      GLbitfield flags)
 {
@@ -244,12 +271,14 @@ void glBufferStorage(GLenum target, GLsizeiptr size, const void* data,
 	(void)data;
 	(void)flags;
 }
+
 void glBindBufferBase(GLenum target, GLuint index, GLuint buffer)
 {
 	(void)target;
 	(void)index;
 	(void)buffer;
 }
+
 void glCopyBufferSubData(GLenum readTarget, GLenum writeTarget,
                          GLintptr readOffset, GLintptr writeOffset,
                          GLsizeiptr size)
@@ -260,6 +289,7 @@ void glCopyBufferSubData(GLenum readTarget, GLenum writeTarget,
 	(void)writeOffset;
 	(void)size;
 }
+
 void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
                         void* data)
 {
@@ -269,6 +299,7 @@ void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
 	if (data)
 		*(float*)data = 1.0f;
 }
+
 void* glMapBuffer(GLenum target, GLenum access)
 {
 	(void)target;
@@ -276,6 +307,7 @@ void* glMapBuffer(GLenum target, GLenum access)
 	static char buf[1024];
 	return buf;
 }
+
 void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
                        GLbitfield access)
 {
@@ -286,6 +318,7 @@ void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
 	static char buf[1024];
 	return buf;
 }
+
 GLboolean glUnmapBuffer(GLenum target)
 {
 	(void)target;
@@ -298,23 +331,28 @@ void glGenVertexArrays(GLsizei n, GLuint* arrays)
 	if (arrays)
 		*arrays = DEFAULT_VAO_ID;
 }
+
 void glDeleteVertexArrays(GLsizei n, const GLuint* arrays)
 {
 	(void)n;
 	(void)arrays;
 }
+
 void glBindVertexArray(GLuint array)
 {
 	(void)array;
 }
+
 void glEnableVertexAttribArray(GLuint index)
 {
 	(void)index;
 }
+
 void glDisableVertexAttribArray(GLuint index)
 {
 	(void)index;
 }
+
 void glVertexAttribPointer(GLuint index, GLint size, GLenum type,
                            GLboolean normalized, GLsizei stride,
                            const void* pointer)
@@ -326,11 +364,13 @@ void glVertexAttribPointer(GLuint index, GLint size, GLenum type,
 	(void)stride;
 	(void)pointer;
 }
+
 void glVertexAttrib4fv(GLuint index, const GLfloat* v)
 {
 	(void)index;
 	(void)v;
 }
+
 void glVertexAttribDivisor(GLuint index, GLuint divisor)
 {
 	(void)index;
@@ -343,6 +383,7 @@ void glDrawArrays(GLenum mode, GLint first, GLsizei count)
 	(void)first;
 	(void)count;
 }
+
 void glDrawElements(GLenum mode, GLsizei count, GLenum type,
                     const void* indices)
 {
@@ -351,6 +392,7 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type,
 	(void)type;
 	(void)indices;
 }
+
 void glDrawArraysInstanced(GLenum mode, GLint first, GLsizei count,
                            GLsizei instancecount)
 {
@@ -359,6 +401,7 @@ void glDrawArraysInstanced(GLenum mode, GLint first, GLsizei count,
 	(void)count;
 	(void)instancecount;
 }
+
 void glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type,
                              const void* indices, GLsizei instancecount)
 {
@@ -374,6 +417,7 @@ uint32_t glCreateShader(GLenum type)
 	(void)type;
 	return 1;
 }
+
 void glShaderSource(GLuint shader, GLsizei count, const char* const* string,
                     const GLint* length)
 {
@@ -382,10 +426,12 @@ void glShaderSource(GLuint shader, GLsizei count, const char* const* string,
 	(void)string;
 	(void)length;
 }
+
 void glCompileShader(GLuint shader)
 {
 	(void)shader;
 }
+
 void glGetShaderiv(GLuint shader, GLenum pname, GLint* params)
 {
 	(void)shader;
@@ -393,6 +439,7 @@ void glGetShaderiv(GLuint shader, GLenum pname, GLint* params)
 	if (params)
 		*params = GL_TRUE;
 }
+
 void glGetShaderInfoLog(GLuint shader, GLsizei bufSize, GLsizei* length,
                         GLchar* infoLog)
 {
@@ -403,6 +450,7 @@ void glGetShaderInfoLog(GLuint shader, GLsizei bufSize, GLsizei* length,
 	if (infoLog)
 		infoLog[0] = '\0';
 }
+
 void glDeleteShader(GLuint shader)
 {
 	(void)shader;
@@ -412,15 +460,18 @@ uint32_t glCreateProgram(void)
 {
 	return 1;
 }
+
 void glAttachShader(GLuint program, GLuint shader)
 {
 	(void)program;
 	(void)shader;
 }
+
 void glLinkProgram(GLuint program)
 {
 	(void)program;
 }
+
 void glGetProgramiv(GLuint program, GLenum pname, GLint* params)
 {
 	(void)program;
@@ -428,6 +479,7 @@ void glGetProgramiv(GLuint program, GLenum pname, GLint* params)
 	if (params)
 		*params = GL_TRUE;
 }
+
 void glGetProgramInfoLog(GLuint program, GLsizei bufSize, GLsizei* length,
                          GLchar* infoLog)
 {
@@ -438,10 +490,12 @@ void glGetProgramInfoLog(GLuint program, GLsizei bufSize, GLsizei* length,
 	if (infoLog)
 		infoLog[0] = '\0';
 }
+
 void glUseProgram(GLuint program)
 {
 	(void)program;
 }
+
 void glDeleteProgram(GLuint program)
 {
 	(void)program;
@@ -453,28 +507,33 @@ GLint glGetUniformLocation(GLuint program, const GLchar* name)
 	(void)name;
 	return 0;
 }
+
 void glUniform1i(GLint location, GLint v0)
 {
 	(void)location;
 	(void)v0;
 }
+
 void glUniform1iv(GLint location, GLsizei count, const GLint* value)
 {
 	(void)location;
 	(void)count;
 	(void)value;
 }
+
 void glUniform1f(GLint location, GLfloat v0)
 {
 	(void)location;
 	(void)v0;
 }
+
 void glUniform2f(GLint location, GLfloat v0, GLfloat v1)
 {
 	(void)location;
 	(void)v0;
 	(void)v1;
 }
+
 void glUniform3f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2)
 {
 	(void)location;
@@ -482,6 +541,7 @@ void glUniform3f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2)
 	(void)v1;
 	(void)v2;
 }
+
 void glUniform4f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3)
 {
 	(void)location;
@@ -490,6 +550,7 @@ void glUniform4f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3)
 	(void)v2;
 	(void)v3;
 }
+
 void glUniform3i(GLint location, GLint v0, GLint v1, GLint v2)
 {
 	(void)location;
@@ -497,29 +558,34 @@ void glUniform3i(GLint location, GLint v0, GLint v1, GLint v2)
 	(void)v1;
 	(void)v2;
 }
+
 void glUniform1ui(GLint location, GLuint v0)
 {
 	(void)location;
 	(void)v0;
 }
+
 void glUniform2fv(GLint location, GLsizei count, const GLfloat* value)
 {
 	(void)location;
 	(void)count;
 	(void)value;
 }
+
 void glUniform3fv(GLint location, GLsizei count, const GLfloat* value)
 {
 	(void)location;
 	(void)count;
 	(void)value;
 }
+
 void glUniform4fv(GLint location, GLsizei count, const GLfloat* value)
 {
 	(void)location;
 	(void)count;
 	(void)value;
 }
+
 void glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
                         const GLfloat* value)
 {
@@ -533,34 +599,41 @@ void glEnable(GLenum cap)
 {
 	(void)cap;
 }
+
 void glDisable(GLenum cap)
 {
 	(void)cap;
 }
+
 GLboolean glIsEnabled(GLenum cap)
 {
 	(void)cap;
 	return GL_FALSE;
 }
+
 void glPolygonMode(GLenum face, GLenum mode)
 {
 	(void)face;
 	(void)mode;
 }
+
 void glBlendFunc(GLenum sfactor, GLenum dfactor)
 {
 	(void)sfactor;
 	(void)dfactor;
 }
+
 GLenum glCheckFramebufferStatus(GLenum target)
 {
 	(void)target;
 	return GL_FRAMEBUFFER_COMPLETE;
 }
+
 void glClear(GLbitfield mask)
 {
 	(void)mask;
 }
+
 void glClearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
 {
 	(void)red;
@@ -568,6 +641,7 @@ void glClearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
 	(void)blue;
 	(void)alpha;
 }
+
 void glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
 {
 	(void)x;
@@ -582,16 +656,19 @@ void glGenQueries(GLsizei n, GLuint* ids)
 		if (ids)
 			ids[i] = (GLuint)(i + 1);
 }
+
 void glDeleteQueries(GLsizei n, const GLuint* ids)
 {
 	(void)n;
 	(void)ids;
 }
+
 void glQueryCounter(GLuint id, GLenum target)
 {
 	(void)id;
 	(void)target;
 }
+
 void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params)
 {
 	(void)id;
@@ -599,6 +676,7 @@ void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params)
 	if (params)
 		*params = 1000;
 }
+
 void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params)
 {
 	(void)id;
@@ -610,6 +688,7 @@ void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params)
 void glFlush(void)
 {
 }
+
 void glFinish(void)
 {
 }
@@ -621,10 +700,12 @@ void glDispatchCompute(GLuint num_groups_x, GLuint num_groups_y,
 	(void)num_groups_y;
 	(void)num_groups_z;
 }
+
 void glMemoryBarrier(GLbitfield barriers)
 {
 	(void)barriers;
 }
+
 void glBindImageTexture(GLuint unit, GLuint texture, GLint level,
                         GLboolean layered, GLint layer, GLenum access,
                         GLenum format)
@@ -646,9 +727,11 @@ void glPushDebugGroup(GLenum source, GLuint id, GLsizei length,
 	(void)length;
 	(void)message;
 }
+
 void glPopDebugGroup(void)
 {
 }
+
 void glObjectLabel(GLenum identifier, GLuint name, GLsizei length,
                    const GLchar* label)
 {
@@ -657,6 +740,7 @@ void glObjectLabel(GLenum identifier, GLuint name, GLsizei length,
 	(void)length;
 	(void)label;
 }
+
 void glGetActiveUniform(GLuint program, GLuint index, GLsizei bufSize,
                         GLsizei* length, GLint* size, GLenum* type,
                         GLchar* name)
@@ -681,6 +765,7 @@ GLsync glFenceSync(GLenum condition, GLbitfield flags)
 	static int s;
 	return (GLsync)&s;
 }
+
 GLenum glClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout)
 {
 	(void)sync;
@@ -688,6 +773,7 @@ GLenum glClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout)
 	(void)timeout;
 	return GL_CONDITION_SATISFIED;
 }
+
 void glDeleteSync(GLsync sync)
 {
 	(void)sync;
@@ -706,33 +792,39 @@ void glDepthMask(GLboolean flag)
 {
 	(void)flag;
 }
+
 void glEnablei(GLenum target, GLuint index)
 {
 	(void)target;
 	(void)index;
 }
+
 void glDisablei(GLenum target, GLuint index)
 {
 	(void)target;
 	(void)index;
 }
+
 void glPolygonOffset(GLfloat factor, GLfloat units)
 {
 	(void)factor;
 	(void)units;
 }
+
 void glStencilOp(GLenum sfail, GLenum dpfail, GLenum dppass)
 {
 	(void)sfail;
 	(void)dpfail;
 	(void)dppass;
 }
+
 void glStencilFunc(GLenum func, GLint ref, GLuint mask)
 {
 	(void)func;
 	(void)ref;
 	(void)mask;
 }
+
 void glStencilMask(GLuint mask)
 {
 	(void)mask;

--- a/tests/mocks/standalone/mock_gpu_profiler.c
+++ b/tests/mocks/standalone/mock_gpu_profiler.c
@@ -4,20 +4,24 @@ void gpu_profiler_init(GPUProfiler* profiler)
 {
 	(void)profiler;
 }
+
 void gpu_profiler_cleanup(GPUProfiler* profiler)
 {
 	(void)profiler;
 }
+
 void gpu_profiler_begin_frame(GPUProfiler* profiler, uint64_t frame_index)
 {
 	(void)profiler;
 	(void)frame_index;
 }
+
 void gpu_profiler_set_enabled(GPUProfiler* profiler, bool enabled)
 {
 	(void)profiler;
 	(void)enabled;
 }
+
 void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
                               uint32_t color)
 {
@@ -25,10 +29,12 @@ void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
 	(void)name;
 	(void)color;
 }
+
 void gpu_profiler_end_stage(GPUProfiler* profiler)
 {
 	(void)profiler;
 }
+
 void gpu_profiler_reset_samplers(GPUProfiler* profiler, double current_time)
 {
 	(void)profiler;

--- a/tests/mocks/standalone/mock_log.c
+++ b/tests/mocks/standalone/mock_log.c
@@ -12,14 +12,17 @@ void log_message(LogLevel level, const char* tag, const char* format, ...)
 	va_end(args);
 	printf("\n");
 }
+
 void log_set_callback(LogCallback callback)
 {
 	(void)callback;
 }
+
 void log_set_level(LogLevel level)
 {
 	(void)level;
 }
+
 LogLevel log_get_level(void)
 {
 	return LOG_LEVEL_DEBUG;

--- a/tests/test_adaptive_sampler_frames.c
+++ b/tests/test_adaptive_sampler_frames.c
@@ -5,6 +5,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_app_metrics.c
+++ b/tests/test_app_metrics.c
@@ -34,6 +34,7 @@ static void setup_mock_profiler(GPUProfiler* profiler)
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }
@@ -94,6 +95,7 @@ void test_app_metrics_log_gpu_stats_no_samples(void)
 
 /* Global buffer for log interception */
 static char g_last_log[2048];
+
 static void mock_log_callback(LogLevel level, const char* tag,
                               const char* message)
 {

--- a/tests/test_async_coordinator.c
+++ b/tests/test_async_coordinator.c
@@ -111,6 +111,7 @@ void* texture_map_pbo(GLuint pbo, size_t size)
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_async_loader.c
+++ b/tests/test_async_loader.c
@@ -61,6 +61,7 @@ void tracy_manager_async_transition(struct TracyManager* mgr, AsyncState state)
 	(void)mgr;
 	(void)state;
 }
+
 void tracy_manager_async_end(struct TracyManager* mgr)
 {
 	(void)mgr;
@@ -73,16 +74,19 @@ void glGenQueries(GLsizei n, GLuint* ids)
 		ids[i] = 300 + i;
 	}
 }
+
 void glDeleteQueries(GLsizei n, const GLuint* ids)
 {
 	(void)n;
 	(void)ids;
 }
+
 void glQueryCounter(GLuint id, GLenum target)
 {
 	(void)id;
 	(void)target;
 }
+
 void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params)
 {
 	(void)id;
@@ -91,6 +95,7 @@ void glGetQueryObjectiv(GLuint id, GLenum pname, GLint* params)
 		*params = 1;
 	}
 }
+
 void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params)
 {
 	(void)id;
@@ -99,9 +104,11 @@ void glGetQueryObjectui64v(GLuint id, GLenum pname, GLuint64* params)
 		*params = 1000;
 	}
 }
+
 void glFlush(void)
 {
 }
+
 void glFinish(void)
 {
 }
@@ -114,6 +121,7 @@ void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
 	(void)name;
 	(void)color;
 }
+
 void gpu_profiler_end_stage(GPUProfiler* profiler)
 {
 	(void)profiler;

--- a/tests/test_benchmark_adaptive_sampler.c
+++ b/tests/test_benchmark_adaptive_sampler.c
@@ -18,6 +18,7 @@ static const int MODULO_DIVISOR = 10;
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_benchmark_billboard_sorting.c
+++ b/tests/test_benchmark_billboard_sorting.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 
 enum { TEST_INITIAL_CAPACITY = 1024 };
+
 enum { TEST_COUNT = 1000 };
 
 int main()

--- a/tests/test_benchmark_billboard_sorting_perf.c
+++ b/tests/test_benchmark_billboard_sorting_perf.c
@@ -10,6 +10,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_billboard_sorting.c
+++ b/tests/test_billboard_sorting.c
@@ -22,6 +22,7 @@ static const float TOLERANCE = 0.01F;
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_camera_input.c
+++ b/tests/test_camera_input.c
@@ -7,6 +7,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_fps.c
+++ b/tests/test_fps.c
@@ -10,6 +10,7 @@ static const double ONE_SECOND = 1.0;
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_gamepad_input.c
+++ b/tests/test_gamepad_input.c
@@ -79,6 +79,7 @@ void setUp(void)
 {
 	mock_gamepad_reset();
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_gpu_profiler_repro.c
+++ b/tests/test_gpu_profiler_repro.c
@@ -15,6 +15,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_ibl_coordinator.c
+++ b/tests/test_ibl_coordinator.c
@@ -37,16 +37,19 @@ void perf_timer_start(PerfTimer* timer)
 {
 	(void)timer;
 }
+
 double perf_timer_elapsed_ms(PerfTimer* timer)
 {
 	(void)timer;
 	return TEST_ELAPSED_MS;
 }
+
 double perf_timer_elapsed_us(PerfTimer* timer)
 {
 	(void)timer;
 	return TEST_ELAPSED_US;
 }
+
 double perf_timer_elapsed_s(PerfTimer* timer)
 {
 	(void)timer;
@@ -58,16 +61,19 @@ void gpu_timer_start(GPUTimer* timer)
 {
 	(void)timer;
 }
+
 void gpu_timer_stop(GPUTimer* timer)
 {
 	(void)timer;
 }
+
 double gpu_timer_elapsed_ms(GPUTimer* timer, int wait)
 {
 	(void)timer;
 	(void)wait;
 	return TEST_GPU_MS;
 }
+
 void gpu_timer_cleanup(GPUTimer* timer)
 {
 	(void)timer;
@@ -79,11 +85,13 @@ HybridTimer perf_hybrid_start(void)
 	HybridTimer timer = {0};
 	return timer;
 }
+
 void perf_hybrid_stop(HybridTimer* timer, const char* label)
 {
 	(void)timer;
 	(void)label;
 }
+
 double perf_hybrid_stop_debug(HybridTimer* timer, const char* label)
 {
 	(void)timer;
@@ -102,12 +110,14 @@ GLuint build_prefiltered_specular_map(GLuint shader, GLuint env, int width,
 	(void)threshold;
 	return 0;
 }
+
 GLuint pbr_prefilter_init(int width, int height)
 {
 	(void)width;
 	(void)height;
 	return TEST_SHADER_ID;
 }
+
 void pbr_prefilter_mip(GLuint shader, const PBRSpecUniforms* uniforms,
                        GLuint env, GLuint dest, int width, int height,
                        int level, int total, int slice, int slices,
@@ -125,6 +135,7 @@ void pbr_prefilter_mip(GLuint shader, const PBRSpecUniforms* uniforms,
 	(void)slices;
 	(void)threshold;
 }
+
 GLuint build_irradiance_map(GLuint shader, GLuint env, int size,
                             float threshold)
 {
@@ -134,11 +145,13 @@ GLuint build_irradiance_map(GLuint shader, GLuint env, int size,
 	(void)threshold;
 	return 0;
 }
+
 GLuint pbr_irradiance_init(int size)
 {
 	(void)size;
 	return TEST_IRRADIANCE_ID;
 }
+
 void pbr_irradiance_slice_compute(GLuint shader, const PBRIrrUniforms* uniforms,
                                   GLuint env, GLuint dest, int size, int slice,
                                   int slices, float threshold)
@@ -152,11 +165,13 @@ void pbr_irradiance_slice_compute(GLuint shader, const PBRIrrUniforms* uniforms,
 	(void)slices;
 	(void)threshold;
 }
+
 GLuint build_brdf_lut_map(int size)
 {
 	(void)size;
 	return TEST_BRDF_ID;
 }
+
 void compute_mean_luminance_gpu_start(GLuint shader_pass1, GLuint shader_pass2,
                                       GLuint hdr_tex, int width, int height,
                                       GLuint ssbos[2],
@@ -201,6 +216,7 @@ void pbr_get_irr_uniforms(GLuint shader, PBRIrrUniforms* out)
 		memset(out, 0, sizeof(*out));
 	}
 }
+
 /* ------------------------------------------------ */
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -7,6 +7,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_material.c
+++ b/tests/test_material.c
@@ -7,6 +7,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_metric_stack.c
+++ b/tests/test_metric_stack.c
@@ -4,6 +4,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_path_traversal.c
+++ b/tests/test_path_traversal.c
@@ -5,6 +5,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_perf_timer.c
+++ b/tests/test_perf_timer.c
@@ -9,6 +9,7 @@ static const double ZERO_THRESHOLD = 0.0;
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_scene_nbody.c
+++ b/tests/test_scene_nbody.c
@@ -308,6 +308,7 @@ void test_nbody_update_multiple_steps(void)
 	reset_mocks();
 
 	enum { STEP_COUNT = 10 };
+
 	for (int i = 0; i < STEP_COUNT; i++) {
 		scene_nbody_update(&scene, 1.0F / 60.0F);
 	}

--- a/tests/test_scene_render.c
+++ b/tests/test_scene_render.c
@@ -57,24 +57,28 @@ void shader_use(Shader* s)
 	(void)s;
 	mock_shader_use_calls++;
 }
+
 void shader_set_int_loc(GLint loc, int val)
 {
 	(void)loc;
 	(void)val;
 	mock_shader_set_int_loc_calls++;
 }
+
 void shader_set_vec3_loc(GLint loc, const float* v)
 {
 	(void)loc;
 	(void)v;
 	mock_shader_set_vec3_loc_calls++;
 }
+
 void shader_set_vec4_loc(GLint loc, const float* v)
 {
 	(void)loc;
 	(void)v;
 	mock_shader_set_vec4_loc_calls++;
 }
+
 void shader_set_mat4_loc(GLint loc, const float* m)
 {
 	(void)loc;
@@ -99,6 +103,7 @@ void light_probe_grid_sync(LightProbeGrid* g)
 	(void)g;
 	mock_probe_sync_calls++;
 }
+
 void light_probe_grid_render_debug(LightProbeGrid* g, mat4 v, mat4 p)
 {
 	(void)g;
@@ -112,21 +117,25 @@ void billboard_group_draw(BillboardGroup* bg)
 	(void)bg;
 	mock_billboard_draw_calls++;
 }
+
 void billboard_group_draw_debug_fill(BillboardGroup* bg)
 {
 	(void)bg;
 	mock_billboard_draw_debug_fill_calls++;
 }
+
 void billboard_group_draw_debug_quads(BillboardGroup* bg)
 {
 	(void)bg;
 	mock_billboard_draw_debug_quads_calls++;
 }
+
 void billboard_group_draw_debug_boxes(BillboardGroup* bg)
 {
 	(void)bg;
 	mock_billboard_draw_debug_boxes_calls++;
 }
+
 void billboard_group_update_from_buffer(BillboardGroup* bg, GLuint ssbo,
                                         int count)
 {
@@ -173,6 +182,7 @@ void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
 	(void)color;
 	mock_profiler_start_calls++;
 }
+
 void gpu_profiler_end_stage(GPUProfiler* profiler)
 {
 	(void)profiler;
@@ -190,6 +200,7 @@ GLuint billboard_sorter_sort_cpu(BillboardSorter* s, const SphereInstance* inst,
 	mock_billboard_sort_cpu_calls++;
 	return 42;
 }
+
 GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* s,
                                        const SphereInstance* inst, int count,
                                        const vec3 cam)
@@ -201,6 +212,7 @@ GLuint billboard_sorter_sort_cpu_radix(BillboardSorter* s,
 	mock_billboard_sort_cpu_radix_calls++;
 	return 43;
 }
+
 GLuint billboard_sorter_sort_gpu(BillboardSorter* s, const SphereInstance* inst,
                                  int count, const vec3 cam)
 {
@@ -830,6 +842,7 @@ void setUp(void)
 {
 	reset_counters();
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_sh_integration.c
+++ b/tests/test_sh_integration.c
@@ -12,24 +12,31 @@ Shader* shader_load(const char* v, const char* f)
 {
 	return (Shader*)1;
 }
+
 void shader_use(Shader* s)
 {
 }
+
 void shader_destroy(Shader* s)
 {
 }
+
 void shader_set_mat4(Shader* s, const char* n, const float* v)
 {
 }
+
 void shader_set_vec3(Shader* s, const char* n, const float* v)
 {
 }
+
 void shader_set_int(Shader* s, const char* n, int v)
 {
 }
+
 void shader_set_vec4(Shader* s, const char* n, const float* v)
 {
 }
+
 GLint shader_get_uniform_location(Shader* s, const char* n)
 {
 	return 0;

--- a/tests/test_shader_api.c
+++ b/tests/test_shader_api.c
@@ -25,6 +25,7 @@ enum {
 	GL_COMPUTE_MIN_MAJOR = 4,
 	GL_COMPUTE_MIN_MINOR = 3
 };
+
 static const GLint UNIFORM_NOT_FOUND = -1;
 static const GLuint PROGRAM_INVALID = 0;
 static const float TEST_INTENSITY = 0.5F;

--- a/tests/test_shader_limit.c
+++ b/tests/test_shader_limit.c
@@ -14,14 +14,17 @@ void log_message(LogLevel level, const char* tag, const char* format, ...)
 	(void)tag;
 	(void)format;
 }
+
 void log_set_callback(LogCallback callback)
 {
 	(void)callback;
 }
+
 void log_set_level(LogLevel level)
 {
 	(void)level;
 }
+
 LogLevel log_get_level(void)
 {
 	return LOG_LEVEL_INFO;
@@ -34,6 +37,7 @@ void setUp(void)
 {
 	mock_gl_reset_calls();
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_shader_path_security_standalone.c
+++ b/tests/test_shader_path_security_standalone.c
@@ -17,14 +17,17 @@ void log_message(LogLevel level, const char* tag, const char* format, ...)
 	(void)format;
 	/* In a real test, we might capture this output */
 }
+
 void log_set_callback(LogCallback callback)
 {
 	(void)callback;
 }
+
 void log_set_level(LogLevel level)
 {
 	(void)level;
 }
+
 LogLevel log_get_level(void)
 {
 	return LOG_LEVEL_INFO;

--- a/tests/test_shader_security.c
+++ b/tests/test_shader_security.c
@@ -8,6 +8,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_simd.c
+++ b/tests/test_simd.c
@@ -6,6 +6,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_stb_image_impl.c
+++ b/tests/test_stb_image_impl.c
@@ -7,6 +7,7 @@
 void setUp(void)
 {
 }
+
 void tearDown(void)
 {
 }

--- a/tests/test_texture_security.c
+++ b/tests/test_texture_security.c
@@ -21,11 +21,13 @@ void glGenBuffers(GLsizei n, GLuint* ids)
 		ids[i] = 100 + i;
 	}
 }
+
 void glBindBuffer(GLenum target, GLuint id)
 {
 	(void)target;
 	(void)id;
 }
+
 void glBufferData(GLenum target, GLsizeiptr size, const void* data,
                   GLenum usage)
 {
@@ -34,6 +36,7 @@ void glBufferData(GLenum target, GLsizeiptr size, const void* data,
 	(void)data;
 	(void)usage;
 }
+
 void* glMapBuffer(GLenum target, GLenum access)
 {
 	(void)target;
@@ -41,6 +44,7 @@ void* glMapBuffer(GLenum target, GLenum access)
 	static char dummy[2048];
 	return dummy;
 }
+
 void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
                        GLbitfield access)
 {
@@ -51,31 +55,37 @@ void* glMapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length,
 	static char dummy[2048];
 	return dummy;
 }
+
 GLboolean glUnmapBuffer(GLenum target)
 {
 	(void)target;
 	return GL_TRUE;
 }
+
 GLenum glGetError(void)
 {
 	return GL_NO_ERROR;
 }
+
 void glGenTextures(GLsizei n, GLuint* ids)
 {
 	for (int i = 0; i < n; i++) {
 		ids[i] = 200 + i;
 	}
 }
+
 void glBindTexture(GLenum target, GLuint id)
 {
 	(void)target;
 	(void)id;
 }
+
 void glPixelStorei(GLenum pname, GLint param)
 {
 	(void)pname;
 	(void)param;
 }
+
 void glTexImage2D(GLenum t, GLint l, GLint i, GLsizei w, GLsizei h, GLint b,
                   GLenum f, GLenum ty, const void* p)
 {
@@ -89,6 +99,7 @@ void glTexImage2D(GLenum t, GLint l, GLint i, GLsizei w, GLsizei h, GLint b,
 	(void)ty;
 	(void)p;
 }
+
 void glTexSubImage2D(GLenum t, GLint l, GLint x, GLint y, GLsizei w, GLsizei h,
                      GLenum f, GLenum ty, const void* p)
 {
@@ -102,29 +113,35 @@ void glTexSubImage2D(GLenum t, GLint l, GLint x, GLint y, GLsizei w, GLsizei h,
 	(void)ty;
 	(void)p;
 }
+
 void glTexParameteri(GLenum target, GLenum pname, GLint param)
 {
 	(void)target;
 	(void)pname;
 	(void)param;
 }
+
 void glGenerateMipmap(GLenum target)
 {
 	(void)target;
 }
+
 void glDeleteTextures(GLsizei n, const GLuint* ids)
 {
 	(void)n;
 	(void)ids;
 }
+
 void glDeleteBuffers(GLsizei n, const GLuint* ids)
 {
 	(void)n;
 	(void)ids;
 }
+
 void glPopDebugGroup(void)
 {
 }
+
 void glPushDebugGroup(GLenum source, GLuint id, GLsizei length,
                       const char* message)
 {
@@ -133,14 +150,17 @@ void glPushDebugGroup(GLenum source, GLuint id, GLsizei length,
 	(void)length;
 	(void)message;
 }
+
 void glUseProgram(GLuint program)
 {
 	(void)program;
 }
+
 void glActiveTexture(GLenum texture)
 {
 	(void)texture;
 }
+
 void glTexStorage2D(GLenum target, GLsizei levels, GLenum internalformat,
                     GLsizei width, GLsizei height)
 {
@@ -150,6 +170,7 @@ void glTexStorage2D(GLenum target, GLsizei levels, GLenum internalformat,
 	(void)width;
 	(void)height;
 }
+
 void glGetTexLevelParameteriv(GLenum target, GLint level, GLenum pname,
                               GLint* params)
 {
@@ -169,6 +190,7 @@ void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
 	(void)name;
 	(void)color;
 }
+
 void gpu_profiler_end_stage(GPUProfiler* profiler)
 {
 	(void)profiler;

--- a/tests/test_texture_toctou.c
+++ b/tests/test_texture_toctou.c
@@ -26,14 +26,17 @@ void log_message(LogLevel level, const char* tag, const char* format, ...)
 	(void)tag;
 	(void)format;
 }
+
 void log_set_callback(LogCallback callback)
 {
 	(void)callback;
 }
+
 void log_set_level(LogLevel level)
 {
 	(void)level;
 }
+
 LogLevel log_get_level(void)
 {
 	return LOG_LEVEL_INFO;
@@ -47,6 +50,7 @@ void gpu_profiler_start_stage(GPUProfiler* profiler, const char* name,
 	(void)name;
 	(void)color;
 }
+
 void gpu_profiler_end_stage(GPUProfiler* profiler)
 {
 	(void)profiler;


### PR DESCRIPTION
## Summary

Add `SeparateDefinitionBlocks: Always` to `.clang-format` and document the project's coding style philosophy aligned with Linux kernel conventions.

## Changes

- **docs**: Add coding style philosophy section to `linting_strategy.md` (EN+FR) — Linux kernel §1-§8 principles, comparison table, rule reference
- **style**: Reformat all 59 C/H/GLSL files with `SeparateDefinitionBlocks: Always` (+253 blank lines)
- **fix(ci)**: Replace `clang-format --dry-run --Werror` with format-then-diff in `make format-check` — fixes false positives caused by LLVM bug with `SeparateDefinitionBlocks` and anonymous enums

## Validation

- `just format` ✅
- `just lint` ✅
- `just test-all` ✅
- Pre-push hooks all pass ✅

Closes #281