### PR TITLE
refactor(input): encapsulate camera↔gamepad copy-in/copy-out

### DIFF
--- a/include/camera_input.h
+++ b/include/camera_input.h
@@ -44,4 +44,19 @@ void camera_input_handle_mouse(Camera* cam, double xpos, double ypos);
  */
 void camera_input_handle_scroll(Camera* cam, double yoffset);
 
+/* Forward declaration */
+typedef struct GamepadState GamepadState;
+
+/**
+ * @brief Applies gamepad input to camera within a fixed physics step.
+ *
+ * Encapsulates the Camera↔GamepadContext copy-in/copy-out pattern:
+ * builds the GamepadContext from Camera fields, calls gamepad_write_input(),
+ * then copies modified values back into the Camera.
+ *
+ * @param cam   Pointer to the Camera instance (move_input, yaw/pitch_target).
+ * @param state Pointer to the gamepad state (with cached axes from poll).
+ */
+void camera_apply_gamepad(Camera* cam, const GamepadState* state);
+
 #endif /* CAMERA_INPUT_H */

--- a/src/app.c
+++ b/src/app.c
@@ -8,6 +8,7 @@
 #include "app_ui.h"
 #include "async/async_coordinator.h"
 #include "async_loader.h"
+#include "camera_input.h"
 #include "env_manager.h"
 #include "lum_histogram.h"
 #include "postprocess_internal.h"
