### PR TITLE
refactor(core): Step 2 — migrate all Phase 1 allocations to descriptors (Issue #286)

### DIFF
--- a/docs/gdb_debugging_tutorial.fr.md
+++ b/docs/gdb_debugging_tutorial.fr.md
@@ -1,0 +1,453 @@
+# Tutoriel GDB — Étude de cas : crash d'alignement SIMD
+
+Ce tutoriel documente le processus de débogage GDB étape par étape utilisé pour diagnostiquer et corriger un **crash SIGSEGV qui ne se produisait qu'en build Release** de suckless-ogl. Il couvre les techniques GDB essentielles pour le débogage d'applications C natives, de la première analyse du crash à l'analyse avancée du désassemblage.
+
+## Contexte
+
+Après la migration des allocations heap vers un pattern de descripteurs de sous-systèmes, l'application crashait avec SIGSEGV en build Release (`-O3`) mais fonctionnait parfaitement en Debug (`-g -O0`). La cause racine était une **violation d'alignement AVX** : Clang auto-vectorisait l'initialisation de structs avec `vmovaps` (qui exige un alignement 32 octets), mais `calloc` ne garantit que 16 octets d'alignement sur glibc x86_64.
+
+---
+
+## 1. Premier réflexe : backtrace en mode batch
+
+Quand une application crashe, le premier réflexe est d'obtenir une backtrace. Le **mode batch** de GDB est idéal pour le triage automatisé des crashs — il lance le programme, capture le crash, et affiche la backtrace sans intervention interactive.
+
+### Commande
+
+```bash
+gdb -batch -ex run -ex 'bt full' ./build/app
+```
+
+### Détail des options
+
+| Option | Rôle |
+|--------|------|
+| `-batch` | Mode non-interactif. GDB quitte après avoir exécuté toutes les commandes `-ex`. |
+| `-ex run` | Démarrer le programme. |
+| `-ex 'bt full'` | Afficher une backtrace complète avec les variables locales quand le crash survient. |
+
+### Résultats attendus
+
+- **Avec symboles de debug** (`-g`) : noms de fonctions, fichiers/lignes, valeurs des variables locales.
+- **Sans symboles** (Release `-O3`) : uniquement des adresses et `??` — utile malgré tout pour l'adresse du crash.
+
+### Exemple de sortie (Release, sans symboles)
+
+```text
+Program received signal SIGSEGV, Segmentation fault.
+0x000055555557a3f0 in ?? ()
+```
+
+On obtient l'adresse du crash (`0x55555557a3f0`) mais rien d'autre. Il faut plus d'informations.
+
+### Exemple de sortie (Debug ou RelWithDebInfo)
+
+```text
+Program received signal SIGSEGV, Segmentation fault.
+postprocess_subsys_init (app=0x7fff...) at src/postprocess_init.c:42
+42    *app->postprocess = (PostProcess){0};
+(gdb) bt full
+#0  postprocess_subsys_init (app=0x7fff...) at src/postprocess_init.c:42
+#1  0x00005555... in app_init (app=0x7fff...) at src/app.c:180
+...
+```
+
+### Astuce : passer des arguments
+
+```bash
+gdb -batch -ex 'run --width 800 --height 600' -ex 'bt full' ./build/app
+```
+
+---
+
+## 2. Types de build et disponibilité des symboles
+
+Tous les builds ne sont pas égaux pour le débogage. Comprendre les types de build CMake est essentiel :
+
+| Type de build | Optimisation | Symboles debug | Le crash se reproduit ? | Usage |
+|--------------|-------------|---------------|------------------------|-------|
+| `Debug` | `-O0` | Complets (`-g`) | Pas toujours | Exécution pas-à-pas, inspection de variables |
+| `RelWithDebInfo` | `-O2` | Complets (`-g`) | Parfois | Le meilleur compromis |
+| `Release` | `-O3` | Aucun | **Oui** (si le bug dépend de l'optimisation) | Validation finale |
+| `ASAN` | `-O1` | Complets (`-g`) + sanitizers | Parfois | Erreurs mémoire |
+
+### Insight clé
+
+**Les bugs dépendants de l'optimisation peuvent NE PAS se reproduire en Debug.** Dans notre cas, le crash ne se produisait qu'en `-O3` car Clang n'auto-vectorise avec AVX qu'aux niveaux d'optimisation élevés. Le même code en `-O0` utilisait des instructions scalaires `mov` (alignement 8 octets) — pas de crash.
+
+### Construire en RelWithDebInfo
+
+```bash
+cmake -B build-reldbg -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build-reldbg -j$(( $(nproc) - 2 ))
+```
+
+Cela donne du code optimisé avec symboles — le compromis idéal pour déboguer les crashs liés à l'optimisation.
+
+---
+
+## 3. Désassemblage : trouver l'instruction fautive
+
+Quand la backtrace n'affiche que `??`, il faut examiner le code machine directement.
+
+### Méthode 1 : `disassemble` dans GDB
+
+```bash
+gdb -batch -ex run -ex 'disassemble $pc-32,$pc+32' ./build/app
+```
+
+Cela désassemble 64 octets autour du compteur programme (`$pc`) au moment du crash.
+
+### Méthode 2 : `objdump` (hors ligne, sans crash nécessaire)
+
+```bash
+objdump -d ./build/app | grep -A5 -B5 "55555557a3f0"
+```
+
+Ou avec le désassemblage complet dans less :
+
+```bash
+objdump -d ./build/app | less
+# Puis chercher avec /vmovaps
+```
+
+### Méthode 3 : désassemblage interactif dans GDB
+
+```bash
+gdb ./build/app
+(gdb) run
+# ... crash ...
+(gdb) disassemble
+(gdb) x/20i $pc-40    # Afficher 20 instructions avant le point de crash
+(gdb) info registers   # Afficher tous les registres
+```
+
+### Ce que nous avons trouvé
+
+```asm
+vmovaps %ymm0, 0x100(%rbx)
+```
+
+C'est l'instruction fautive :
+
+- `vmovaps` = **V**ector **MOV**e **A**ligned **P**acked **S**ingle — une instruction AVX qui déplace 32 octets (256 bits) et **exige un alignement 32 octets**.
+- `%ymm0` = Registre source (registre YMM 256 bits, mis à zéro par `vxorps`).
+- `0x100(%rbx)` = Destination : adresse de base dans `%rbx` plus décalage `0x100` (256 en décimal).
+
+---
+
+## 4. Inspection des registres
+
+Les registres sont la clé pour comprendre quelle adresse mémoire a causé la faute.
+
+### Examiner les registres au moment du crash
+
+```bash
+gdb -batch -ex run -ex 'info registers' ./build/app
+```
+
+Ou de manière interactive :
+
+```gdb
+(gdb) info registers
+(gdb) info registers rbx    # Un seul registre
+(gdb) p/x $rbx              # Afficher en hexadécimal
+(gdb) p/x $rbx + 0x100      # Calculer l'adresse effective
+```
+
+### Vérification d'alignement
+
+```gdb
+(gdb) p/x ($rbx + 0x100) % 32
+$1 = 0x10
+```
+
+Si le résultat n'est pas `0x0`, l'adresse n'est **pas alignée sur 32 octets** — et `vmovaps` provoquera une faute.
+
+### Notre cas
+
+```text
+rbx = 0x5555559c3f10   (pointeur PostProcess)
+adresse effective = rbx + 0x100 = 0x5555559c4010
+0x5555559c4010 % 32 = 16  ← PAS aligné sur 32 !
+```
+
+`calloc` a retourné une adresse avec un alignement de 16 octets (minimum glibc pour x86_64). L'instruction AVX avait besoin d'un alignement de 32 octets.
+
+---
+
+## 5. Mapper les décalages aux champs de structure
+
+Le décalage `0x100` nous indique quel champ de la structure a déclenché le crash. Pour le mapper, on écrit un petit programme utilitaire :
+
+### Le programme de calcul des décalages
+
+```c
+// /tmp/check_offsets.c
+#include <stddef.h>
+#include <stdio.h>
+#include <stdalign.h>
+#include "postprocess.h"
+
+int main(void) {
+    printf("PostProcess: size=%zu, align=%zu\n",
+           sizeof(PostProcess), alignof(PostProcess));
+
+    printf("  +0x%03lx: enabled\n", offsetof(PostProcess, enabled));
+    printf("  +0x%03lx: bloom\n", offsetof(PostProcess, bloom));
+    printf("  +0x%03lx: dof\n", offsetof(PostProcess, dof));
+    // ... ajouter tous les champs ...
+
+    return 0;
+}
+```
+
+### Compiler et exécuter
+
+```bash
+gcc -I include -I _deps/cglm-src/include /tmp/check_offsets.c -o /tmp/check_offsets
+/tmp/check_offsets
+```
+
+### Exemple de sortie
+
+```text
+PostProcess: size=2800, align=16
+  +0x000: enabled
+  +0x004: bloom
+  +0x0f8: dof
+  +0x1b0: auto_exposure
+  ...
+```
+
+Croiser le décalage du crash (`0x100`) avec la disposition de la structure pour identifier le champ exact en cours d'écriture au moment du crash.
+
+---
+
+## 6. Comprendre la cause racine : auto-vectorisation SIMD
+
+### Pourquoi ça crashe en Release mais pas en Debug
+
+En `-O0` (Debug), le compilateur génère du code scalaire :
+
+```asm
+movq $0, (%rax)      # Écriture de 8 octets, aucune exigence d'alignement au-delà de 8
+movq $0, 8(%rax)
+movq $0, 16(%rax)
+...
+```
+
+En `-O3` (Release), le compilateur **auto-vectorise** l'initialisation à zéro :
+
+```asm
+vxorps %ymm0, %ymm0, %ymm0    # Mettre à zéro le registre YMM 256 bits
+vmovaps %ymm0, (%rbx)           # Stocker 32 octets (ALIGNÉ — exige alignement 32 octets)
+vmovaps %ymm0, 0x20(%rbx)       # 32 octets suivants
+vmovaps %ymm0, 0x40(%rbx)       # ...
+```
+
+L'instruction `vmovaps` provoque une faute si l'adresse effective n'est pas alignée sur 32 octets. `calloc` ne garantit que `max(16, sizeof(max_align_t))` = 16 octets sur glibc x86_64.
+
+### Le correctif
+
+Remplacer `calloc` par `posix_memalign` (via `platform_aligned_alloc`) avec un alignement de 64 octets :
+
+```c
+// Avant (crashe en Release)
+PostProcess* pp = calloc(1, sizeof(PostProcess));
+
+// Après (compatible AVX-512)
+PostProcess* pp = platform_aligned_alloc(sizeof(*pp), SIMD_ALIGNMENT);
+*pp = (PostProcess){0};  // Initialisation à zéro via littéral composé
+```
+
+L'alignement de 64 octets (`SIMD_ALIGNMENT`) est choisi car :
+
+1. Il satisfait les exigences AVX (32 octets) et AVX-512 (64 octets)
+2. Il correspond à la taille d'une ligne de cache L1 sur les CPU x86_64 modernes
+3. Il évite le découpage de lignes de cache (*cache line splitting*) pour de meilleures performances
+
+---
+
+## 7. Référence des commandes GDB essentielles
+
+### Démarrage et exécution
+
+| Commande | Description |
+|----------|-------------|
+| `gdb ./app` | Lancer GDB avec le programme |
+| `gdb -batch -ex run -ex 'bt' ./app` | Mode batch : lancer et backtrace |
+| `run` / `r` | Démarrer/redémarrer le programme |
+| `run --arg1 val1` | Démarrer avec des arguments |
+| `continue` / `c` | Reprendre après un point d'arrêt |
+| `next` / `n` | Pas suivant (passe au-dessus des appels) |
+| `step` / `s` | Pas dans la fonction |
+| `finish` | Exécuter jusqu'au retour de la fonction courante |
+
+### Points d'arrêt
+
+| Commande | Description |
+|----------|-------------|
+| `break main` | Arrêt à une fonction |
+| `break file.c:42` | Arrêt à un fichier:ligne |
+| `break *0x555555557a3f0` | Arrêt à une adresse |
+| `watch *0x7fff0000` | Arrêt quand la mémoire change |
+| `info breakpoints` | Lister les points d'arrêt |
+| `delete 1` | Supprimer le point d'arrêt #1 |
+
+### Inspection
+
+| Commande | Description |
+|----------|-------------|
+| `bt` / `backtrace` | Afficher la pile d'appels |
+| `bt full` | Backtrace avec variables locales |
+| `frame 3` | Basculer vers le cadre #3 |
+| `info locals` | Afficher les variables locales |
+| `info args` | Afficher les arguments de la fonction |
+| `print expr` | Évaluer une expression C |
+| `p/x $rax` | Afficher un registre en hexadécimal |
+| `p sizeof(MyStruct)` | Afficher la taille d'un type |
+
+### Mémoire et désassemblage
+
+| Commande | Description |
+|----------|-------------|
+| `x/10x $rsp` | Examiner 10 mots hex au pointeur de pile |
+| `x/20i $pc` | Examiner 20 instructions au compteur programme |
+| `x/s $rdi` | Examiner une chaîne à l'adresse du registre |
+| `disassemble` | Désassembler la fonction courante |
+| `disassemble $pc-32,$pc+32` | Désassembler autour du crash |
+| `info registers` | Tous les registres |
+| `info registers rax rbx` | Registres spécifiques |
+
+### Avancé
+
+| Commande | Description |
+|----------|-------------|
+| `set disassembly-flavor intel` | Passer en syntaxe Intel |
+| `layout asm` | Vue TUI assembleur |
+| `layout split` | Vue TUI source + assembleur |
+| `info threads` | Lister les threads |
+| `thread 2` | Basculer vers le thread #2 |
+| `set follow-fork-mode child` | Déboguer le processus fils après fork |
+| `catch signal SIGSEGV` | Arrêt sur un signal spécifique |
+| `handle SIGUSR1 nostop` | Ignorer un signal spécifique |
+
+---
+
+## 8. Résumé du workflow de débogage
+
+```mermaid
+flowchart TD
+    A[L'application crashe] --> B{Symboles de debug disponibles ?}
+    B -->|Oui| C["gdb -batch -ex run -ex 'bt full' ./app"]
+    B -->|Non| D[Construire en RelWithDebInfo]
+    D --> E{Le crash se reproduit ?}
+    E -->|Oui| C
+    E -->|No| F[Utiliser objdump -d sur le binaire Release]
+    C --> G{Backtrace claire ?}
+    G -->|Oui| H[Inspecter le code source à la ligne du crash]
+    G -->|Non| I[Désassembler autour de $pc]
+    F --> I
+    I --> J[Identifier l'instruction fautive]
+    J --> K["Inspecter les registres : info registers"]
+    K --> L[Calculer l'adresse effective]
+    L --> M{Problème d'alignement ?}
+    M -->|Oui| N[Écrire un programme de calcul des décalages]
+    N --> O[Mapper le décalage au champ de la structure]
+    O --> P[Corriger : utiliser une allocation alignée]
+    M -->|Non| Q[Vérifier la validité du pointeur, les bornes, etc.]
+    H --> R[Corriger le bug]
+    P --> R
+    Q --> R
+    R --> S["Valider : build Release + run + test-all"]
+```
+
+---
+
+## 9. Astuces pratiques
+
+### Astuce 1 : toujours tester les builds Release
+
+Les builds Debug cachent les bugs d'alignement, les conditions de course et les comportements indéfinis que l'optimiseur expose. Toujours valider avec :
+
+```bash
+timeout 5 ./build/app
+```
+
+Utiliser `timeout` pour éviter les blocages en environnement headless/CI.
+
+### Astuce 2 : utiliser `objdump` pour les binaires Release
+
+Quand un binaire Release crashe et que le bug ne se reproduit pas en RelWithDebInfo :
+
+```bash
+# Trouver la fonction du crash
+objdump -d ./build/app | grep -B20 "vmovaps"
+
+# Désassemblage complet dans un fichier pour analyse
+objdump -d ./build/app > /tmp/disasm.txt
+```
+
+### Astuce 3 : arithmétique d'alignement
+
+Vérification rapide de l'alignement en bash :
+
+```bash
+python3 -c "addr=0x5555559c4010; print(f'mod 16: {addr%16}, mod 32: {addr%32}, mod 64: {addr%64}')"
+```
+
+Ou dans GDB :
+
+```gdb
+(gdb) p/x $rbx % 64
+```
+
+### Astuce 4 : core dumps
+
+Activer les core dumps pour l'analyse post-mortem :
+
+```bash
+ulimit -c unlimited
+./build/app        # Crashe, produit un fichier core
+gdb ./build/app core   # Analyser le core dump
+(gdb) bt full
+```
+
+### Astuce 5 : points d'arrêt conditionnels
+
+S'arrêter uniquement quand une condition est remplie :
+
+```gdb
+(gdb) break postprocess_subsys_init if app->postprocess == 0
+(gdb) break scene_init.c:42 if count > 100
+```
+
+### Astuce 6 : GDB avec les sanitizers
+
+ASAN et GDB fonctionnent ensemble. ASAN détecte l'erreur, GDB permet d'inspecter l'état :
+
+```bash
+gdb ./build-asan/app
+(gdb) set environment ASAN_OPTIONS=abort_on_error=1
+(gdb) run
+# ASAN signale l'erreur, puis GDB capture l'abort
+(gdb) bt full
+```
+
+### Astuce 7 : examiner la mémoire autour d'un pointeur
+
+```gdb
+(gdb) x/32xb $rbx          # 32 octets à partir de rbx
+(gdb) x/8xg $rbx           # 8 mots géants (64 bits) à partir de rbx
+(gdb) p *(PostProcess*)$rbx # Caster le registre en struct et afficher
+```
+
+---
+
+## 10. Ressources associées
+
+- [Guide de débogage](debugging.fr.md) — Sortie de débogage OpenGL et ApiTrace
+- [Profilage CPU Flamegraph](cpu_profiling_flamegraph.fr.md) — Profilage de performances
+- [Audit de gestion mémoire](memory_management_audit.fr.md) — Patterns d'allocation
+- [Cycle de vie de l'application](application_lifecycle.fr.md) — Architecture init/cleanup des sous-systèmes

--- a/docs/gdb_debugging_tutorial.md
+++ b/docs/gdb_debugging_tutorial.md
@@ -1,0 +1,453 @@
+# GDB Debugging Tutorial — Case Study: SIMD Alignment Crash
+
+This tutorial documents the step-by-step GDB debugging process used to diagnose and fix a **SIGSEGV crash that only occurred in Release builds** of suckless-ogl. It covers essential GDB techniques for native C application debugging, from basic crash triage to advanced disassembly analysis.
+
+## Context
+
+After migrating heap allocations to a subsystem descriptor pattern, the application crashed with SIGSEGV in Release (`-O3`) builds but ran fine in Debug (`-g -O0`). The root cause was an **AVX alignment violation**: Clang auto-vectorized struct initialization with `vmovaps` (which requires 32-byte alignment), but `calloc` only guarantees 16-byte alignment on glibc x86_64.
+
+---
+
+## 1. First Response: Batch-Mode Backtrace
+
+When an application crashes, the first reflex is to get a backtrace. GDB's **batch mode** is ideal for automated crash triage — it runs the program, captures the crash, and prints the backtrace without interactive input.
+
+### Command
+
+```bash
+gdb -batch -ex run -ex 'bt full' ./build/app
+```
+
+### Breakdown
+
+| Flag | Purpose |
+|------|---------|
+| `-batch` | Non-interactive mode. GDB exits after executing all `-ex` commands. |
+| `-ex run` | Start the program. |
+| `-ex 'bt full'` | Print a full backtrace with local variables when the crash occurs. |
+
+### What to expect
+
+- **With debug symbols** (`-g`): Full function names, file/line numbers, local variable values.
+- **Without symbols** (Release `-O3`): Only addresses and `??` — still useful for the crash address.
+
+### Example output (Release, no symbols)
+
+```text
+Program received signal SIGSEGV, Segmentation fault.
+0x000055555557a3f0 in ?? ()
+```
+
+This tells us the crash address (`0x55555557a3f0`) but nothing else. We need more information.
+
+### Example output (Debug or RelWithDebInfo)
+
+```text
+Program received signal SIGSEGV, Segmentation fault.
+postprocess_subsys_init (app=0x7fff...) at src/postprocess_init.c:42
+42    *app->postprocess = (PostProcess){0};
+(gdb) bt full
+#0  postprocess_subsys_init (app=0x7fff...) at src/postprocess_init.c:42
+#1  0x00005555... in app_init (app=0x7fff...) at src/app.c:180
+...
+```
+
+### Tip: Adding arguments
+
+```bash
+gdb -batch -ex 'run --width 800 --height 600' -ex 'bt full' ./build/app
+```
+
+---
+
+## 2. Build Types and Symbol Availability
+
+Not all builds are equal for debugging. Understanding CMake build types is critical:
+
+| Build Type | Optimization | Debug Symbols | Crashes Reproduce? | Use For |
+|-----------|-------------|---------------|-------------------|---------|
+| `Debug` | `-O0` | Full (`-g`) | Maybe not | Step-through, variable inspection |
+| `RelWithDebInfo` | `-O2` | Full (`-g`) | Sometimes | Best of both worlds |
+| `Release` | `-O3` | None | **Yes** (if bug is optimization-related) | Final validation |
+| `ASAN` | `-O1` | Full (`-g`) + sanitizers | Sometimes | Memory errors |
+
+### Key insight
+
+**Optimization-dependent bugs may NOT reproduce in Debug builds.** In our case, the crash only happened at `-O3` because Clang only auto-vectorizes with AVX at higher optimization levels. The same code at `-O0` used scalar `mov` instructions (8-byte aligned) — no crash.
+
+### Building RelWithDebInfo
+
+```bash
+cmake -B build-reldbg -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build-reldbg -j$(( $(nproc) - 2 ))
+```
+
+This gives optimized code with symbols — the sweet spot for debugging optimization-related crashes.
+
+---
+
+## 3. Disassembly: Finding the Faulting Instruction
+
+When the backtrace shows `??`, you need to examine the machine code directly.
+
+### Method 1: GDB `disassemble`
+
+```bash
+gdb -batch -ex run -ex 'disassemble $pc-32,$pc+32' ./build/app
+```
+
+This disassembles 64 bytes around the program counter (`$pc`) at crash time.
+
+### Method 2: `objdump` (offline, no crash needed)
+
+```bash
+objdump -d ./build/app | grep -A5 -B5 "55555557a3f0"
+```
+
+Or with full disassembly piped to less:
+
+```bash
+objdump -d ./build/app | less
+# Then search with /vmovaps
+```
+
+### Method 3: GDB interactive disassembly
+
+```bash
+gdb ./build/app
+(gdb) run
+# ... crash ...
+(gdb) disassemble
+(gdb) x/20i $pc-40    # Show 20 instructions before crash point
+(gdb) info registers   # Show all register values
+```
+
+### What we found
+
+```asm
+vmovaps %ymm0, 0x100(%rbx)
+```
+
+This is the faulting instruction:
+
+- `vmovaps` = **V**ector **MOV**e **A**ligned **P**acked **S**ingle — an AVX instruction that moves 32 bytes (256 bits) and **requires 32-byte alignment**.
+- `%ymm0` = Source register (256-bit YMM register, zeroed by `vxorps`).
+- `0x100(%rbx)` = Destination: base address in `%rbx` plus offset `0x100` (256 decimal).
+
+---
+
+## 4. Register Inspection
+
+Registers are the key to understanding what memory address caused the fault.
+
+### Examining registers at crash
+
+```bash
+gdb -batch -ex run -ex 'info registers' ./build/app
+```
+
+Or interactively:
+
+```gdb
+(gdb) info registers
+(gdb) info registers rbx    # Single register
+(gdb) p/x $rbx              # Print in hex
+(gdb) p/x $rbx + 0x100      # Compute effective address
+```
+
+### Alignment check
+
+```gdb
+(gdb) p/x ($rbx + 0x100) % 32
+$1 = 0x10
+```
+
+If the result is not `0x0`, the address is **not 32-byte aligned** — and `vmovaps` will fault.
+
+### Our case
+
+```text
+rbx = 0x5555559c3f10   (PostProcess pointer)
+effective address = rbx + 0x100 = 0x5555559c4010
+0x5555559c4010 % 32 = 16  ← NOT 32-aligned!
+```
+
+`calloc` returned an address with 16-byte alignment (glibc minimum for x86_64). The AVX instruction needed 32-byte alignment.
+
+---
+
+## 5. Mapping Offsets to Struct Fields
+
+The offset `0x100` tells us which field in the struct triggered the crash. To map it, write a small helper program:
+
+### The offset helper
+
+```c
+// /tmp/check_offsets.c
+#include <stddef.h>
+#include <stdio.h>
+#include <stdalign.h>
+#include "postprocess.h"
+
+int main(void) {
+    printf("PostProcess: size=%zu, align=%zu\n",
+           sizeof(PostProcess), alignof(PostProcess));
+
+    printf("  +0x%03lx: enabled\n", offsetof(PostProcess, enabled));
+    printf("  +0x%03lx: bloom\n", offsetof(PostProcess, bloom));
+    printf("  +0x%03lx: dof\n", offsetof(PostProcess, dof));
+    // ... add all fields ...
+
+    return 0;
+}
+```
+
+### Compile and run
+
+```bash
+gcc -I include -I _deps/cglm-src/include /tmp/check_offsets.c -o /tmp/check_offsets
+/tmp/check_offsets
+```
+
+### Output example
+
+```text
+PostProcess: size=2800, align=16
+  +0x000: enabled
+  +0x004: bloom
+  +0x0f8: dof
+  +0x1b0: auto_exposure
+  ...
+```
+
+Cross-reference the crash offset (`0x100`) with the struct layout to identify the exact field being written when the crash occurred.
+
+---
+
+## 6. Understanding the Root Cause: SIMD Auto-Vectorization
+
+### Why Release crashes but Debug doesn't
+
+At `-O0` (Debug), the compiler generates scalar code:
+
+```asm
+movq $0, (%rax)      # 8-byte store, no alignment requirement beyond 8
+movq $0, 8(%rax)
+movq $0, 16(%rax)
+...
+```
+
+At `-O3` (Release), the compiler **auto-vectorizes** the zero-initialization:
+
+```asm
+vxorps %ymm0, %ymm0, %ymm0    # Zero the 256-bit YMM register
+vmovaps %ymm0, (%rbx)           # Store 32 bytes (ALIGNED — requires 32-byte alignment)
+vmovaps %ymm0, 0x20(%rbx)       # Next 32 bytes
+vmovaps %ymm0, 0x40(%rbx)       # ...
+```
+
+The `vmovaps` instruction faults if the effective address is not 32-byte aligned. `calloc` only guarantees `max(16, sizeof(max_align_t))` = 16 bytes on glibc x86_64.
+
+### The fix
+
+Replace `calloc` with `posix_memalign` (via `platform_aligned_alloc`) using 64-byte alignment:
+
+```c
+// Before (crashes in Release)
+PostProcess* pp = calloc(1, sizeof(PostProcess));
+
+// After (safe for AVX-512)
+PostProcess* pp = platform_aligned_alloc(sizeof(*pp), SIMD_ALIGNMENT);
+*pp = (PostProcess){0};  // Zero-init via compound literal
+```
+
+64-byte alignment (`SIMD_ALIGNMENT`) is chosen because:
+
+1. It satisfies AVX (32-byte) and AVX-512 (64-byte) requirements
+2. It matches the L1 cache line size on modern x86_64 CPUs
+3. It prevents cache line splitting for better performance
+
+---
+
+## 7. Essential GDB Commands Reference
+
+### Startup and execution
+
+| Command | Description |
+|---------|-------------|
+| `gdb ./app` | Start GDB with the program |
+| `gdb -batch -ex run -ex 'bt' ./app` | Batch mode: run and backtrace |
+| `run` / `r` | Start/restart the program |
+| `run --arg1 val1` | Start with arguments |
+| `continue` / `c` | Resume after breakpoint |
+| `next` / `n` | Step over (next line) |
+| `step` / `s` | Step into function |
+| `finish` | Run until current function returns |
+
+### Breakpoints
+
+| Command | Description |
+|---------|-------------|
+| `break main` | Break at function |
+| `break file.c:42` | Break at file:line |
+| `break *0x555555557a3f0` | Break at address |
+| `watch *0x7fff0000` | Break when memory changes |
+| `info breakpoints` | List breakpoints |
+| `delete 1` | Remove breakpoint #1 |
+
+### Inspection
+
+| Command | Description |
+|---------|-------------|
+| `bt` / `backtrace` | Print call stack |
+| `bt full` | Backtrace with local variables |
+| `frame 3` | Switch to frame #3 |
+| `info locals` | Print local variables |
+| `info args` | Print function arguments |
+| `print expr` | Evaluate C expression |
+| `p/x $rax` | Print register in hex |
+| `p sizeof(MyStruct)` | Print type size |
+
+### Memory and disassembly
+
+| Command | Description |
+|---------|-------------|
+| `x/10x $rsp` | Examine 10 hex words at stack pointer |
+| `x/20i $pc` | Examine 20 instructions at program counter |
+| `x/s $rdi` | Examine string at register |
+| `disassemble` | Disassemble current function |
+| `disassemble $pc-32,$pc+32` | Disassemble around crash |
+| `info registers` | All registers |
+| `info registers rax rbx` | Specific registers |
+
+### Advanced
+
+| Command | Description |
+|---------|-------------|
+| `set disassembly-flavor intel` | Switch to Intel syntax |
+| `layout asm` | TUI assembly view |
+| `layout split` | TUI source + assembly |
+| `info threads` | List threads |
+| `thread 2` | Switch to thread #2 |
+| `set follow-fork-mode child` | Debug child after fork |
+| `catch signal SIGSEGV` | Break on specific signal |
+| `handle SIGUSR1 nostop` | Ignore specific signal |
+
+---
+
+## 8. Debugging Workflow Summary
+
+```mermaid
+flowchart TD
+    A[Application crashes] --> B{Debug symbols available?}
+    B -->|Yes| C["gdb -batch -ex run -ex 'bt full' ./app"]
+    B -->|No| D[Build RelWithDebInfo]
+    D --> E{Crash reproduces?}
+    E -->|Yes| C
+    E -->|No| F[Use objdump -d on Release binary]
+    C --> G{Backtrace clear?}
+    G -->|Yes| H[Inspect source code at crash line]
+    G -->|No| I[Disassemble around $pc]
+    F --> I
+    I --> J[Identify faulting instruction]
+    J --> K[Inspect registers: info registers]
+    K --> L[Compute effective address]
+    L --> M{Alignment issue?}
+    M -->|Yes| N[Write offset helper program]
+    N --> O[Map offset to struct field]
+    O --> P[Fix: use aligned allocation]
+    M -->|No| Q[Check pointer validity, bounds, etc.]
+    H --> R[Fix bug]
+    P --> R
+    Q --> R
+    R --> S["Validate: build Release + run + test-all"]
+```
+
+---
+
+## 9. Practical Tips
+
+### Tip 1: Always test Release builds
+
+Debug builds hide alignment bugs, race conditions, and UB that the optimizer exposes. Always validate with:
+
+```bash
+timeout 5 ./build/app
+```
+
+Use `timeout` to avoid hanging on a headless/CI environment.
+
+### Tip 2: Use `objdump` for Release binaries
+
+When a Release binary crashes and you can't reproduce in RelWithDebInfo:
+
+```bash
+# Find the crash function
+objdump -d ./build/app | grep -B20 "vmovaps"
+
+# Full disassembly to a file for analysis
+objdump -d ./build/app > /tmp/disasm.txt
+```
+
+### Tip 3: Alignment arithmetic
+
+Quick alignment check in bash:
+
+```bash
+python3 -c "addr=0x5555559c4010; print(f'mod 16: {addr%16}, mod 32: {addr%32}, mod 64: {addr%64}')"
+```
+
+Or in GDB:
+
+```gdb
+(gdb) p/x $rbx % 64
+```
+
+### Tip 4: Core dumps
+
+Enable core dumps for post-mortem analysis:
+
+```bash
+ulimit -c unlimited
+./build/app        # Crashes, produces core file
+gdb ./build/app core   # Analyze the core dump
+(gdb) bt full
+```
+
+### Tip 5: Conditional breakpoints
+
+Break only when a condition is met:
+
+```gdb
+(gdb) break postprocess_subsys_init if app->postprocess == 0
+(gdb) break scene_init.c:42 if count > 100
+```
+
+### Tip 6: GDB with sanitizers
+
+ASAN and GDB work together. ASAN detects the error, GDB lets you inspect the state:
+
+```bash
+gdb ./build-asan/app
+(gdb) set environment ASAN_OPTIONS=abort_on_error=1
+(gdb) run
+# ASAN reports error, then GDB catches the abort
+(gdb) bt full
+```
+
+### Tip 7: Examining memory around a pointer
+
+```gdb
+(gdb) x/32xb $rbx          # 32 bytes starting at rbx
+(gdb) x/8xg $rbx           # 8 giant words (64-bit) starting at rbx
+(gdb) p *(PostProcess*)$rbx # Cast register to struct and print
+```
+
+---
+
+## 10. Related Resources
+
+- [Debugging Guide](debugging.md) — OpenGL debug output and ApiTrace
+- [CPU Profiling Flamegraph](cpu_profiling_flamegraph.md) — Performance profiling
+- [Memory Management Audit](memory_management_audit.md) — Allocation patterns
+- [Application Lifecycle](application_lifecycle.md) — Subsystem init/cleanup architecture

--- a/include/async/async_coordinator.h
+++ b/include/async/async_coordinator.h
@@ -22,4 +22,13 @@ void async_coordinator_cleanup(AsyncCoordinator* coord);
 bool async_coordinator_update(AsyncCoordinator* coord, AsyncLoader* loader,
                               AsyncRequest* out_req);
 
+/* --- Subsystem descriptor (alloc-only Phase 1) --- */
+#include "app_subsystem.h"
+
+int async_coord_subsys_init(struct App* app);
+void async_coord_subsys_cleanup(struct App* app);
+
+#define APP_ASYNC_COORD_DESCRIPTOR \
+	{"async_coord", async_coord_subsys_init, async_coord_subsys_cleanup}
+
 #endif /* ASYNC_COORDINATOR_H */

--- a/include/env_manager.h
+++ b/include/env_manager.h
@@ -101,4 +101,13 @@ void env_manager_update_transition(EnvManager* mgr, Scene* scene,
  */
 void env_manager_render_overlay(const EnvManager* mgr, const Scene* scene);
 
+/* --- Subsystem descriptor (alloc-only Phase 1) --- */
+#include "app_subsystem.h"
+
+int env_mgr_subsys_init(struct App* app);
+void env_mgr_subsys_cleanup(struct App* app);
+
+#define APP_ENV_MGR_DESCRIPTOR \
+	{"env_mgr", env_mgr_subsys_init, env_mgr_subsys_cleanup}
+
 #endif /* ENV_MANAGER_H */

--- a/include/postprocess.h
+++ b/include/postprocess.h
@@ -43,4 +43,13 @@ void postprocess_apply_preset(PostProcess* post_processing,
 #include "postprocess_readback.h"
 #include "postprocess_setters.h"
 
+/* --- Subsystem descriptor (alloc-only Phase 1) --- */
+#include "app_subsystem.h"
+
+int postprocess_subsys_init(struct App* app);
+void postprocess_subsys_cleanup(struct App* app);
+
+#define APP_POSTPROCESS_DESCRIPTOR \
+	{"postprocess", postprocess_subsys_init, postprocess_subsys_cleanup}
+
 #endif /* POSTPROCESS_H */

--- a/include/scene.h
+++ b/include/scene.h
@@ -113,4 +113,12 @@ void scene_toggle_nbody(Scene* scene);
  */
 void scene_nbody_update(Scene* scene, float delta_time);
 
+/* --- Subsystem descriptor (alloc-only Phase 1) --- */
+#include "app_subsystem.h"
+
+int scene_subsys_init(struct App* app);
+void scene_subsys_cleanup(struct App* app);
+
+#define APP_SCENE_DESCRIPTOR {"scene", scene_subsys_init, scene_subsys_cleanup}
+
 #endif /* SCENE_H */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,6 +211,7 @@ nav:
   - Memory Management Audit: memory_management_audit.md
   - Standalone Mocking: standalone_testing_mocking.md
   - Debugging Guide: debugging.md
+  - GDB Debugging Tutorial: gdb_debugging_tutorial.md
   - Docs Staging: docs_staging_guide.md
   - Technical Docs System: documentation_system.md
   - Doxygen Customization: doxygen_customization.md

--- a/src/app.c
+++ b/src/app.c
@@ -27,6 +27,10 @@ static const char* const DEFAULT_ENV_FILENAME = "env.hdr";
 static const SubsystemDescriptor APP_SUBSYSTEM_TABLE[] = {
     APP_INPUT_DESCRIPTOR,
     APP_PROFILING_DESCRIPTOR,
+    APP_POSTPROCESS_DESCRIPTOR,
+    APP_SCENE_DESCRIPTOR,
+    APP_ENV_MGR_DESCRIPTOR,
+    APP_ASYNC_COORD_DESCRIPTOR,
     {0},
 };
 
@@ -57,34 +61,15 @@ int app_init(App* app, int width, int height, const char* title)
 		return 0;
 	}
 
-	/* Remaining allocations (not yet migrated to descriptors). */
-	app->postprocess = calloc(1, sizeof(*app->postprocess));
-	if (!app->postprocess) {
-		goto cleanup_alloc;
-	}
-	app->scene = calloc(1, sizeof(*app->scene));
-	if (!app->scene) {
-		goto cleanup_alloc;
-	}
-	app->env_mgr = calloc(1, sizeof(*app->env_mgr));
-	if (!app->env_mgr) {
-		goto cleanup_alloc;
-	}
-	app->async_coord = calloc(1, sizeof(*app->async_coord));
-	if (!app->async_coord) {
-		goto cleanup_alloc;
-	}
-
 	app->win.is_fullscreen = false;
 	app->win.resize_pending = 0;
-	app->scene->config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
-	app->env_mgr->is_first_load = true;
 
-	/* Phase 2: Window & GL context (goto cleanup_alloc on failure —
-	 * no GL resources exist yet). */
+	/* Phase 2: Window & GL context (no GL resources exist yet,
+	 * descriptor cleanup is sufficient on failure). */
 	app->win.handle = window_create(width, height, title, DEFAULT_SAMPLES);
 	if (!app->win.handle) {
-		goto cleanup_alloc;
+		app_subsystems_cleanup(app, APP_SUBSYSTEM_TABLE);
+		return 0;
 	}
 
 	glfwSwapInterval(0);
@@ -168,18 +153,6 @@ int app_init(App* app, int width, int height, const char* title)
 cleanup_full:
 	app_cleanup(app);
 	return 0;
-
-cleanup_alloc:
-	free(app->async_coord);
-	app->async_coord = NULL;
-	free(app->env_mgr);
-	app->env_mgr = NULL;
-	free(app->scene);
-	app->scene = NULL;
-	free(app->postprocess);
-	app->postprocess = NULL;
-	app_subsystems_cleanup(app, APP_SUBSYSTEM_TABLE);
-	return 0;
 }
 
 void app_cleanup(App* app)
@@ -191,8 +164,6 @@ void app_cleanup(App* app)
 	/* 1. High-level systems first (may depend on textures/shaders) */
 	app_ui_cleanup(&app->overlay);
 	postprocess_cleanup(app->postprocess);
-	free(app->postprocess);
-	app->postprocess = NULL;
 
 	/* Async Loader Shutdown before other resources */
 	async_loader_destroy(app->async_loader);
@@ -200,16 +171,9 @@ void app_cleanup(App* app)
 
 	/* 2. Scene / Rendering groups */
 	scene_cleanup(app->scene);
-	free(app->scene);
-	app->scene = NULL;
 
 	/* 3. Common low-level resources */
-	free(app->env_mgr);
-	app->env_mgr = NULL;
-
 	async_coordinator_cleanup(app->async_coord);
-	free(app->async_coord);
-	app->async_coord = NULL;
 
 	if (app->lum_histogram_buffer) {
 		free(app->lum_histogram_buffer);

--- a/src/app_input_state.c
+++ b/src/app_input_state.c
@@ -4,7 +4,7 @@
 
 #include "app.h"
 #include "app_settings.h"
-#include <stdlib.h>
+#include "platform/platform_utils.h"
 
 void app_input_state_init(AppInput* input)
 {
@@ -24,10 +24,12 @@ void app_input_state_cleanup(AppInput* input)
 
 int app_input_subsys_init(App* app)
 {
-	app->input = calloc(1, sizeof(*app->input));
+	app->input =
+	    platform_aligned_alloc(sizeof(*app->input), SIMD_ALIGNMENT);
 	if (!app->input) {
 		return 0;
 	}
+	*app->input = (AppInput){0};
 	app_input_state_init(app->input);
 	return 1;
 }
@@ -36,7 +38,7 @@ void app_input_subsys_cleanup(App* app)
 {
 	if (app->input) {
 		app_input_state_cleanup(app->input);
-		free(app->input);
+		platform_aligned_free(app->input);
 		app->input = NULL;
 	}
 }

--- a/src/app_profiling.c
+++ b/src/app_profiling.c
@@ -4,7 +4,7 @@
 
 #include "app.h"
 #include "app_settings.h"
-#include <stdlib.h>
+#include "platform/platform_utils.h"
 
 void app_profiling_init(AppProfiling* prof, int width, int height)
 {
@@ -29,10 +29,12 @@ void app_profiling_cleanup(AppProfiling* prof)
 
 int app_profiling_subsys_init(App* app)
 {
-	app->profiling = calloc(1, sizeof(*app->profiling));
+	app->profiling =
+	    platform_aligned_alloc(sizeof(*app->profiling), SIMD_ALIGNMENT);
 	if (!app->profiling) {
 		return 0;
 	}
+	*app->profiling = (AppProfiling){0};
 	return 1;
 }
 
@@ -40,7 +42,7 @@ void app_profiling_subsys_cleanup(App* app)
 {
 	if (app->profiling) {
 		app_profiling_cleanup(app->profiling);
-		free(app->profiling);
+		platform_aligned_free(app->profiling);
 		app->profiling = NULL;
 	}
 }

--- a/src/async_coordinator.c
+++ b/src/async_coordinator.c
@@ -1,7 +1,9 @@
 #include "async/async_coordinator.h"
 
+#include "app.h"
 #include "gl_common.h"
 #include "log.h"
+#include "platform/platform_utils.h"
 #include "profiler.h"
 #include "texture.h"
 #include <stdlib.h>
@@ -82,4 +84,25 @@ bool async_coordinator_update(AsyncCoordinator* coord, AsyncLoader* loader,
 	}
 
 	return result;
+}
+
+/* --- Subsystem descriptor (Phase 1: alloc only) --- */
+
+int async_coord_subsys_init(App* app)
+{
+	app->async_coord =
+	    platform_aligned_alloc(sizeof(*app->async_coord), SIMD_ALIGNMENT);
+	if (!app->async_coord) {
+		return 0;
+	}
+	*app->async_coord = (AsyncCoordinator){0};
+	return 1;
+}
+
+void async_coord_subsys_cleanup(App* app)
+{
+	if (app->async_coord) {
+		platform_aligned_free(app->async_coord);
+		app->async_coord = NULL;
+	}
 }

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -1,10 +1,12 @@
 #include "env_manager.h"
 
+#include "app.h"
 #include "app_settings.h"
 #include "async_loader.h"
 #include "gl_common.h"
 #include "ibl_coordinator.h"
 #include "log.h"
+#include "platform/platform_utils.h"
 #include "postprocess_readback.h"
 #include "scene.h"
 #include "scene_gpu_resources.h"
@@ -12,7 +14,6 @@
 #include "shader.h"
 #include "texture.h"
 #include "utils.h"
-#include <stdlib.h>
 
 static const int MAX_PATH_LENGTH = 256;
 
@@ -318,5 +319,27 @@ void env_manager_render_overlay(const EnvManager* mgr, const Scene* scene)
 
 		glEnable(GL_DEPTH_TEST);
 		glDisable(GL_BLEND);
+	}
+}
+
+/* --- Subsystem descriptor (Phase 1: alloc + defaults) --- */
+
+int env_mgr_subsys_init(App* app)
+{
+	app->env_mgr =
+	    platform_aligned_alloc(sizeof(*app->env_mgr), SIMD_ALIGNMENT);
+	if (!app->env_mgr) {
+		return 0;
+	}
+	*app->env_mgr = (EnvManager){0};
+	app->env_mgr->is_first_load = 1;
+	return 1;
+}
+
+void env_mgr_subsys_cleanup(App* app)
+{
+	if (app->env_mgr) {
+		platform_aligned_free(app->env_mgr);
+		app->env_mgr = NULL;
 	}
 }

--- a/src/postprocess_init.c
+++ b/src/postprocess_init.c
@@ -1,3 +1,4 @@
+#include "app.h"
 #include "app_settings.h"
 #include "effects/fx_auto_exposure.h"
 #include "effects/fx_bloom.h"
@@ -6,6 +7,7 @@
 #include "effects/fx_lut_viz.h"
 #include "effects/fx_motion_blur.h"
 #include "log.h"
+#include "platform/platform_utils.h"
 #include "postprocess_internal.h"
 #include "render_utils.h"
 
@@ -370,4 +372,25 @@ void postprocess_resize(PostProcess* post_processing, int width, int height)
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
 	LOG_INFO("suckless-ogl.postprocess", "Resized to %dx%d", width, height);
+}
+
+/* --- Subsystem descriptor (Phase 1: alloc only) --- */
+
+int postprocess_subsys_init(App* app)
+{
+	app->postprocess =
+	    platform_aligned_alloc(sizeof(*app->postprocess), SIMD_ALIGNMENT);
+	if (!app->postprocess) {
+		return 0;
+	}
+	*app->postprocess = (PostProcess){0};
+	return 1;
+}
+
+void postprocess_subsys_cleanup(App* app)
+{
+	if (app->postprocess) {
+		platform_aligned_free(app->postprocess);
+		app->postprocess = NULL;
+	}
 }

--- a/src/scene_init.c
+++ b/src/scene_init.c
@@ -1,3 +1,5 @@
+#include "app.h"
+#include "app_settings.h"
 #include "billboard_rendering.h"
 #include "ibl_coordinator.h"
 #include "instanced_rendering.h"
@@ -489,4 +491,26 @@ int scene_init(Scene* scene)
 	    shader_get_uniform_location(scene->shaders->debug_line, "u_color");
 
 	return 1;
+}
+
+/* --- Subsystem descriptor (Phase 1: alloc + defaults) --- */
+
+int scene_subsys_init(App* app)
+{
+	app->scene =
+	    platform_aligned_alloc(sizeof(*app->scene), SIMD_ALIGNMENT);
+	if (!app->scene) {
+		return 0;
+	}
+	*app->scene = (Scene){0};
+	app->scene->config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
+	return 1;
+}
+
+void scene_subsys_cleanup(App* app)
+{
+	if (app->scene) {
+		platform_aligned_free(app->scene);
+		app->scene = NULL;
+	}
 }

--- a/tests/test_app_subsystem.c
+++ b/tests/test_app_subsystem.c
@@ -3,7 +3,12 @@
 #include "app.h"
 #include "app_input_state.h"
 #include "app_profiling.h"
+#include "app_settings.h"
 #include "app_subsystem.h"
+#include "async/async_coordinator.h"
+#include "env_manager.h"
+#include "postprocess.h"
+#include "scene.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
 #include <stdlib.h>
@@ -288,6 +293,135 @@ void test_profiling_subsys_roundtrip(void)
 }
 
 /* ===================================================================
+ * Phase C — Step 2 descriptor roundtrips (alloc-only, no GL)
+ * =================================================================== */
+
+/** postprocess_subsys roundtrip: alloc + free. */
+void test_postprocess_subsys_roundtrip(void)
+{
+	App app;
+	memset(&app, 0, sizeof(app));
+
+	TEST_ASSERT_EQUAL(1, postprocess_subsys_init(&app));
+	TEST_ASSERT_NOT_NULL(app.postprocess);
+
+	postprocess_subsys_cleanup(&app);
+	TEST_ASSERT_NULL(app.postprocess);
+}
+
+/** scene_subsys roundtrip: alloc + defaults + free. */
+void test_scene_subsys_init_sets_defaults(void)
+{
+	App app;
+	memset(&app, 0, sizeof(app));
+
+	TEST_ASSERT_EQUAL(1, scene_subsys_init(&app));
+	TEST_ASSERT_NOT_NULL(app.scene);
+	TEST_ASSERT_EQUAL(DEFAULT_SPECULAR_AA_ENABLED,
+	                  app.scene->config.specular_aa_enabled);
+
+	scene_subsys_cleanup(&app);
+	TEST_ASSERT_NULL(app.scene);
+}
+
+/** env_mgr_subsys roundtrip: alloc + is_first_load default + free. */
+void test_env_mgr_subsys_init_sets_defaults(void)
+{
+	App app;
+	memset(&app, 0, sizeof(app));
+
+	TEST_ASSERT_EQUAL(1, env_mgr_subsys_init(&app));
+	TEST_ASSERT_NOT_NULL(app.env_mgr);
+	TEST_ASSERT_EQUAL(1, app.env_mgr->is_first_load);
+
+	env_mgr_subsys_cleanup(&app);
+	TEST_ASSERT_NULL(app.env_mgr);
+}
+
+/** async_coord_subsys roundtrip: alloc + free. */
+void test_async_coord_subsys_roundtrip(void)
+{
+	App app;
+	memset(&app, 0, sizeof(app));
+
+	TEST_ASSERT_EQUAL(1, async_coord_subsys_init(&app));
+	TEST_ASSERT_NOT_NULL(app.async_coord);
+
+	async_coord_subsys_cleanup(&app);
+	TEST_ASSERT_NULL(app.async_coord);
+}
+
+/** Integration: full Phase 1 table (6 entries) init + cleanup. */
+void test_phase1_table_full_init_cleanup(void)
+{
+	static const SubsystemDescriptor phase1_table[] = {
+	    APP_INPUT_DESCRIPTOR,
+	    APP_PROFILING_DESCRIPTOR,
+	    APP_POSTPROCESS_DESCRIPTOR,
+	    APP_SCENE_DESCRIPTOR,
+	    APP_ENV_MGR_DESCRIPTOR,
+	    APP_ASYNC_COORD_DESCRIPTOR,
+	    {0},
+	};
+
+	App app;
+	memset(&app, 0, sizeof(app));
+	app.width = 800;
+	app.height = 600;
+
+	TEST_ASSERT_EQUAL(1, app_subsystems_init(&app, phase1_table));
+	TEST_ASSERT_NOT_NULL(app.input);
+	TEST_ASSERT_NOT_NULL(app.profiling);
+	TEST_ASSERT_NOT_NULL(app.postprocess);
+	TEST_ASSERT_NOT_NULL(app.scene);
+	TEST_ASSERT_NOT_NULL(app.env_mgr);
+	TEST_ASSERT_NOT_NULL(app.async_coord);
+
+	app_subsystems_cleanup(&app, phase1_table);
+	TEST_ASSERT_NULL(app.input);
+	TEST_ASSERT_NULL(app.profiling);
+	TEST_ASSERT_NULL(app.postprocess);
+	TEST_ASSERT_NULL(app.scene);
+	TEST_ASSERT_NULL(app.env_mgr);
+	TEST_ASSERT_NULL(app.async_coord);
+}
+
+/** Sweep: replace each real descriptor's init with fail_always,
+ *  verify preceding entries are cleaned up. */
+void test_phase1_failure_sweep(void)
+{
+	static const SubsystemDescriptor real_table[] = {
+	    APP_INPUT_DESCRIPTOR,
+	    APP_PROFILING_DESCRIPTOR,
+	    APP_POSTPROCESS_DESCRIPTOR,
+	    APP_SCENE_DESCRIPTOR,
+	    APP_ENV_MGR_DESCRIPTOR,
+	    APP_ASYNC_COORD_DESCRIPTOR,
+	    {0},
+	};
+
+	enum { TABLE_SIZE = 6 };
+
+	for (int fail_at = 0; fail_at < TABLE_SIZE; fail_at++) {
+		/* Build a table with fail_always injected at position fail_at
+		 */
+		SubsystemDescriptor table[TABLE_SIZE + 1];
+		for (int k = 0; k < TABLE_SIZE; k++) {
+			table[k] = real_table[k];
+		}
+		table[fail_at].init = fail_always;
+		table[TABLE_SIZE] = (SubsystemDescriptor){0};
+
+		App app;
+		memset(&app, 0, sizeof(app));
+		app.width = 800;
+		app.height = 600;
+
+		TEST_ASSERT_EQUAL(0, app_subsystems_init(&app, table));
+	}
+}
+
+/* ===================================================================
  * main
  * =================================================================== */
 
