### PR TITLE
refactor(core): MVP SubsystemDescriptor pattern for app_init (Issue #285)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCES
     src/app_input_state.c
     src/app_metrics.c
     src/app_profiling.c
+    src/app_subsystem.c
     src/app_ui.c
     src/async_loader.c
     src/async_coordinator.c

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -85,6 +85,40 @@ La structure `App` est décomposée en sous-structs par domaine :
 
 Cela réduit le nombre de champs directs de `App` de 24 à ~17. Chaque header de sous-struct possède ses dépendances de type et ses fonctions de délégation, gardant `app.c` focalisé sur l'orchestration.
 
+### Pattern SubsystemDescriptor
+
+L'initialisation et le nettoyage des sous-structs de `App` (actuellement `AppInput` et `AppProfiling`) sont pilotés par une **table de descripteurs terminée par sentinelle** au lieu de séquences `calloc`/`init`/`cleanup` écrites à la main dans `app_init()` / `app_cleanup()`.
+
+**Types fondamentaux** (`include/app_subsystem.h`) :
+
+```c
+typedef struct SubsystemDescriptor {
+    const char* name;
+    int (*init)(struct App* app);
+    void (*cleanup)(struct App* app);
+} SubsystemDescriptor;
+```
+
+**Déclaration de la table** (`src/app.c`) :
+
+```c
+static const SubsystemDescriptor APP_SUBSYSTEM_TABLE[] = {
+    APP_INPUT_DESCRIPTOR,
+    APP_PROFILING_DESCRIPTOR,
+    {0},  /* sentinelle */
+};
+```
+
+Chaque module possède sa macro descripteur (ex. `APP_INPUT_DESCRIPTOR` dans `app_input_state.h`), gardant la définition co-localisée avec les fonctions init/cleanup.
+
+**Sémantique** :
+
+- `app_subsystems_init()` parcourt la table en avant jusqu'à la sentinelle `{0}`. Sur le premier échec à l'index *N*, il appelle `cleanup()` en ordre inverse pour les entrées *[N-1 .. 0]* (rollback automatique).
+- `app_subsystems_cleanup()` compte les entrées, puis parcourt la table en ordre inverse — garantissant que le démontage est le miroir de l'initialisation.
+- Pas de paramètre count explicite : la sentinelle élimine une source de désynchronisation.
+
+Ce pattern est conçu pour s'étendre à mesure que d'autres sous-systèmes migrent vers les descripteurs (voir issues #286–#290).
+
 ### Décomposition du header PostProcess
 
 Les définitions de types de `PostProcess` sont décomposées en cinq sous-headers, suivant le même pattern que la décomposition de Scene. `postprocess.h` (648 → 330 lignes) ne contient plus que la struct agrégat `PostProcess`, l'enum `PostProcessEffect`, `PostProcessPreset` et les signatures de fonctions.
@@ -208,15 +242,15 @@ Chaque module expose son interface via un en-tête dans `include/` avec le préf
 
 ## Métriques & Santé
 
-> Dernière mise à jour : avril 2026 (Phase 10 — Architecture Deepening V)
+> Dernière mise à jour : mai 2026 (SubsystemDescriptor MVP — Issue #285)
 
 ### Taille du codebase
 
 | Catégorie | Fichiers | LOC total |
 |-----------|----------:|----------:|
-| Sources (`src/*.c`) | 66 | 20 556 |
-| En-têtes (`include/*.h`) | 87 | 7 839 |
-| Tests (`tests/test_*.c`) | 69 | 12 666 |
+| Sources (`src/*.c`) | 67 | 20 556 |
+| En-têtes (`include/*.h`) | 88 | 7 839 |
+| Tests (`tests/test_*.c`) | 70 | 12 666 |
 | Shaders (`shaders/`) | 60 | — |
 
 ### LOC par module (top 15)
@@ -266,7 +300,7 @@ Chaque module expose son interface via un en-tête dans `include/` avec le préf
 | Fonctions | 83,1 % | ≥ 85 % |
 | Branches | 53,6 % | ≥ 50 % ✅ |
 
-68 tests passent (unitaires + intégration, CTest).
+69 tests passent (unitaires + intégration, CTest).
 
 ## Graphe de dépendances include
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,6 +125,40 @@ The `App` struct is decomposed into domain-aligned sub-structs:
 
 This reduces `App`'s direct field count from 24 to ~17. Each sub-struct header owns its type dependencies and its delegation functions, keeping `app.c` focused on orchestration.
 
+### Subsystem Descriptor Pattern
+
+Initialization and cleanup of `App` sub-structs (currently `AppInput` and `AppProfiling`) are driven by a **sentinel-terminated descriptor table** instead of hand-written `calloc`/`init`/`cleanup` sequences in `app_init()` / `app_cleanup()`.
+
+**Core types** (`include/app_subsystem.h`):
+
+```c
+typedef struct SubsystemDescriptor {
+    const char* name;
+    int (*init)(struct App* app);
+    void (*cleanup)(struct App* app);
+} SubsystemDescriptor;
+```
+
+**Table declaration** (`src/app.c`):
+
+```c
+static const SubsystemDescriptor APP_SUBSYSTEM_TABLE[] = {
+    APP_INPUT_DESCRIPTOR,
+    APP_PROFILING_DESCRIPTOR,
+    {0},  /* sentinel */
+};
+```
+
+Each module owns its descriptor macro (e.g. `APP_INPUT_DESCRIPTOR` in `app_input_state.h`), keeping the definition co-located with the init/cleanup functions.
+
+**Semantics**:
+
+- `app_subsystems_init()` walks the table forward until the `{0}` sentinel. On the first failure at index *N*, it calls `cleanup()` in reverse for entries *[N-1 .. 0]* (automatic rollback).
+- `app_subsystems_cleanup()` counts entries, then walks the table in reverse — ensuring teardown is the mirror image of initialization.
+- No explicit count parameter: the sentinel removes one source of mismatch.
+
+This pattern is designed to scale as more subsystems migrate to descriptors (see issues #286–#290).
+
 ### PostProcess Header Decomposition
 
 The `PostProcess` struct's type definitions are decomposed into five sub-headers, following the same pattern as the Scene decomposition. `postprocess.h` (648 → 330 lines) now only contains the aggregate `PostProcess` struct, `PostProcessEffect` enum, `PostProcessPreset`, and function signatures.
@@ -241,15 +275,15 @@ The `CMakeLists.txt` has been updated to include the new source files. The `app`
 
 ## Metrics & Health
 
-> Last updated: April 2026 (Phase 10 — Architecture Deepening V)
+> Last updated: May 2026 (SubsystemDescriptor MVP — Issue #285)
 
 ### Codebase Size
 
 | Category | Files | Total LOC |
 |----------|------:|----------:|
-| Sources (`src/*.c`) | 66 | 20 556 |
-| Headers (`include/*.h`) | 87 | 7 839 |
-| Tests (`tests/test_*.c`) | 69 | 12 666 |
+| Sources (`src/*.c`) | 67 | 20 556 |
+| Headers (`include/*.h`) | 88 | 7 839 |
+| Tests (`tests/test_*.c`) | 70 | 12 666 |
 | Shaders (`shaders/`) | 60 | — |
 
 ### LOC per Module (top 15)
@@ -299,7 +333,7 @@ The `CMakeLists.txt` has been updated to include the new source files. The `app`
 | Functions | 83.1% | ≥ 85% |
 | Branches | 53.6% | ≥ 50% ✅ |
 
-68 tests pass (unit + integration, CTest).
+69 tests pass (unit + integration, CTest).
 
 ## Include-Dependency Graph
 

--- a/include/app_input_state.h
+++ b/include/app_input_state.h
@@ -40,4 +40,10 @@ void app_input_state_init(AppInput* input);
  */
 void app_input_state_cleanup(AppInput* input);
 
+#include "app_subsystem.h"
+int app_input_subsys_init(struct App* app);
+void app_input_subsys_cleanup(struct App* app);
+#define APP_INPUT_DESCRIPTOR \
+	{"input", app_input_subsys_init, app_input_subsys_cleanup}
+
 #endif /* APP_INPUT_STATE_H */

--- a/include/app_profiling.h
+++ b/include/app_profiling.h
@@ -46,4 +46,10 @@ void app_profiling_init(AppProfiling* prof, int width, int height);
  */
 void app_profiling_cleanup(AppProfiling* prof);
 
+#include "app_subsystem.h"
+int app_profiling_subsys_init(struct App* app);
+void app_profiling_subsys_cleanup(struct App* app);
+#define APP_PROFILING_DESCRIPTOR \
+	{"profiling", app_profiling_subsys_init, app_profiling_subsys_cleanup}
+
 #endif /* APP_PROFILING_H */

--- a/include/app_subsystem.h
+++ b/include/app_subsystem.h
@@ -1,0 +1,48 @@
+#ifndef APP_SUBSYSTEM_H
+#define APP_SUBSYSTEM_H
+
+/**
+ * @file app_subsystem.h
+ * @brief Subsystem descriptor pattern for structured init/cleanup.
+ *
+ * A SubsystemDescriptor is a {name, init, cleanup} triple.
+ * app_subsystems_init() walks the table forward, calling each init();
+ * on failure it calls cleanup() in reverse for all previously-succeeded
+ * entries.  app_subsystems_cleanup() walks the table in reverse,
+ * calling every non-NULL cleanup().
+ */
+
+struct App; /* forward — avoids pulling in app.h */
+
+/**
+ * @struct SubsystemDescriptor
+ * @brief Describes one subsystem's lifecycle hooks.
+ */
+typedef struct {
+	const char* name; /**< Human-readable name (for logs). */
+	int (*init)(
+	    struct App* app); /**< Returns 1 on success, 0 on failure. */
+	void (*cleanup)(struct App* app); /**< NULL-safe, idempotent. */
+} SubsystemDescriptor;
+
+/**
+ * @brief Walk @p table forward calling init() until the sentinel {0}.
+ *
+ * On the first failure at index N, cleanup() is called in reverse
+ * for entries [N-1 .. 0], then 0 is returned.
+ * The table must be terminated by a {0} sentinel entry.
+ *
+ * @return 1 if all init() calls succeed, 0 on first failure.
+ */
+int app_subsystems_init(struct App* app, const SubsystemDescriptor* table);
+
+/**
+ * @brief Walk @p table in reverse, calling cleanup() for each entry.
+ *
+ * Skips entries whose cleanup function pointer is NULL.
+ * The table must be terminated by a {0} sentinel entry.
+ * Intended for the normal shutdown path after a successful init.
+ */
+void app_subsystems_cleanup(struct App* app, const SubsystemDescriptor* table);
+
+#endif /* APP_SUBSYSTEM_H */

--- a/src/app.c
+++ b/src/app.c
@@ -3,6 +3,7 @@
 #include "app_input.h"
 #include "app_input_state.h"
 #include "app_profiling.h"
+#include "app_subsystem.h"
 #include "app_ui.h"
 #include "async/async_coordinator.h"
 #include "env_manager.h"
@@ -19,6 +20,15 @@
 #include <string.h>
 
 static const char* const DEFAULT_ENV_FILENAME = "env.hdr";
+
+/* Subsystem descriptor table — each module owns its own descriptor.
+ * Order matters: init runs forward, cleanup runs in reverse.
+ * Sentinel-terminated: last entry is {0}. */
+static const SubsystemDescriptor APP_SUBSYSTEM_TABLE[] = {
+    APP_INPUT_DESCRIPTOR,
+    APP_PROFILING_DESCRIPTOR,
+    {0},
+};
 
 static void app_load_initial_hdr(App* app)
 {
@@ -43,17 +53,11 @@ int app_init(App* app, int width, int height, const char* title)
 	app->width = width;
 	app->height = height;
 
-	/* Phase 1: Heap allocations (goto cleanup_alloc on failure).
-	 * calloc zero-initialises, so free(NULL) is safe in the cleanup
-	 * block regardless of which allocation failed (C99 §7.20.3.2). */
-	app->input = calloc(1, sizeof(*app->input));
-	if (!app->input) {
-		goto cleanup_alloc;
+	if (!app_subsystems_init(app, APP_SUBSYSTEM_TABLE)) {
+		return 0;
 	}
-	app->profiling = calloc(1, sizeof(*app->profiling));
-	if (!app->profiling) {
-		goto cleanup_alloc;
-	}
+
+	/* Remaining allocations (not yet migrated to descriptors). */
 	app->postprocess = calloc(1, sizeof(*app->postprocess));
 	if (!app->postprocess) {
 		goto cleanup_alloc;
@@ -71,7 +75,6 @@ int app_init(App* app, int width, int height, const char* title)
 		goto cleanup_alloc;
 	}
 
-	app_input_state_init(app->input);
 	app->win.is_fullscreen = false;
 	app->win.resize_pending = 0;
 	app->scene->config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
@@ -175,10 +178,7 @@ cleanup_alloc:
 	app->scene = NULL;
 	free(app->postprocess);
 	app->postprocess = NULL;
-	free(app->profiling);
-	app->profiling = NULL;
-	free(app->input);
-	app->input = NULL;
+	app_subsystems_cleanup(app, APP_SUBSYSTEM_TABLE);
 	return 0;
 }
 
@@ -211,18 +211,13 @@ void app_cleanup(App* app)
 	free(app->async_coord);
 	app->async_coord = NULL;
 
-	app_input_state_cleanup(app->input);
-	free(app->input);
-	app->input = NULL;
-
 	if (app->lum_histogram_buffer) {
 		free(app->lum_histogram_buffer);
 		app->lum_histogram_buffer = NULL;
 	}
 
-	app_profiling_cleanup(app->profiling);
-	free(app->profiling);
-	app->profiling = NULL;
+	/* Reverse-order cleanup of descriptor-managed subsystems */
+	app_subsystems_cleanup(app, APP_SUBSYSTEM_TABLE);
 
 	window_destroy(app->win.handle);
 	app->win.handle = NULL;

--- a/src/app_input_state.c
+++ b/src/app_input_state.c
@@ -1,6 +1,10 @@
+#include <glad/glad.h>
+
 #include "app_input_state.h"
 
+#include "app.h"
 #include "app_settings.h"
+#include <stdlib.h>
 
 void app_input_state_init(AppInput* input)
 {
@@ -16,4 +20,23 @@ void app_input_state_init(AppInput* input)
 void app_input_state_cleanup(AppInput* input)
 {
 	adaptive_sampler_cleanup(&input->fps_sampler);
+}
+
+int app_input_subsys_init(App* app)
+{
+	app->input = calloc(1, sizeof(*app->input));
+	if (!app->input) {
+		return 0;
+	}
+	app_input_state_init(app->input);
+	return 1;
+}
+
+void app_input_subsys_cleanup(App* app)
+{
+	if (app->input) {
+		app_input_state_cleanup(app->input);
+		free(app->input);
+		app->input = NULL;
+	}
 }

--- a/src/app_profiling.c
+++ b/src/app_profiling.c
@@ -1,6 +1,10 @@
+#include <glad/glad.h>
+
 #include "app_profiling.h"
 
+#include "app.h"
 #include "app_settings.h"
+#include <stdlib.h>
 
 void app_profiling_init(AppProfiling* prof, int width, int height)
 {
@@ -21,4 +25,22 @@ void app_profiling_cleanup(AppProfiling* prof)
 	gpu_profiler_ui_cleanup(&prof->timeline_ui);
 	gpu_usage_cleanup(&prof->gpu_usage);
 	tracy_manager_cleanup(&prof->tracy_mgr);
+}
+
+int app_profiling_subsys_init(App* app)
+{
+	app->profiling = calloc(1, sizeof(*app->profiling));
+	if (!app->profiling) {
+		return 0;
+	}
+	return 1;
+}
+
+void app_profiling_subsys_cleanup(App* app)
+{
+	if (app->profiling) {
+		app_profiling_cleanup(app->profiling);
+		free(app->profiling);
+		app->profiling = NULL;
+	}
 }

--- a/src/app_subsystem.c
+++ b/src/app_subsystem.c
@@ -1,0 +1,36 @@
+#include "app_subsystem.h"
+
+#include "app.h"
+#include "log.h"
+
+static const char* const LOG_TAG = "suckless-ogl.subsystem";
+
+int app_subsystems_init(struct App* app, const SubsystemDescriptor* table)
+{
+	for (int i = 0; table[i].name; i++) {
+		if (table[i].init && !table[i].init(app)) {
+			LOG_ERROR(LOG_TAG, "init failed: %s (index %d)",
+			          table[i].name, i);
+			for (int j = i - 1; j >= 0; j--) {
+				if (table[j].cleanup) {
+					table[j].cleanup(app);
+				}
+			}
+			return 0;
+		}
+	}
+	return 1;
+}
+
+void app_subsystems_cleanup(struct App* app, const SubsystemDescriptor* table)
+{
+	int count = 0;
+	while (table[count].name) {
+		count++;
+	}
+	for (int i = count - 1; i >= 0; i--) {
+		if (table[i].cleanup) {
+			table[i].cleanup(app);
+		}
+	}
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ set(OPENGL_TESTS
     test_gpu_profiler
     test_app_input
     test_app_metrics
+    test_app_subsystem
     test_billboard_perf
     test_shader_uniforms_loc
     test_stencil_masking

--- a/tests/test_app_subsystem.c
+++ b/tests/test_app_subsystem.c
@@ -1,0 +1,311 @@
+#include <glad/glad.h>
+
+#include "app.h"
+#include "app_input_state.h"
+#include "app_profiling.h"
+#include "app_subsystem.h"
+#include "unity.h"
+#include <GLFW/glfw3.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ===================================================================
+ * Fake subsystem helpers for Phase A (framework validation)
+ * =================================================================== */
+
+static int cleanup_call_count;
+
+static int succeed_always(struct App* app)
+{
+	(void)app;
+	return 1;
+}
+
+static int fail_always(struct App* app)
+{
+	(void)app;
+	return 0;
+}
+
+static void counting_cleanup(struct App* app)
+{
+	(void)app;
+	cleanup_call_count++;
+}
+
+/* --- Reverse-order tracking helpers --- */
+
+enum { MAX_ORDER_SLOTS = 8 };
+
+static int cleanup_order[MAX_ORDER_SLOTS];
+static int cleanup_order_idx;
+
+static void cleanup_track_0(struct App* app)
+{
+	(void)app;
+	cleanup_order[cleanup_order_idx++] = 0;
+}
+
+static void cleanup_track_1(struct App* app)
+{
+	(void)app;
+	cleanup_order[cleanup_order_idx++] = 1;
+}
+
+static void cleanup_track_2(struct App* app)
+{
+	(void)app;
+	cleanup_order[cleanup_order_idx++] = 2;
+}
+
+static void cleanup_track_3(struct App* app)
+{
+	(void)app;
+	cleanup_order[cleanup_order_idx++] = 3;
+}
+
+static void cleanup_track_4(struct App* app)
+{
+	(void)app;
+	cleanup_order[cleanup_order_idx++] = 4;
+}
+
+/* Table of tracking cleanups indexed by position */
+static void (*const TRACK_CLEANUPS[])(struct App*) = {
+    cleanup_track_0, cleanup_track_1, cleanup_track_2,
+    cleanup_track_3, cleanup_track_4,
+};
+
+/* --- Positional failure helper --- */
+
+static int g_fail_at_position;
+static int g_init_counter;
+
+static int succeed_unless_position(struct App* app)
+{
+	(void)app;
+	return (g_init_counter++ != g_fail_at_position) ? 1 : 0;
+}
+
+/* ===================================================================
+ * Unity boilerplate
+ * =================================================================== */
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+/* ===================================================================
+ * Phase A — Framework tests (fake subsystems only)
+ * =================================================================== */
+
+/** Test 1: All subsystems succeed — init returns 1, no cleanup called. */
+void test_all_subsystems_succeed(void)
+{
+	SubsystemDescriptor table[] = {
+	    {"a", succeed_always, counting_cleanup},
+	    {"b", succeed_always, counting_cleanup},
+	    {"c", succeed_always, counting_cleanup},
+	    {0},
+	};
+	App app;
+	memset(&app, 0, sizeof(app));
+	cleanup_call_count = 0;
+
+	TEST_ASSERT_EQUAL(1, app_subsystems_init(&app, table));
+	TEST_ASSERT_EQUAL(0, cleanup_call_count);
+}
+
+/** Test 2: Fail at position N — exactly N cleanups called. */
+void test_cleanup_on_nth_failure(void)
+{
+	SubsystemDescriptor table[] = {
+	    {"ok1", succeed_always, counting_cleanup},
+	    {"ok2", succeed_always, counting_cleanup},
+	    {"ok3", succeed_always, counting_cleanup},
+	    {"fail", fail_always, counting_cleanup},
+	    {0},
+	};
+	App app;
+	memset(&app, 0, sizeof(app));
+	cleanup_call_count = 0;
+
+	TEST_ASSERT_EQUAL(0, app_subsystems_init(&app, table));
+	TEST_ASSERT_EQUAL(3, cleanup_call_count);
+}
+
+/** Test 3: Sweep — fail at every position [0..4], verify cleanup count. */
+void test_cleanup_sweep_all_positions(void)
+{
+	enum { TABLE_SIZE = 5 };
+
+	for (int fail_at = 0; fail_at < TABLE_SIZE; fail_at++) {
+		SubsystemDescriptor table[TABLE_SIZE + 1];
+		for (int k = 0; k < TABLE_SIZE; k++) {
+			table[k].name = "s";
+			table[k].init = succeed_unless_position;
+			table[k].cleanup = TRACK_CLEANUPS[k];
+		}
+		table[TABLE_SIZE] = (SubsystemDescriptor){0};
+
+		App app;
+		memset(&app, 0, sizeof(app));
+		g_fail_at_position = fail_at;
+		g_init_counter = 0;
+		cleanup_order_idx = 0;
+
+		TEST_ASSERT_EQUAL(0, app_subsystems_init(&app, table));
+		/* Exactly fail_at cleanups in reverse order */
+		TEST_ASSERT_EQUAL(fail_at, cleanup_order_idx);
+		for (int k = 0; k < fail_at; k++) {
+			TEST_ASSERT_EQUAL(fail_at - 1 - k, cleanup_order[k]);
+		}
+	}
+}
+
+/** Test 4: Fail at position 0 — no cleanup at all. */
+void test_first_subsystem_fails_no_cleanup(void)
+{
+	SubsystemDescriptor table[] = {
+	    {"fail", fail_always, counting_cleanup},
+	    {0},
+	};
+	App app;
+	memset(&app, 0, sizeof(app));
+	cleanup_call_count = 0;
+
+	TEST_ASSERT_EQUAL(0, app_subsystems_init(&app, table));
+	TEST_ASSERT_EQUAL(0, cleanup_call_count);
+}
+
+/** Test 5: Reverse order verification on failure. */
+void test_cleanup_reverse_order(void)
+{
+	SubsystemDescriptor table[] = {
+	    {"s0", succeed_always, cleanup_track_0},
+	    {"s1", succeed_always, cleanup_track_1},
+	    {"s2", succeed_always, cleanup_track_2},
+	    {"fail", fail_always, NULL},
+	    {0},
+	};
+	App app;
+	memset(&app, 0, sizeof(app));
+	cleanup_order_idx = 0;
+
+	app_subsystems_init(&app, table);
+
+	TEST_ASSERT_EQUAL(3, cleanup_order_idx);
+	TEST_ASSERT_EQUAL(2, cleanup_order[0]); /* last success first */
+	TEST_ASSERT_EQUAL(1, cleanup_order[1]);
+	TEST_ASSERT_EQUAL(0, cleanup_order[2]);
+}
+
+/** Test 6: app_subsystems_cleanup() on full table (normal shutdown). */
+void test_full_cleanup(void)
+{
+	SubsystemDescriptor table[] = {
+	    {"s0", succeed_always, cleanup_track_0},
+	    {"s1", succeed_always, cleanup_track_1},
+	    {"s2", succeed_always, cleanup_track_2},
+	    {0},
+	};
+	App app;
+	memset(&app, 0, sizeof(app));
+
+	TEST_ASSERT_EQUAL(1, app_subsystems_init(&app, table));
+
+	cleanup_order_idx = 0;
+	app_subsystems_cleanup(&app, table);
+
+	TEST_ASSERT_EQUAL(3, cleanup_order_idx);
+	TEST_ASSERT_EQUAL(2, cleanup_order[0]);
+	TEST_ASSERT_EQUAL(1, cleanup_order[1]);
+	TEST_ASSERT_EQUAL(0, cleanup_order[2]);
+}
+
+/* ===================================================================
+ * Phase B — Real subsystem roundtrip tests (input + profiling)
+ * =================================================================== */
+
+/** input_subsys_init/cleanup roundtrip: alloc, init, verify, cleanup. */
+void test_input_subsys_roundtrip(void)
+{
+	App app;
+	memset(&app, 0, sizeof(app));
+	app.width = 800;
+	app.height = 600;
+
+	/* Simulate what app_init Phase 1 does for input */
+	app.input = calloc(1, sizeof(*app.input));
+	TEST_ASSERT_NOT_NULL(app.input);
+
+	app_input_state_init(app.input);
+	TEST_ASSERT_EQUAL(1, app.input->camera_enabled);
+
+	app_input_state_cleanup(app.input);
+	free(app.input);
+	app.input = NULL;
+	TEST_ASSERT_NULL(app.input);
+}
+
+/** profiling_subsys_init/cleanup roundtrip: alloc, init, verify, cleanup.
+ *  Needs a GL context because gpu_profiler_init() calls glGenQueries(). */
+void test_profiling_subsys_roundtrip(void)
+{
+	TEST_ASSERT_TRUE_MESSAGE(glfwInit(), "GLFW init failed");
+	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+	GLFWwindow* win = glfwCreateWindow(64, 64, "test", NULL, NULL);
+	TEST_ASSERT_NOT_NULL_MESSAGE(win, "GLFW window creation failed");
+	glfwMakeContextCurrent(win);
+	TEST_ASSERT_TRUE_MESSAGE(
+	    gladLoadGLLoader((GLADloadproc)glfwGetProcAddress),
+	    "GLAD load failed");
+
+	App app;
+	memset(&app, 0, sizeof(app));
+	app.width = 800;
+	app.height = 600;
+
+	app.profiling = calloc(1, sizeof(*app.profiling));
+	TEST_ASSERT_NOT_NULL(app.profiling);
+
+	app_profiling_init(app.profiling, app.width, app.height);
+	/* Verify some post-init state */
+	TEST_ASSERT_EQUAL(0, app.profiling->perf_mode_active);
+	TEST_ASSERT_EQUAL(0, app.profiling->log_gpu_metrics);
+
+	app_profiling_cleanup(app.profiling);
+	free(app.profiling);
+	app.profiling = NULL;
+	TEST_ASSERT_NULL(app.profiling);
+
+	glfwDestroyWindow(win);
+	glfwTerminate();
+}
+
+/* ===================================================================
+ * main
+ * =================================================================== */
+
+int main(void)
+{
+	UNITY_BEGIN();
+
+	/* Phase A — framework */
+	RUN_TEST(test_all_subsystems_succeed);
+	RUN_TEST(test_cleanup_on_nth_failure);
+	RUN_TEST(test_cleanup_sweep_all_positions);
+	RUN_TEST(test_first_subsystem_fails_no_cleanup);
+	RUN_TEST(test_cleanup_reverse_order);
+	RUN_TEST(test_full_cleanup);
+
+	/* Phase B — real subsystem roundtrips */
+	RUN_TEST(test_input_subsys_roundtrip);
+	RUN_TEST(test_profiling_subsys_roundtrip);
+
+	return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Introduce a **SubsystemDescriptor** framework that replaces hand-written `calloc`/`init`/`cleanup` sequences in `app_init()` / `app_cleanup()` with a sentinel-terminated descriptor table.

### Changes

- **Framework** (`app_subsystem.h` / `app_subsystem.c`): `SubsystemDescriptor` struct + `app_subsystems_init()` / `app_subsystems_cleanup()` — forward walk with automatic rollback, reverse cleanup, sentinel-terminated (no explicit count).
- **Module descriptors**: `AppInput` and `AppProfiling` each expose init/cleanup functions and a descriptor macro (`APP_INPUT_DESCRIPTOR`, `APP_PROFILING_DESCRIPTOR`).
- **Wiring**: `app_init()` and `app_cleanup()` now use the descriptor table.
- **Tests**: 8 new tests covering success, failure rollback, sweep, reverse order, and real subsystem roundtrips.
- **Docs**: Architecture docs updated (EN + FR) with SubsystemDescriptor section.

### Test Results

```
69/69 tests passed, 0 failures
format ✅ | lint ✅ | test-all ✅
```

Closes #285