### PR TITLE
refactor(core): extract window lifecycle into APP_WINDOW_DESCRIPTOR (Step 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SOURCES
     src/app_profiling.c
     src/app_subsystem.c
     src/app_ui.c
+    src/app_window.c
     src/async_loader.c
     src/async_coordinator.c
     src/billboard_rendering.c

--- a/docs/application_lifecycle.fr.md
+++ b/docs/application_lifecycle.fr.md
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
 
 ## Chapitre 2 — Ouvrir une Fenêtre (GLFW + X11 + OpenGL)
 
-Le premier vrai travail se fait dans `window_create()` ([src/window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/window.c)).
+La création de la fenêtre est pilotée par le descripteur de sous-système `APP_WINDOW_DESCRIPTOR` ([src/app_window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/app_window.c)). C'est la **première** entrée dans la table des descripteurs — le contexte GL qu'il crée est nécessaire à tous les sous-systèmes suivants. Le travail bas-niveau GLFW/GLX se fait dans `window_create()` ([src/window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/window.c)).
 
 ### 2.1 — Initialisation GLFW & Window Hints
 
@@ -148,16 +148,17 @@ Cela active `GL_DEBUG_OUTPUT_SYNCHRONOUS` et enregistre un callback ([src/gl_deb
 
 ### 2.4 — Callbacks d'Entrée & VSync
 
+La configuration suivante est effectuée par `app_window_subsys_init()` ([src/app_window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/app_window.c)) dans le cadre du descripteur de sous-système fenêtre :
+
 ```c
 glfwSwapInterval(0);                    // VSync OFF — FPS illimité
 glfwSetKeyCallback(app->win.handle, key_callback);
 glfwSetCursorPosCallback(app->win.handle, mouse_callback);
 glfwSetScrollCallback(app->win.handle, scroll_callback);
 glfwSetFramebufferSizeCallback(app->win.handle, framebuffer_size_callback);
-glfwSetInputMode(app->win.handle, GLFW_CURSOR, GLFW_CURSOR_DISABLED);  // Mode FPS
 ```
 
-Le curseur est capturé en **mode relatif** — les mouvements de souris produisent des décalages delta pour le contrôle de la caméra orbitale, pas des coordonnées écran absolues.
+Le mode de capture du curseur (`GLFW_CURSOR_DISABLED` pour le contrôle FPS) est défini plus tard dans `app_init()`, après l'initialisation du sous-système d'entrée et une fois que `camera_enabled` est connu.
 
 ---
 

--- a/docs/application_lifecycle.md
+++ b/docs/application_lifecycle.md
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
 
 ## Chapter 2 — Opening a Window (GLFW + X11 + OpenGL)
 
-The first real work happens in `window_create()` ([src/window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/window.c)).
+Window creation is driven by the `APP_WINDOW_DESCRIPTOR` subsystem descriptor ([src/app_window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/app_window.c)). It is the **first** entry in the descriptor table — the GL context it creates is required by all subsequent subsystems. The low-level GLFW/GLX work happens in `window_create()` ([src/window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/window.c)).
 
 ### 2.1 — GLFW Initialization & Window Hints
 
@@ -148,16 +148,17 @@ This enables `GL_DEBUG_OUTPUT_SYNCHRONOUS` and registers a callback ([src/gl_deb
 
 ### 2.4 — Input Callbacks & VSync
 
+The following setup is performed by `app_window_subsys_init()` ([src/app_window.c](https://github.com/yoyonel/suckless-ogl/blob/master/src/app_window.c)) as part of the window subsystem descriptor:
+
 ```c
 glfwSwapInterval(0);                    // VSync OFF — unlimited FPS
 glfwSetKeyCallback(app->win.handle, key_callback);
 glfwSetCursorPosCallback(app->win.handle, mouse_callback);
 glfwSetScrollCallback(app->win.handle, scroll_callback);
 glfwSetFramebufferSizeCallback(app->win.handle, framebuffer_size_callback);
-glfwSetInputMode(app->win.handle, GLFW_CURSOR, GLFW_CURSOR_DISABLED);  // FPS-style
 ```
 
-The cursor is captured in **relative mode** — mouse movements produce delta offsets for orbit camera control, not absolute screen coordinates.
+The cursor capture mode (`GLFW_CURSOR_DISABLED` for FPS-style control) is set later in `app_init()`, after the input subsystem has been initialized and `camera_enabled` is known.
 
 ---
 

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -79,7 +79,7 @@ La structure `App` est décomposée en sous-structs par domaine :
 
 - **`AppProfiling`** (`include/app_profiling.h`) : regroupe le profiling et les métriques — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Accès via `app->profiling->gpu_profiler`, etc. Init/cleanup délégués à `app_profiling_init()` / `app_profiling_cleanup()` dans `src/app_profiling.c`.
 - **`AppInput`** (`include/app_input_state.h`) : regroupe la caméra, le gamepad, les raccourcis clavier et le lissage d'entrée — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Accès via `app->input->camera`, etc. Init/cleanup délégués à `app_input_state_init()` / `app_input_state_cleanup()` dans `src/app_input_state.c`.
-- **`AppWindow`** (`include/app_window.h`) : regroupe le handle de fenêtre GLFW et tout l'état fenêtre/resize — `GLFWwindow* handle`, `is_fullscreen`, `saved_x/y`, `saved_width/height`, `resize_pending`, `pending_width/height`. Accès via `app->win.handle`, `app->win.is_fullscreen`, etc.
+- **`AppWindow`** (`include/app_window.h`) : regroupe le handle de fenêtre GLFW et tout l'état fenêtre/resize — `GLFWwindow* handle`, `is_fullscreen`, `saved_x/y`, `saved_width/height`, `resize_pending`, `pending_width/height`. Accès via `app->win.handle`, `app->win.is_fullscreen`, etc. Init/cleanup délégués à `app_window_subsys_init()` / `app_window_subsys_cleanup()` dans `src/app_window.c`. Le descripteur fenêtre est **premier** dans la table des sous-systèmes — il crée le contexte OpenGL nécessaire à tous les autres sous-systèmes, et est nettoyé en **dernier** (ordre inverse) pour garantir que le contexte GL survit à toutes les libérations de ressources GPU.
 
 > **Note de nommage** : `app_input_state.h` héberge la définition de la sous-struct `AppInput`, tandis que le fichier existant `app_input.h` héberge le seam `AppInputContext` (bundle de pointeurs ciblés pour les handlers d'entrée, issue #204).
 
@@ -87,7 +87,7 @@ Cela réduit le nombre de champs directs de `App` de 24 à ~17. Chaque header de
 
 ### Pattern SubsystemDescriptor
 
-L'initialisation et le nettoyage des sous-structs de `App` (actuellement `AppInput` et `AppProfiling`) sont pilotés par une **table de descripteurs terminée par sentinelle** au lieu de séquences `calloc`/`init`/`cleanup` écrites à la main dans `app_init()` / `app_cleanup()`.
+L'initialisation et le nettoyage des sous-structs de `App` sont pilotés par une **table de descripteurs terminée par sentinelle** au lieu de séquences `calloc`/`init`/`cleanup` écrites à la main dans `app_init()` / `app_cleanup()`.
 
 **Types fondamentaux** (`include/app_subsystem.h`) :
 
@@ -103,21 +103,26 @@ typedef struct SubsystemDescriptor {
 
 ```c
 static const SubsystemDescriptor APP_SUBSYSTEM_TABLE[] = {
+    APP_WINDOW_DESCRIPTOR,      // Crée le contexte GL — doit être premier
     APP_INPUT_DESCRIPTOR,
     APP_PROFILING_DESCRIPTOR,
+    APP_POSTPROCESS_DESCRIPTOR,
+    APP_SCENE_DESCRIPTOR,
+    APP_ENV_MGR_DESCRIPTOR,
+    APP_ASYNC_COORD_DESCRIPTOR,
     {0},  /* sentinelle */
 };
 ```
 
-Chaque module possède sa macro descripteur (ex. `APP_INPUT_DESCRIPTOR` dans `app_input_state.h`), gardant la définition co-localisée avec les fonctions init/cleanup.
+Chaque module possède sa macro descripteur (ex. `APP_WINDOW_DESCRIPTOR` dans `app_window.h`), gardant la définition co-localisée avec les fonctions init/cleanup.
+
+**Contrainte d'ordre** : `APP_WINDOW_DESCRIPTOR` doit être la **première** entrée car il crée le contexte OpenGL. Le cleanup s'exécutant en ordre inverse, la fenêtre est détruite en **dernier**, garantissant que le contexte GL reste valide pendant la libération de tous les sous-systèmes dépendants du GPU (requêtes profiler, FBOs, VAOs, shaders, etc.).
 
 **Sémantique** :
 
 - `app_subsystems_init()` parcourt la table en avant jusqu'à la sentinelle `{0}`. Sur le premier échec à l'index *N*, il appelle `cleanup()` en ordre inverse pour les entrées *[N-1 .. 0]* (rollback automatique).
 - `app_subsystems_cleanup()` compte les entrées, puis parcourt la table en ordre inverse — garantissant que le démontage est le miroir de l'initialisation.
 - Pas de paramètre count explicite : la sentinelle élimine une source de désynchronisation.
-
-Ce pattern est conçu pour s'étendre à mesure que d'autres sous-systèmes migrent vers les descripteurs (voir issues #286–#290).
 
 ### Décomposition du header PostProcess
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,7 +119,7 @@ The `App` struct is decomposed into domain-aligned sub-structs:
 
 - **`AppProfiling`** (`include/app_profiling.h`): Groups profiling and metrics — `GPUProfiler`, `GPUProfilerUI`, `FpsCounter`, `TracyManager`, `GPUUsageMonitor`, `PerfModeContext`, `perf_mode_active`, `log_gpu_metrics`. Access via `app->profiling->gpu_profiler`, etc. Init/cleanup delegated to `app_profiling_init()` / `app_profiling_cleanup()` in `src/app_profiling.c`.
 - **`AppInput`** (`include/app_input_state.h`): Groups camera, gamepad, key-bindings, and input smoothing — `Camera`, `GamepadState`, `AppBindingRegistry`, `AdaptiveSampler`, `camera_enabled`. Access via `app->input->camera`, etc. Init/cleanup delegated to `app_input_state_init()` / `app_input_state_cleanup()` in `src/app_input_state.c`.
-- **`AppWindow`** (`include/app_window.h`): Groups GLFW window handle and all window/resize state — `GLFWwindow* handle`, `is_fullscreen`, `saved_x/y`, `saved_width/height`, `resize_pending`, `pending_width/height`. Access via `app->win.handle`, `app->win.is_fullscreen`, etc.
+- **`AppWindow`** (`include/app_window.h`): Groups GLFW window handle and all window/resize state — `GLFWwindow* handle`, `is_fullscreen`, `saved_x/y`, `saved_width/height`, `resize_pending`, `pending_width/height`. Access via `app->win.handle`, `app->win.is_fullscreen`, etc. Init/cleanup delegated to `app_window_subsys_init()` / `app_window_subsys_cleanup()` in `src/app_window.c`. The window descriptor is **first** in the subsystem table — it creates the OpenGL context needed by all other subsystems, and is cleaned up **last** (reverse order) to ensure the GL context outlives all GPU resource teardowns.
 
 > **Naming note**: `app_input_state.h` hosts the `AppInput` sub-struct definition, while the existing `app_input.h` hosts the `AppInputContext` seam (focused pointer bundle for input handlers, issue #204).
 
@@ -127,7 +127,7 @@ This reduces `App`'s direct field count from 24 to ~17. Each sub-struct header o
 
 ### Subsystem Descriptor Pattern
 
-Initialization and cleanup of `App` sub-structs (currently `AppInput` and `AppProfiling`) are driven by a **sentinel-terminated descriptor table** instead of hand-written `calloc`/`init`/`cleanup` sequences in `app_init()` / `app_cleanup()`.
+Initialization and cleanup of `App` sub-structs are driven by a **sentinel-terminated descriptor table** instead of hand-written `calloc`/`init`/`cleanup` sequences in `app_init()` / `app_cleanup()`.
 
 **Core types** (`include/app_subsystem.h`):
 
@@ -143,21 +143,26 @@ typedef struct SubsystemDescriptor {
 
 ```c
 static const SubsystemDescriptor APP_SUBSYSTEM_TABLE[] = {
+    APP_WINDOW_DESCRIPTOR,      // Creates GL context — must be first
     APP_INPUT_DESCRIPTOR,
     APP_PROFILING_DESCRIPTOR,
+    APP_POSTPROCESS_DESCRIPTOR,
+    APP_SCENE_DESCRIPTOR,
+    APP_ENV_MGR_DESCRIPTOR,
+    APP_ASYNC_COORD_DESCRIPTOR,
     {0},  /* sentinel */
 };
 ```
 
-Each module owns its descriptor macro (e.g. `APP_INPUT_DESCRIPTOR` in `app_input_state.h`), keeping the definition co-located with the init/cleanup functions.
+Each module owns its descriptor macro (e.g. `APP_WINDOW_DESCRIPTOR` in `app_window.h`), keeping the definition co-located with the init/cleanup functions.
+
+**Ordering constraint**: `APP_WINDOW_DESCRIPTOR` must be the **first** entry because it creates the OpenGL context. Since cleanup runs in reverse, the window is destroyed **last**, ensuring the GL context remains valid during teardown of all GPU-dependent subsystems (profiler queries, FBOs, VAOs, shaders, etc.).
 
 **Semantics**:
 
 - `app_subsystems_init()` walks the table forward until the `{0}` sentinel. On the first failure at index *N*, it calls `cleanup()` in reverse for entries *[N-1 .. 0]* (automatic rollback).
 - `app_subsystems_cleanup()` counts entries, then walks the table in reverse — ensuring teardown is the mirror image of initialization.
 - No explicit count parameter: the sentinel removes one source of mismatch.
-
-This pattern is designed to scale as more subsystems migrate to descriptors (see issues #286–#290).
 
 ### PostProcess Header Decomposition
 

--- a/docs/goto_cleanup_pattern.fr.md
+++ b/docs/goto_cleanup_pattern.fr.md
@@ -63,14 +63,13 @@ Le standard C garantit que `free(NULL)` est un no-op. Quand `calloc` initialise 
 
 ## Application : `app_init()` dans suckless-ogl
 
-La fonction `app_init()` utilise une **variante à deux labels** :
+La fonction `app_init()` utilise un pattern **à label unique** `goto cleanup_full` :
 
 | Label | Quand utilisé | Action de nettoyage |
 |-------|--------------|-------------------|
-| `cleanup_alloc` | Échecs d'allocation avant le contexte GL | `free()` direct des 6 pointeurs calloc'd |
-| `cleanup_full` | Échecs après l'init des sous-systèmes (GL actif) | Appelle `app_cleanup()` qui gère le teardown partiel |
+| `cleanup_full` | Échecs après l'init des descripteurs de sous-systèmes (GL actif) | Appelle `app_cleanup()` qui gère le teardown partiel |
 
-**Pourquoi deux labels ?** `app_cleanup()` appelle `app_input_state_cleanup()` et `app_profiling_cleanup()` qui n'ont **pas** de gardes NULL — les appeler sur des pointeurs non initialisés provoquerait un crash. Le label `cleanup_alloc` gère la phase pré-init de manière sûre avec des appels directs `free(NULL)`.
+L'ancien label `cleanup_alloc` (pour les échecs d'allocation avant le GL) a été supprimé lorsque les descripteurs de sous-systèmes ont pris le relais. La fonction `app_subsystems_init()` de la table des descripteurs gère désormais le rollback automatiquement : sur le premier échec à l'index *N*, elle appelle `cleanup()` en ordre inverse pour les entrées *[N-1 .. 0]*, libérant toutes les sous-structs allouées par `calloc`. Seuls les échecs de Phase 3 post-descripteurs (scène, chargeur async, post-traitement) utilisent encore `goto cleanup_full`.
 
 ## Comparaison
 

--- a/docs/goto_cleanup_pattern.md
+++ b/docs/goto_cleanup_pattern.md
@@ -63,14 +63,13 @@ The C standard guarantees that `free(NULL)` is a no-op. When `calloc` zero-initi
 
 ## Applied: `app_init()` in suckless-ogl
 
-The `app_init()` function uses a **two-label variant**:
+The `app_init()` function uses a **single-label** `goto cleanup_full` pattern:
 
 | Label | When Used | Cleanup Action |
 |-------|-----------|---------------|
-| `cleanup_alloc` | Allocation failures before GL context | Direct `free()` of 6 calloc'd pointers |
-| `cleanup_full` | Failures after subsystem init (GL active) | Calls `app_cleanup()` which handles partial teardown |
+| `cleanup_full` | Failures after subsystem descriptor init (GL active) | Calls `app_cleanup()` which handles partial teardown |
 
-**Why two labels?** `app_cleanup()` calls `app_input_state_cleanup()` and `app_profiling_cleanup()` which do **not** have NULL guards — calling them on uninitialized pointers would crash. The `cleanup_alloc` label handles the pre-init phase safely with direct `free(NULL)` calls.
+The previous `cleanup_alloc` label (for pre-GL allocation failures) was removed when subsystem descriptors took over. The descriptor table's `app_subsystems_init()` now handles rollback automatically: on the first failure at index *N*, it calls `cleanup()` in reverse for entries *[N-1 .. 0]*, freeing any `calloc`'d sub-structs. Only post-descriptor Phase 3 failures (scene, async loader, post-processing) still use `goto cleanup_full`.
 
 ## Comparison
 

--- a/include/app.h
+++ b/include/app.h
@@ -37,10 +37,11 @@ typedef struct App {
 	AppUIOverlay overlay; /**< Overlay and text rendering state. */
 
 	/* --- App State Flags and Values --- */
-	int width;                    /**< Current window/viewport width. */
-	int height;                   /**< Current window/viewport height. */
-	EnvManager* env_mgr;          /**< Environment/IBL state. */
-	ActionNotifier notifier;      /**< Temporary user notifications. */
+	const char* title;       /**< Window title (borrowed, not owned). */
+	int width;               /**< Current window/viewport width. */
+	int height;              /**< Current window/viewport height. */
+	EnvManager* env_mgr;     /**< Environment/IBL state. */
+	ActionNotifier notifier; /**< Temporary user notifications. */
 	EffectBenchmark effect_bench; /**< A/B effect cost measurement. */
 
 	/* --- Global GPU Resources --- */

--- a/include/app_window.h
+++ b/include/app_window.h
@@ -21,4 +21,10 @@ typedef struct {
 	int pending_height;            /**< Deferred resize target height. */
 } AppWindow;
 
+#include "app_subsystem.h"
+int app_window_subsys_init(struct App* app);
+void app_window_subsys_cleanup(struct App* app);
+#define APP_WINDOW_DESCRIPTOR \
+	{"window", app_window_subsys_init, app_window_subsys_cleanup}
+
 #endif /* APP_WINDOW_H */

--- a/src/app.c
+++ b/src/app.c
@@ -14,7 +14,6 @@
 #include "scene_gpu_resources.h"
 #include "texture.h"
 #include "tracy_gpu.h"
-#include "window.h"
 #include <GLFW/glfw3.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,13 +24,10 @@ static const char* const DEFAULT_ENV_FILENAME = "env.hdr";
  * Order matters: init runs forward, cleanup runs in reverse.
  * Sentinel-terminated: last entry is {0}. */
 static const SubsystemDescriptor APP_SUBSYSTEM_TABLE[] = {
-    APP_INPUT_DESCRIPTOR,
-    APP_PROFILING_DESCRIPTOR,
-    APP_POSTPROCESS_DESCRIPTOR,
-    APP_SCENE_DESCRIPTOR,
-    APP_ENV_MGR_DESCRIPTOR,
-    APP_ASYNC_COORD_DESCRIPTOR,
-    {0},
+    APP_WINDOW_DESCRIPTOR,      APP_INPUT_DESCRIPTOR,
+    APP_PROFILING_DESCRIPTOR,   APP_POSTPROCESS_DESCRIPTOR,
+    APP_SCENE_DESCRIPTOR,       APP_ENV_MGR_DESCRIPTOR,
+    APP_ASYNC_COORD_DESCRIPTOR, {0},
 };
 
 static void app_load_initial_hdr(App* app)
@@ -56,29 +52,11 @@ int app_init(App* app, int width, int height, const char* title)
 {
 	app->width = width;
 	app->height = height;
+	app->title = title;
 
 	if (!app_subsystems_init(app, APP_SUBSYSTEM_TABLE)) {
 		return 0;
 	}
-
-	app->win.is_fullscreen = false;
-	app->win.resize_pending = 0;
-
-	/* Phase 2: Window & GL context (no GL resources exist yet,
-	 * descriptor cleanup is sufficient on failure). */
-	app->win.handle = window_create(width, height, title, DEFAULT_SAMPLES);
-	if (!app->win.handle) {
-		app_subsystems_cleanup(app, APP_SUBSYSTEM_TABLE);
-		return 0;
-	}
-
-	glfwSwapInterval(0);
-	glfwSetWindowUserPointer(app->win.handle, app);
-	glfwSetKeyCallback(app->win.handle, key_callback);
-	glfwSetCursorPosCallback(app->win.handle, mouse_callback);
-	glfwSetScrollCallback(app->win.handle, scroll_callback);
-	glfwSetFramebufferSizeCallback(app->win.handle,
-	                               framebuffer_size_callback);
 
 	if (app->input->camera_enabled) {
 		glfwSetInputMode(app->win.handle, GLFW_CURSOR,
@@ -182,9 +160,6 @@ void app_cleanup(App* app)
 
 	/* Reverse-order cleanup of descriptor-managed subsystems */
 	app_subsystems_cleanup(app, APP_SUBSYSTEM_TABLE);
-
-	window_destroy(app->win.handle);
-	app->win.handle = NULL;
 }
 
 static void app_render_ui_trampoline(void* user_data)

--- a/src/app_window.c
+++ b/src/app_window.c
@@ -1,0 +1,34 @@
+#include "app.h"
+#include "app_input.h"
+#include "app_settings.h"
+#include "window.h"
+
+int app_window_subsys_init(App* app)
+{
+	app->win.is_fullscreen = false;
+	app->win.resize_pending = 0;
+
+	app->win.handle =
+	    window_create(app->width, app->height, app->title, DEFAULT_SAMPLES);
+	if (!app->win.handle) {
+		return 0;
+	}
+
+	glfwSwapInterval(0);
+	glfwSetWindowUserPointer(app->win.handle, app);
+	glfwSetKeyCallback(app->win.handle, key_callback);
+	glfwSetCursorPosCallback(app->win.handle, mouse_callback);
+	glfwSetScrollCallback(app->win.handle, scroll_callback);
+	glfwSetFramebufferSizeCallback(app->win.handle,
+	                               framebuffer_size_callback);
+
+	return 1;
+}
+
+void app_window_subsys_cleanup(App* app)
+{
+	if (app->win.handle) {
+		window_destroy(app->win.handle);
+		app->win.handle = NULL;
+	}
+}

--- a/src/camera_input.c
+++ b/src/camera_input.c
@@ -1,6 +1,9 @@
 #include "camera_input.h"
 
 #include "camera.h"
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
 #include <GLFW/glfw3.h>
 
 void camera_input_handle_key(Camera* cam, int key, int action)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -662,6 +662,7 @@ add_executable(test_async_coordinator
     test_async_coordinator.c
     ${unity_SOURCE_DIR}/src/unity.c
     ${CMAKE_SOURCE_DIR}/src/async_coordinator.c
+    ${CMAKE_SOURCE_DIR}/src/platform/platform_utils.c
 )
 target_include_directories(test_async_coordinator PRIVATE
     ${CMAKE_SOURCE_DIR}/tests/mocks/standalone


### PR DESCRIPTION
## Summary

Extract GLFW window creation/destruction from inline code in `app_init()`/`app_cleanup()` into a dedicated subsystem descriptor (`APP_WINDOW_DESCRIPTOR`) in `src/app_window.c`.

## Changes

### refactor(core): extract window lifecycle
- **`src/app_window.c`** (new): `app_window_subsys_init()` creates window, registers GLFW callbacks, sets VSync off; `app_window_subsys_cleanup()` destroys window
- **`include/app_window.h`**: Declares init/cleanup + `APP_WINDOW_DESCRIPTOR` macro
- **`include/app.h`**: Adds `const char* title` field (borrowed pointer)
- **`src/app.c`**: `APP_WINDOW_DESCRIPTOR` placed **first** in table (GL context needed by all others; cleaned up last in reverse)
- **`CMakeLists.txt`**: Adds `src/app_window.c` to SOURCES

### fix(build): unity build compatibility
- **`src/camera_input.c`**: Adds `GLFW_INCLUDE_NONE` guard — prevents GLFW from pulling system GL headers when `CMAKE_UNITY_BUILD` merges TUs

### fix(test): linker fix
- **`tests/CMakeLists.txt`**: Links `platform_utils.c` in `test_async_coordinator` (resolves `platform_aligned_alloc` undefined)

### docs(architecture): update documentation
- **architecture.md/fr**: Descriptor table updated (2→7 entries), ordering constraint documented, AppWindow delegation added
- **application_lifecycle.md/fr**: Chapter 2 references descriptor-driven window creation
- **goto_cleanup_pattern.md/fr**: Removes obsolete `cleanup_alloc` label (descriptor rollback handles it)

## Validation

| Target | Build | Run | Integration |
|--------|-------|-----|-------------|
| Debug | ✅ | ✅ (exit 124) | ✅ |
| Release | ✅ | ✅ | ✅ |
| Ultra (Unity+LTO) | ✅ | ✅ | ✅ |
| Small (-Os) | ✅ | ✅ | ✅ |
| Profile | ✅ | ✅ | ✅ |
| ASAN | ✅ | ✅ | ✅ |
| SSBO | ✅ | ✅ | ✅ |
| Sync | ✅ | ✅ | ✅ |
| RenderDoc | ✅ | ⊘ (shares build/) | — |
| Tracy | ❌ pre-existing | — | — |

- **Unit tests**: 69/69 passed
- **Format**: 0 changes
- **Lint**: 0 warnings

Part of #284 (re-architect app_init with subsystem descriptors).
Stacked on #292.