@@ -236,24 +237,8 @@ void app_run(App* app)
 			       app->input->camera.fixed_timestep) {
 				camera_build_keyboard_input(
 				    &app->input->camera);
-				Camera* cam = &app->input->camera;
-				GamepadContext gctx = {
-				    .move_input = {cam->move_input[0],
-				                   cam->move_input[1],
-				                   cam->move_input[2]},
-				    .yaw_target = cam->yaw_target,
-				    .pitch_target = cam->pitch_target,
-				    .fixed_timestep = cam->fixed_timestep,
-				    .max_pitch = DEFAULT_MAX_PITCH,
-				    .min_pitch = DEFAULT_MIN_PITCH,
-				};
-				gamepad_write_input(&app->input->gamepad,
-				                    &gctx);
-				cam->move_input[0] = gctx.move_input[0];
-				cam->move_input[1] = gctx.move_input[1];
-				cam->move_input[2] = gctx.move_input[2];
-				cam->yaw_target = gctx.yaw_target;
-				cam->pitch_target = gctx.pitch_target;
+				camera_apply_gamepad(&app->input->camera,
+				                     &app->input->gamepad);
 				camera_fixed_update(&app->input->camera);
 				app->input->camera.physics_accumulator -=
 				    app->input->camera.fixed_timestep;

--- a/src/camera_input.c
+++ b/src/camera_input.c
@@ -1,6 +1,7 @@
 #include "camera_input.h"
 
 #include "camera.h"
+#include "gamepad_input.h"
 #ifndef GLFW_INCLUDE_NONE
 #define GLFW_INCLUDE_NONE
 #endif
@@ -51,4 +52,20 @@ void camera_input_handle_mouse(Camera* cam, double xpos, double ypos)
 void camera_input_handle_scroll(Camera* cam, double yoffset)
 {
 	camera_process_scroll(cam, (float)yoffset);
+}
+
+void camera_apply_gamepad(Camera* cam, const GamepadState* state)
+{
+	GamepadContext gctx = {
+	    .yaw_target = cam->yaw_target,
+	    .pitch_target = cam->pitch_target,
+	    .fixed_timestep = cam->fixed_timestep,
+	    .max_pitch = DEFAULT_MAX_PITCH,
+	    .min_pitch = DEFAULT_MIN_PITCH,
+	};
+	glm_vec3_copy(cam->move_input, gctx.move_input);
+	gamepad_write_input(state, &gctx);
+	glm_vec3_copy(gctx.move_input, cam->move_input);
+	cam->yaw_target = gctx.yaw_target;
+	cam->pitch_target = gctx.pitch_target;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -436,6 +436,7 @@ add_executable(test_gamepad_input
     test_gamepad_input.c
     ${unity_SOURCE_DIR}/src/unity.c
     ${CMAKE_SOURCE_DIR}/src/camera.c
+    ${CMAKE_SOURCE_DIR}/src/camera_input.c
     ${CMAKE_SOURCE_DIR}/src/gamepad_input.c
     ${CMAKE_SOURCE_DIR}/src/utils.c
 )

--- a/tests/test_camera_input.c
+++ b/tests/test_camera_input.c
@@ -1,8 +1,16 @@
 #include "camera.h"
 #include "camera_input.h"
+#include "gamepad_input.h"
 #include "unity.h"
 #include <GLFW/glfw3.h>
 #include <math.h>
+
+/* Stub — test_camera_input only validates keyboard/mouse, not gamepad. */
+void gamepad_write_input(const GamepadState* state, GamepadContext* ctx)
+{
+	(void)state;
+	(void)ctx;
+}
 
 void setUp(void)
 {

--- a/tests/test_gamepad_input.c
+++ b/tests/test_gamepad_input.c
@@ -1,4 +1,5 @@
 #include "camera.h"
+#include "camera_input.h"
 #include "gamepad_input.h"
 #include "log.h"
 #include "unity.h"
@@ -11,22 +12,20 @@
 
 static GamepadContext gamepad_ctx_from_camera(const Camera* cam)
 {
-	return (GamepadContext){
-	    .move_input = {cam->move_input[0], cam->move_input[1],
-	                   cam->move_input[2]},
+	GamepadContext gctx = {
 	    .yaw_target = cam->yaw_target,
 	    .pitch_target = cam->pitch_target,
 	    .fixed_timestep = cam->fixed_timestep,
 	    .max_pitch = DEFAULT_MAX_PITCH,
 	    .min_pitch = DEFAULT_MIN_PITCH,
 	};
+	glm_vec3_copy((float*)cam->move_input, gctx.move_input);
+	return gctx;
 }
 
 static void gamepad_ctx_to_camera(const GamepadContext* ctx, Camera* cam)
 {
-	cam->move_input[0] = ctx->move_input[0];
-	cam->move_input[1] = ctx->move_input[1];
-	cam->move_input[2] = ctx->move_input[2];
+	glm_vec3_copy((float*)ctx->move_input, cam->move_input);
 	cam->yaw_target = ctx->yaw_target;
 	cam->pitch_target = ctx->pitch_target;
 }
@@ -344,6 +343,61 @@ void test_poll_sticks_in_deadzone_no_effect(void)
 	TEST_ASSERT_FLOAT_WITHIN(0.0001F, yaw_before, cam.yaw_target);
 }
 
+/* ---- camera_apply_gamepad encapsulation test ---- */
+
+void test_camera_apply_gamepad_transfers_axes(void)
+{
+	GamepadState state;
+	gamepad_input_init(&state);
+
+	Camera cam;
+	camera_init(&cam, 10.0F, 90.0F, 0.0F);
+	glm_vec3_zero(cam.velocity_current);
+
+	g_mock_gamepad_connected = 1;
+	/* Left stick pushed full forward (Y axis negative = forward). */
+	g_mock_gamepad_state.axes[GLFW_GAMEPAD_AXIS_LEFT_X] = 0.0F;
+	g_mock_gamepad_state.axes[GLFW_GAMEPAD_AXIS_LEFT_Y] = -1.0F;
+	/* Right stick pushed right (yaw). */
+	g_mock_gamepad_state.axes[GLFW_GAMEPAD_AXIS_RIGHT_X] = 0.8F;
+	g_mock_gamepad_state.axes[GLFW_GAMEPAD_AXIS_RIGHT_Y] = 0.0F;
+	g_mock_gamepad_state.axes[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER] = -1.0F;
+	g_mock_gamepad_state.axes[GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER] = -1.0F;
+
+	gamepad_input_poll(&state, NULL);
+	camera_build_keyboard_input(&cam);
+
+	float yaw_before = cam.yaw_target;
+	camera_apply_gamepad(&cam, &state);
+
+	/* Forward movement should be set (move_input[2] > 0). */
+	TEST_ASSERT_TRUE(cam.move_input[2] > 0.5F);
+	/* Yaw should have changed from the right stick. */
+	TEST_ASSERT_TRUE(cam.yaw_target != yaw_before);
+}
+
+void test_camera_apply_gamepad_no_gamepad_no_change(void)
+{
+	GamepadState state;
+	gamepad_input_init(&state);
+
+	Camera cam;
+	camera_init(&cam, 10.0F, 90.0F, 0.0F);
+	glm_vec3_zero(cam.velocity_current);
+	cam.move_input[0] = 0.5F;
+	cam.move_input[2] = 0.7F;
+	float yaw_before = cam.yaw_target;
+
+	g_mock_gamepad_connected = 0;
+	gamepad_input_poll(&state, NULL);
+	camera_apply_gamepad(&cam, &state);
+
+	/* With no gamepad, values should remain unchanged. */
+	TEST_ASSERT_FLOAT_WITHIN(0.0001F, 0.5F, cam.move_input[0]);
+	TEST_ASSERT_FLOAT_WITHIN(0.0001F, 0.7F, cam.move_input[2]);
+	TEST_ASSERT_FLOAT_WITHIN(0.0001F, yaw_before, cam.yaw_target);
+}
+
 int main(void)
 {
 	UNITY_BEGIN();
@@ -359,5 +413,7 @@ int main(void)
 	RUN_TEST(test_poll_left_trigger_moves_down);
 	RUN_TEST(test_share_button_triggers_camera_reset);
 	RUN_TEST(test_poll_sticks_in_deadzone_no_effect);
+	RUN_TEST(test_camera_apply_gamepad_transfers_axes);
+	RUN_TEST(test_camera_apply_gamepad_no_gamepad_no_change);
 	return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Extracts the 15-line copy-in/copy-out boilerplate between `Camera` and `GamepadContext` in `app_run()`'s physics loop into a single `camera_apply_gamepad()` function.

## Changes

### Production code
- **`include/camera_input.h`**: declare `camera_apply_gamepad(Camera*, const GamepadState*)`
- **`src/camera_input.c`**: implement using `glm_vec3_copy()` for vec3 transfers
- **`src/app.c`**: replace 15-line block with single call

### Tests
- **`tests/test_gamepad_input.c`**: add 2 tests (`transfers_axes`, `no_gamepad_no_change`), use `glm_vec3_copy()` in bridge helpers
- **`tests/test_camera_input.c`**: add `gamepad_write_input` stub for linker
- **`tests/CMakeLists.txt`**: add `camera_input.c` to `test_gamepad_input` sources

## Acceptance criteria from #280
- [x] Copy-in/copy-out encapsulated in single function
- [x] Adding a new gamepad axis = 1 modification point
- [x] Call site in `app_run()` reduced to 1 line
- [x] No regression: 69/69 tests pass
- [x] `just format && just lint`: 0 new violations
- [x] Unit tests covering `camera_apply_gamepad()`

Closes #280