@@ -303,9 +437,17 @@ int main(void)
 	RUN_TEST(test_cleanup_reverse_order);
 	RUN_TEST(test_full_cleanup);
 
-	/* Phase B — real subsystem roundtrips */
+	/* Phase B — real subsystem roundtrips (step 1) */
 	RUN_TEST(test_input_subsys_roundtrip);
 	RUN_TEST(test_profiling_subsys_roundtrip);
+
+	/* Phase C — step 2 descriptor roundtrips (alloc-only) */
+	RUN_TEST(test_postprocess_subsys_roundtrip);
+	RUN_TEST(test_scene_subsys_init_sets_defaults);
+	RUN_TEST(test_env_mgr_subsys_init_sets_defaults);
+	RUN_TEST(test_async_coord_subsys_roundtrip);
+	RUN_TEST(test_phase1_table_full_init_cleanup);
+	RUN_TEST(test_phase1_failure_sweep);
 
 	return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Step 2 of the SubsystemDescriptor migration (Issue #286). Stacked on PR #291.

### Changes

**4 new descriptors** (6-entry table total):
- `postprocess_subsys_init/cleanup` (PostProcess)
- `scene_subsys_init/cleanup` (Scene)
- `env_mgr_subsys_init/cleanup` (EnvManager)
- `async_coord_subsys_init/cleanup` (AsyncCoordinator)

**SIMD alignment fix** (all 6 subsystems):
- Replace `calloc`/`free` with `platform_aligned_alloc`/`platform_aligned_free` (SIMD_ALIGNMENT=64)
- Zero-init via compound literal `*ptr = (Type){0}` instead of `memset` (lint-safe)
- Fixes SIGSEGV in Release builds: Clang `-O3` auto-vectorizes with `vmovaps` (AVX, 32-byte aligned) but `calloc` only guarantees 16-byte alignment on glibc x86_64

**Tests**: 6 new tests (4 roundtrips + 1 integration + 1 sweep), 14 total

**Documentation**: GDB debugging tutorial (EN+FR) — step-by-step case study of the SIMD crash investigation

### Commits (SoC)
1. `refactor(core)`: 4 new descriptors + 6-entry table + delete `cleanup_alloc`
2. `fix(core)`: aligned allocation for input/profiling (step-1 descriptors)
3. `test(core)`: 6 new tests
4. `docs(debugging)`: GDB tutorial EN+FR + mkdocs.yml

### Validation
- ✅ `just format` — clean
- ✅ `just lint` — 0 failures, 0 warnings
- ✅ `just test-all` — 69/69 pass
- ✅ Release build + `timeout 5 ./build/app` — exit 143 (SIGTERM, no SIGSEGV)
- ✅ Pre-push hooks — all passed

Closes #286