### PR TITLE
ci(github-actions): trigger CI on PRs targeting any branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,8 @@ on:
     branches: ["master", "main"]
     tags: ["v*"]
   pull_request:
-    # Pour tout le reste, on passe par les PRs (master/main comme cibles)
-    # Cela garantit un seul run par commit dans une PR
+    # Run CI on ALL PRs regardless of target branch (supports stacked PRs)
     # 'closed' is needed for PR preview cleanup on GitHub Pages
-    branches: ["master", "main"]
     types: [opened, reopened, synchronize, closed]
   schedule:
     # Build nightly tous les jours à 01h00 UTC


### PR DESCRIPTION
## Summary

Remove the `branches: ["master", "main"]` filter from the `pull_request` trigger so that **all PRs** get CI validation, not just those targeting master/main.

## Motivation

Stacked PRs (e.g. `step3 → step2 → mvp → master`) never triggered CI because their target branch was another feature branch, not master. This is a blind spot — code changes should always be validated.

## Safety

Deploy/release/pages jobs already guard themselves with `if: github.ref == 'refs/heads/master'`, so they naturally skip on feature branches. Only build/test/lint jobs will run on non-master PRs.

## Change

```diff
  pull_request:
-    branches: ["master", "main"]
+    # Run CI on ALL PRs regardless of target branch (supports stacked PRs)
     types: [opened, reopened, synchronize, closed]
```