### PR TITLE
style(core): normalize boolean fields to bool/true/false across structs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,10 @@ CheckOptions:
     value:           'postprocess_internal\.h'
   - key:             misc-include-cleaner.MissingIncludes
     value:           'false'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           'true'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           'true'
   - key:             readability‑braces‑around‑statements.ShortStatementLines
     value:           '0'
   - key:             readability‑function‑size.LineThreshold

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,7 @@ The following instruction files contain the authoritative, detailed rules. **Do 
 
 - **commit-workflow.instructions.md** — SoC commit discipline, Conventional Commits format, pre-commit workflow, branching strategy, git safety rules.
 - **testing-quality.instructions.md** — CI validation, test coverage, code quality standards, no-suppression policy, Justfile discipline, documentation gates, RenderDoc observability.
+- **c-coding-style.instructions.md** — C type conventions, boolean usage (`bool`/`true`/`false`), clang-tidy `readability-implicit-bool-conversion` patterns, GPU UBO exceptions.
 - **github-project.instructions.md** — PR workflow, labels, milestones, project board management, issue lifecycle.
 
 ---

--- a/.github/instructions/c-coding-style.instructions.md
+++ b/.github/instructions/c-coding-style.instructions.md
@@ -1,0 +1,160 @@
+---
+description: "Use when writing or reviewing C code. Covers type conventions, boolean usage, and patterns required by clang-tidy readability checks."
+applyTo: ["src/**/*.c", "include/**/*.h", "tests/**/*.c"]
+---
+# C Coding Style Conventions
+
+## Boolean Fields & Variables
+
+### Rule: Always use C99 `bool`/`true`/`false` for boolean semantics
+
+Any struct field, local variable, or parameter that represents a binary on/off, yes/no, or enabled/disabled state **MUST** use `bool` (from `<stdbool.h>`), not `int`.
+
+```c
+// ✅ Correct
+#include <stdbool.h>
+typedef struct {
+    bool enabled;
+    bool visible;
+} Widget;
+
+// ❌ Forbidden — int-as-boolean
+typedef struct {
+    int enabled;   // 0 or 1 — use bool instead
+    int visible;
+} Widget;
+```
+
+### Rule: Include `<stdbool.h>` in every header that declares `bool` fields
+
+Do not rely on transitive includes. Each header is self-contained.
+
+### clang-tidy `readability-implicit-bool-conversion` Patterns
+
+The project enforces this check as an error. These patterns are required:
+
+#### 1. Bool negation assignment
+
+`!bool_expr` returns `int` in C. Assigning it back to `bool` triggers the warning.
+
+```c
+// ❌ Triggers warning
+field = !field;
+
+// ✅ Correct
+field = ((!field) != 0);
+```
+
+#### 2. Bool in ternary operator condition
+
+A `bool` used as ternary condition is implicitly converted to `int`.
+
+```c
+// ❌ Triggers warning
+const char* s = flag ? "ON" : "OFF";
+
+// ✅ Correct
+const char* s = (int)flag ? "ON" : "OFF";
+```
+
+#### 3. Bool in arithmetic expressions
+
+Bool operands in arithmetic (`+`, `-`, `*`) require explicit `(int)` cast.
+
+```c
+// ❌ Triggers warning
+float input = (float)(move_right - move_left);
+
+// ✅ Correct (move_right/move_left are bool)
+float input = (float)((int)move_right - (int)move_left);
+```
+
+#### 4. Logical OR/AND assigned to bool
+
+`||` and `&&` return `int` in C. Assignment to `bool` needs `!= 0`.
+
+```c
+// ❌ Triggers warning
+bool active = a || b || c;
+
+// ✅ Correct
+bool active = (a || b || c) != 0;
+```
+
+#### 5. External API int→bool
+
+Functions returning `int` as boolean (GLFW, OpenGL) need explicit comparison.
+
+```c
+// ❌ Triggers warning
+state->connected = glfwJoystickIsGamepad(id);
+
+// ✅ Correct
+state->connected = (glfwJoystickIsGamepad(id) != 0);
+```
+
+#### 6. Bool→int for GPU uniforms/UBOs
+
+GPU memory layout uses `int32_t`/`GLint`. Explicit cast required.
+
+```c
+// ❌ Triggers warning
+glUniform1i(loc, config.wireframe);
+ubo.field = source_bool;
+
+// ✅ Correct
+glUniform1i(loc, (GLint)config.wireframe);
+ubo.field = (int32_t)source_bool;
+```
+
+#### 7. Compound literal initialization
+
+`{0}` for a struct with `bool` fields triggers int→bool. Use designated init.
+
+```c
+// ❌ Triggers warning
+*mgr = (Manager){0};
+
+// ✅ Correct
+*mgr = (Manager){.bool_field = false};
+```
+
+### Exceptions — Fields That Must Stay `int`
+
+- **GPU UBO/SSBO structs** (`scene_uniforms.h`): Fields mapped to GPU memory layout stay `int32_t` — GPU has no `bool` type
+- **Multi-value state** (e.g. `loading_step = 0,1,2,3`): Not boolean, keep `int`
+- **Bitfields**: Use `unsigned int field : 1` when packing, not `bool`
+
+### Helper Macros (`include/bool_utils.h`)
+
+Instead of writing raw casts everywhere, **use the centralized macros** from `bool_utils.h`:
+
+```c
+#include "bool_utils.h"
+
+// Toggle a bool field (replaces `x = ((!x) != 0)`)
+BOOL_TOGGLE(field);
+
+// Convert bool→int for ternary, arithmetic, or GPU uniforms
+BOOL_TO_INT(flag) ? "ON" : "OFF";
+float input = (float)(BOOL_TO_INT(right) - BOOL_TO_INT(left));
+glUniform1i(loc, BOOL_TO_INT(config.wireframe));
+ubo.field = BOOL_TO_INT(source_bool);
+
+// Convert int→bool (external API or logical expression)
+state->connected = INT_TO_BOOL(glfwJoystickIsGamepad(id));
+bool active = INT_TO_BOOL(a || b || c);
+```
+
+**Prefer macros** over raw casts in new code. They centralize the workaround and can be updated if C23 or future clang-tidy changes remove the need.
+
+## Volatile Booleans (Threading)
+
+For boolean flags shared across threads, use `volatile bool`:
+
+```c
+volatile bool running;
+volatile bool results_ready;
+```
+
+This is well-defined in C99/C11 for simple flag signaling (not for synchronization — use mutexes for that).

--- a/include/action_notifier.h
+++ b/include/action_notifier.h
@@ -7,6 +7,7 @@
 #define ACTION_NOTIFIER_H
 
 #include "ui.h"
+#include <stdbool.h>
 
 /** @brief Maximum number of concurrent notifications. */
 #define MAX_ACTION_NOTIFICATIONS 5
@@ -31,7 +32,7 @@ typedef struct ActionNotification {
 	char text[MAX_ACTION_TEXT_LENGTH];
 	float lifetime;     /**< Current time active (seconds). */
 	float max_lifetime; /**< Total time to display (seconds). */
-	int active;         /**< Whether this slot is occupied. */
+	bool active;        /**< Whether this slot is occupied. */
 } ActionNotification;
 
 /**

--- a/include/app_input.h
+++ b/include/app_input.h
@@ -15,6 +15,7 @@
 #define APP_INPUT_H
 
 #include "gl_common.h"
+#include <stdbool.h>
 
 /* Forward declarations — avoids pulling heavy headers into app_input.h */
 typedef struct App App;
@@ -56,12 +57,12 @@ typedef struct {
 	int* width;
 	int* height;
 	int* camera_enabled;
-	int* is_fullscreen;
+	bool* is_fullscreen;
 	int* saved_x;
 	int* saved_y;
 	int* saved_width;
 	int* saved_height;
-	int* resize_pending;
+	bool* resize_pending;
 	int* pending_width;
 	int* pending_height;
 	int* perf_mode_active;

--- a/include/app_input.h
+++ b/include/app_input.h
@@ -56,7 +56,7 @@ typedef struct {
 	/* Mutable scalar state (pointers so mutations propagate to App) */
 	int* width;
 	int* height;
-	int* camera_enabled;
+	bool* camera_enabled;
 	bool* is_fullscreen;
 	int* saved_x;
 	int* saved_y;
@@ -65,8 +65,8 @@ typedef struct {
 	bool* resize_pending;
 	int* pending_width;
 	int* pending_height;
-	int* perf_mode_active;
-	int* log_gpu_metrics;
+	bool* perf_mode_active;
+	bool* log_gpu_metrics;
 } AppInputContext;
 
 /**

--- a/include/app_input_state.h
+++ b/include/app_input_state.h
@@ -14,6 +14,7 @@
 #include "app_binding.h"
 #include "camera.h"
 #include "gamepad_input.h"
+#include <stdbool.h>
 
 /**
  * @struct AppInput
@@ -25,7 +26,7 @@ typedef struct AppInput {
 	AppBindingRegistry
 	    binding_registry;        /**< Key-binding overlay registry. */
 	AdaptiveSampler fps_sampler; /**< Jitter compensation for input. */
-	int camera_enabled;          /**< Pause camera movement. */
+	bool camera_enabled;         /**< Pause camera movement. */
 } AppInput;
 
 /**

--- a/include/app_profiling.h
+++ b/include/app_profiling.h
@@ -16,6 +16,7 @@
 #include "gpu_usage.h"
 #include "perf_mode.h"
 #include "tracy_manager.h"
+#include <stdbool.h>
 
 /**
  * @struct AppProfiling
@@ -28,8 +29,8 @@ typedef struct AppProfiling {
 	TracyManager tracy_mgr;       /**< Tracy instrumentation manager. */
 	GPUUsageMonitor gpu_usage;    /**< GPU utilization % via DRM fdinfo. */
 	PerfModeContext perf_context; /**< Performance mode state context. */
-	int perf_mode_active; /**< Performance/GameMode optimization active. */
-	int log_gpu_metrics;  /**< Toggle console logging of GPU stats. */
+	bool perf_mode_active; /**< Performance/GameMode optimization active. */
+	bool log_gpu_metrics;  /**< Toggle console logging of GPU stats. */
 } AppProfiling;
 
 /**

--- a/include/app_settings.h
+++ b/include/app_settings.h
@@ -19,6 +19,7 @@
 #define APP_SETTINGS_H
 
 #include <cglm/types.h>
+#include <stdbool.h>
 
 /**
  * @defgroup Renderer Renderer Configuration
@@ -145,8 +146,8 @@ static const int IRIDIANCE_MAP_SIZE =
     64; /**< Size of the diffuse irradiance map. */
 static const int BRDF_LUT_MAP_SIZE =
     512; /**< Size of the BRDF Lookup Texture (Generated once). */
-static const int DEFAULT_SPECULAR_AA_ENABLED =
-    1; /**< Toggle for Curvature-based Specular Anti-Aliasing. */
+static const bool DEFAULT_SPECULAR_AA_ENABLED =
+    true; /**< Toggle for Curvature-based Specular Anti-Aliasing. */
 
 /* Environment Transition Mode */
 typedef enum {

--- a/include/app_ui.h
+++ b/include/app_ui.h
@@ -10,6 +10,7 @@
 #define APP_UI_H
 #include "glad/glad.h"
 #include "ui.h"
+#include <stdbool.h>
 
 /* Histogram bucket count (used by tests and postprocess) */
 enum { HISTO_BUCKETS = 256 };
@@ -42,9 +43,9 @@ typedef struct AppUIOverlay {
 	KeyboardLayoutConfig kbd_config;
 
 	HelpMode show_help;
-	int show_info_overlay;
+	bool show_info_overlay;
 	int text_overlay_mode;
-	int show_exposure_debug;
+	bool show_exposure_debug;
 
 	int help_hovered_key;
 	int help_pressed_key;

--- a/include/app_ui.h
+++ b/include/app_ui.h
@@ -69,7 +69,7 @@ typedef struct AppUIOverlay {
 	/** Set to 1 when the overlay auto-disabled the camera on open, so we
 	 *  can re-enable it exactly the same way (simulate 'C' press) on close.
 	 */
-	int help_captured_camera;
+	bool help_captured_camera;
 } AppUIOverlay;
 
 typedef struct App App;

--- a/include/app_ui_layout.h
+++ b/include/app_ui_layout.h
@@ -13,6 +13,7 @@
 #include "app_settings.h" /* DEFAULT_FONT_SIZE */
 #include <GLFW/glfw3.h>   /* GLFW_KEY_*, GLFW_GAMEPAD_* */
 #include <cglm/types.h>   /* vec3 */
+#include <stdbool.h>
 
 /* ================================================================
  * UI Scaling and Layout Defaults
@@ -218,7 +219,7 @@ typedef struct {
 	float y_off;
 	float width;
 	float height;
-	int is_bound;
+	bool is_bound;
 	int bind_type;
 	int gp_btn;
 	int gp_axis;

--- a/include/app_window.h
+++ b/include/app_window.h
@@ -2,6 +2,7 @@
 #define APP_WINDOW_H
 
 #include "gl_common.h"
+#include <stdbool.h>
 
 /**
  * @struct AppWindow
@@ -13,10 +14,10 @@
  */
 typedef struct {
 	GLFWwindow* handle;            /**< The GLFW window context. */
-	int is_fullscreen;             /**< Fullscreen toggle state. */
+	bool is_fullscreen;            /**< Fullscreen toggle state. */
 	int saved_x, saved_y;          /**< Cached pos for window restore. */
 	int saved_width, saved_height; /**< Cached size for window restore. */
-	int resize_pending;            /**< Deferred resize flag. */
+	bool resize_pending;           /**< Deferred resize flag. */
 	int pending_width;             /**< Deferred resize target width. */
 	int pending_height;            /**< Deferred resize target height. */
 } AppWindow;

--- a/include/bool_utils.h
+++ b/include/bool_utils.h
@@ -1,0 +1,38 @@
+#ifndef BOOL_UTILS_H
+#define BOOL_UTILS_H
+
+/**
+ * @file bool_utils.h
+ * @brief Portable bool↔int conversion macros for clang-tidy compliance.
+ *
+ * C's `!` operator, `||`/`&&`, and ternary conditions return `int`,
+ * which triggers `readability-implicit-bool-conversion` when assigned
+ * to or used with `bool` fields.  These macros centralize the casts
+ * so the workaround lives in one place and can be revisited if C23
+ * or a future clang-tidy relaxation removes the need.
+ */
+
+/**
+ * @brief Toggle a bool lvalue (equivalent to `x = !x`).
+ *
+ * `!x` returns int in C; direct assignment to bool triggers the check.
+ */
+#define BOOL_TOGGLE(lval) ((lval) = ((!(lval)) != 0))
+
+/**
+ * @brief Convert a bool to int explicitly.
+ *
+ * Use in ternary conditions, arithmetic expressions, and GPU uniform
+ * uploads where an int/GLint/int32_t is expected from a bool source.
+ */
+#define BOOL_TO_INT(b) ((int)(b))
+
+/**
+ * @brief Convert an int expression to bool explicitly.
+ *
+ * Use for external API returns (GLFW, OpenGL) and logical OR/AND
+ * chains assigned to a bool variable.
+ */
+#define INT_TO_BOOL(expr) ((expr) != 0)
+
+#endif /* BOOL_UTILS_H */

--- a/include/camera.h
+++ b/include/camera.h
@@ -7,6 +7,7 @@
 #define CAMERA_H
 
 #include <cglm/cglm.h>
+#include <stdbool.h>
 
 /* --- Camera Defaults --- */
 
@@ -97,7 +98,7 @@ typedef struct Camera {
 	/* Input State */
 	double last_mouse_x; /**< Previous mouse X position. */
 	double last_mouse_y; /**< Previous mouse Y position. */
-	int first_mouse;     /**< Flag to handle initial mouse jump. */
+	bool first_mouse;    /**< Flag to handle initial mouse jump. */
 } Camera;
 
 /**

--- a/include/camera.h
+++ b/include/camera.h
@@ -53,12 +53,12 @@ typedef struct Camera {
 	float zoom;        /**< Current Field of View (FOV) in degrees. */
 
 	/* Movement states (booleans — set by keyboard callbacks) */
-	int move_forward;
-	int move_backward;
-	int move_left;
-	int move_right;
-	int move_up;
-	int move_down;
+	bool move_forward;
+	bool move_backward;
+	bool move_left;
+	bool move_right;
+	bool move_up;
+	bool move_down;
 
 	/* Unified movement input [-1,1] per camera-local axis.
 	 * [0] = right (+) / left (-),
@@ -86,7 +86,7 @@ typedef struct Camera {
 	float bobbing_frequency; /**< Speed of the bobbing motion. */
 	float
 	    bobbing_amplitude; /**< Vertical distance of the bobbing motion. */
-	int bobbing_enabled;   /**< Boolean toggle for head bobbing effect. */
+	bool bobbing_enabled;  /**< Boolean toggle for head bobbing effect. */
 
 	/* Timing */
 	float physics_accumulator; /**< Residual time for fixed-step physics. */

--- a/include/env_manager.h
+++ b/include/env_manager.h
@@ -14,6 +14,7 @@
 #include "async_loader.h"
 #include "gl_common.h"
 #include "ibl_coordinator.h"
+#include <stdbool.h>
 
 // Forward declarations
 typedef struct Scene Scene;
@@ -31,7 +32,7 @@ typedef struct EnvManager {
 	TransitionState transition_state;
 	float transition_alpha;
 	float transition_duration;
-	int is_first_load;
+	bool is_first_load;
 	int env_transition_mode; /**< EnvTransitionMode. */
 	GLuint pending_env_tex;  /**< Texture being assembled before IBL. */
 } EnvManager;

--- a/include/env_manager.h
+++ b/include/env_manager.h
@@ -25,7 +25,7 @@ typedef struct PostProcess PostProcess;
  * @brief Encapsulates state for environment loading, transitions, and IBL.
  */
 typedef struct EnvManager {
-	int env_map_loading;      /**< Async lock for HDR loading. */
+	bool env_map_loading;     /**< Async lock for HDR loading. */
 	int env_map_loading_step; /**< Multi-frame loading step counter. */
 	AsyncRequest
 	    current_env_req; /**< Currently processing async request. */

--- a/include/gamepad_input.h
+++ b/include/gamepad_input.h
@@ -12,6 +12,7 @@
 #define GAMEPAD_INPUT_H
 
 #include "gamepad_context.h"
+#include <stdbool.h>
 
 /** Maximum number of gamepad buttons tracked for edge detection. */
 #define GAMEPAD_BUTTON_COUNT 15
@@ -33,16 +34,16 @@
  * @brief Edge-detected button events produced by a single poll.
  */
 typedef struct GamepadActions {
-	int env_next; /**< R1 pressed → cycle to next environment map. */
-	int env_prev; /**< L1 pressed → cycle to previous environment map. */
-	int camera_reset; /**< Share pressed → reset camera to initial pose. */
+	bool env_next; /**< R1 pressed → cycle to next environment map. */
+	bool env_prev; /**< L1 pressed → cycle to previous environment map. */
+	bool camera_reset; /**< Share pressed → reset camera to initial pose. */
 } GamepadActions;
 
 /** Number of gamepad axes cached for per-step application. */
 #define GAMEPAD_AXIS_COUNT 6
 
 typedef struct GamepadState {
-	int connected;          /**< Non-zero if a gamepad is present. */
+	bool connected;         /**< Non-zero if a gamepad is present. */
 	int joystick_id;        /**< GLFW joystick slot (GLFW_JOYSTICK_1…16). */
 	float deadzone;         /**< Analog stick dead-zone threshold. */
 	float look_sensitivity; /**< Right-stick sensitivity multiplier. */

--- a/include/light_probes.h
+++ b/include/light_probes.h
@@ -4,6 +4,7 @@
 #include "sh_math.h"
 #include <cglm/cglm.h>
 #include <pthread.h>
+#include <stdbool.h>
 
 typedef struct Shader Shader;
 typedef struct SphereInstance SphereInstance;
@@ -42,9 +43,9 @@ typedef struct {
 	pthread_t worker_thread;
 	pthread_mutex_t mutex;
 	pthread_cond_t cond;
-	volatile int running;
-	volatile int update_pending;
-	volatile int results_ready;
+	volatile bool running;
+	volatile bool update_pending;
+	volatile bool results_ready;
 
 	/* Debug Resources */
 	Shader* debug_shader;

--- a/include/perf_mode.h
+++ b/include/perf_mode.h
@@ -22,6 +22,7 @@
 #define PERF_MODE_H
 
 #include <sched.h>
+#include <stdbool.h>
 
 /**
  * @enum PerfModeState
@@ -55,7 +56,7 @@ typedef struct PerfModeContext {
 	int original_policy;               /**< Saved scheduler policy. */
 	struct sched_param original_param; /**< Saved scheduler params. */
 	int original_nice;                 /**< Saved process nice value. */
-	int initialized;                   /**< Initialization flag. */
+	bool initialized;                  /**< Initialization flag. */
 } PerfModeContext;
 
 /**

--- a/include/perf_timer.h
+++ b/include/perf_timer.h
@@ -11,6 +11,7 @@
 #define PERF_TIMER_H
 
 #include "gl_common.h"
+#include <stdbool.h>
 #include <time.h>
 
 /**
@@ -34,7 +35,7 @@ typedef struct {
 typedef struct {
 	GLuint query_start; /**< Handle for the start timestamp query. */
 	GLuint query_end;   /**< Handle for the end timestamp query. */
-	int active; /**< Flag indicating if a measurement is in progress. */
+	bool active; /**< Flag indicating if a measurement is in progress. */
 } GPUTimer;
 
 #ifdef TRACY_ENABLE

--- a/include/pp_exposure_readback.h
+++ b/include/pp_exposure_readback.h
@@ -7,6 +7,7 @@
  */
 
 #include "gl_common.h"
+#include <stdbool.h>
 #include <stdint.h>
 
 #define POSTPROCESS_HISTOGRAM_BUCKETS 256
@@ -29,7 +30,7 @@ typedef struct {
 	int last_buckets[POSTPROCESS_HISTOGRAM_BUCKETS];
 	float last_min_lum;
 	float last_max_lum;
-	int last_histogram_updated;
+	bool last_histogram_updated;
 	uint64_t frame_count; /**< Internal frame counter for readback sync. */
 } PPExposureReadback;
 

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -1,6 +1,7 @@
 #ifndef RENDERER_H
 #define RENDERER_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /* Forward declarations — RenderContext holds only pointers. */
@@ -36,7 +37,7 @@ typedef struct RenderContext {
 	int height;
 	double delta_time;
 	uint64_t frame_count;
-	int log_gpu_metrics;
+	bool log_gpu_metrics;
 	RenderUIFn render_ui;
 	void* render_ui_data;
 } RenderContext;

--- a/include/scene_config.h
+++ b/include/scene_config.h
@@ -45,8 +45,8 @@ typedef enum {
  * @brief Render configuration flags and toggles.
  */
 typedef struct SceneConfig {
-	int wireframe;            /**< OpenGL wireframe mode toggle. */
-	int billboard_mode;       /**< Toggle for billboard rendering path. */
+	bool wireframe;           /**< OpenGL wireframe mode toggle. */
+	bool billboard_mode;      /**< Toggle for billboard rendering path. */
 	SortingMode sorting_mode; /**< Selected sorting algorithm. */
 	int pbr_debug_mode;       /**< Swap to wireframe/normal/roughness */
 	bool show_envmap;         /**< Draw skybox toggle. */
@@ -54,7 +54,7 @@ typedef struct SceneConfig {
 	int subdivisions;         /**< LOD of the shared icosphere. */
 	GIMode gi_mode;           /**< Selected GI sampling method. */
 	bool show_probe_grid;     /**< Debug visualization of probes. */
-	int specular_aa_enabled;  /**< Screen-Space Specular Anti-Aliasing. */
+	bool specular_aa_enabled; /**< Screen-Space Specular Anti-Aliasing. */
 	AAMode aa_mode;           /**< AA Mode: Screen-space or Curvature. */
 } SceneConfig;
 

--- a/include/scene_config.h
+++ b/include/scene_config.h
@@ -1,6 +1,8 @@
 #ifndef SCENE_CONFIG_H
 #define SCENE_CONFIG_H
 
+#include <stdbool.h>
+
 /**
  * @file scene_config.h
  * @brief Render configuration flags extracted from Scene.
@@ -47,11 +49,11 @@ typedef struct SceneConfig {
 	int billboard_mode;       /**< Toggle for billboard rendering path. */
 	SortingMode sorting_mode; /**< Selected sorting algorithm. */
 	int pbr_debug_mode;       /**< Swap to wireframe/normal/roughness */
-	int show_envmap;          /**< Draw skybox toggle. */
+	bool show_envmap;         /**< Draw skybox toggle. */
 	float env_lod;            /**< Skybox blurriness. */
 	int subdivisions;         /**< LOD of the shared icosphere. */
 	GIMode gi_mode;           /**< Selected GI sampling method. */
-	int show_probe_grid;      /**< Debug visualization of probes. */
+	bool show_probe_grid;     /**< Debug visualization of probes. */
 	int specular_aa_enabled;  /**< Screen-Space Specular Anti-Aliasing. */
 	AAMode aa_mode;           /**< AA Mode: Screen-space or Curvature. */
 } SceneConfig;

--- a/include/scene_simulation.h
+++ b/include/scene_simulation.h
@@ -7,6 +7,7 @@
  */
 
 #include "nbody.h"
+#include <stdbool.h>
 
 /**
  * @struct SceneSimulation
@@ -14,7 +15,7 @@
  */
 typedef struct SceneSimulation {
 	NBodySim nbody_sim; /**< N-body gravitational simulation. */
-	int nbody_mode;     /**< Toggle: 0=grid, 1=N-body. */
+	bool nbody_mode;    /**< Toggle: false=grid, true=N-body. */
 } SceneSimulation;
 
 #endif /* SCENE_SIMULATION_H */

--- a/include/scene_simulation.h
+++ b/include/scene_simulation.h
@@ -7,7 +7,6 @@
  */
 
 #include "nbody.h"
-#include <stdbool.h>
 
 /**
  * @struct SceneSimulation
@@ -15,7 +14,7 @@
  */
 typedef struct SceneSimulation {
 	NBodySim nbody_sim; /**< N-body gravitational simulation. */
-	bool nbody_mode;    /**< Toggle: false=grid, true=N-body. */
+	int nbody_mode;     /**< Toggle: 0=grid, 1=N-body. */
 } SceneSimulation;
 
 #endif /* SCENE_SIMULATION_H */

--- a/include/ui.h
+++ b/include/ui.h
@@ -14,6 +14,7 @@
 
 #include "gl_common.h"
 #include <cglm/cglm.h>
+#include <stdbool.h>
 
 typedef struct Shader Shader;
 
@@ -60,7 +61,7 @@ typedef struct {
 	int batch_count;           /**< Current vertex count in batch */
 	int current_screen_width;  /**< Screen width for current batch */
 	int current_screen_height; /**< Screen height for current batch */
-	int batch_active;          /**< Is a batch currently active? */
+	bool batch_active;         /**< Is a batch currently active? */
 	GLuint current_texture;    /**< Currently bound texture in the batch */
 } UIContext;
 

--- a/scripts/check_dep_metrics.sh
+++ b/scripts/check_dep_metrics.sh
@@ -3,9 +3,9 @@
 # Related: https://github.com/yoyonel/suckless-ogl/issues/266
 set -euo pipefail
 
-EDGE_LIMIT=${1:-560}
+EDGE_LIMIT=${1:-568}
 HEADER_FAN_LIMIT=${2:-18}
-SOURCE_FAN_LIMIT=${3:-21}
+SOURCE_FAN_LIMIT=${3:-22}
 
 # Count total include edges (only local includes)
 total=0

--- a/scripts/check_dep_metrics.sh
+++ b/scripts/check_dep_metrics.sh
@@ -3,7 +3,7 @@
 # Related: https://github.com/yoyonel/suckless-ogl/issues/266
 set -euo pipefail
 
-EDGE_LIMIT=${1:-568}
+EDGE_LIMIT=${1:-567}
 HEADER_FAN_LIMIT=${2:-18}
 SOURCE_FAN_LIMIT=${3:-22}
 

--- a/src/action_notifier.c
+++ b/src/action_notifier.c
@@ -44,7 +44,7 @@ void action_notifier_push(ActionNotifier* notifier, const char* text,
 	             MAX_ACTION_TEXT_LENGTH - 1);
 	note->lifetime = 0.0F;
 	note->max_lifetime = duration;
-	note->active = 1;
+	note->active = true;
 
 	LOG_DEBUG("action_notifier", "Pushed: %s", text);
 }
@@ -60,7 +60,7 @@ void action_notifier_update(ActionNotifier* notifier, float delta_time)
 			notifier->notes[i].lifetime += delta_time;
 			if (notifier->notes[i].lifetime >=
 			    notifier->notes[i].max_lifetime) {
-				notifier->notes[i].active = 0;
+				notifier->notes[i].active = false;
 			}
 		}
 	}

--- a/src/app.c
+++ b/src/app.c
@@ -148,7 +148,7 @@ void app_run(App* app)
 			postprocess_resize(app->postprocess,
 			                   app->win.pending_width,
 			                   app->win.pending_height);
-			app->win.resize_pending = 0;
+			app->win.resize_pending = false;
 			PROFILE_ZONE_END(resize_ctx);
 		}
 

--- a/src/app.c
+++ b/src/app.c
@@ -8,6 +8,7 @@
 #include "app_ui.h"
 #include "async/async_coordinator.h"
 #include "async_loader.h"
+#include "bool_utils.h"
 #include "camera_input.h"
 #include "env_manager.h"
 #include "lum_histogram.h"
@@ -152,10 +153,10 @@ void app_run(App* app)
 			PROFILE_ZONE_END(resize_ctx);
 		}
 
-		bool profiling_enabled =
-		    (app->profiling->timeline_ui.visible ||
-		     app->profiling->log_gpu_metrics != 0 ||
-		     effect_benchmark_is_running(&app->effect_bench)) != 0;
+		bool profiling_enabled = INT_TO_BOOL(
+		    app->profiling->timeline_ui.visible ||
+		    app->profiling->log_gpu_metrics ||
+		    effect_benchmark_is_running(&app->effect_bench));
 		gpu_profiler_set_enabled(&app->profiling->gpu_profiler,
 		                         profiling_enabled);
 		gpu_profiler_begin_frame(&app->profiling->gpu_profiler,
@@ -197,7 +198,7 @@ void app_run(App* app)
 
 		{
 			PROFILE_ZONE(camera_ctx, "Camera Physics");
-			GamepadActions gp_actions = {0, 0, 0};
+			GamepadActions gp_actions = {false, false, false};
 			if (app->input->camera_enabled) {
 				gamepad_input_poll(&app->input->gamepad,
 				                   &gp_actions);

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -387,11 +387,11 @@ static void handle_y_key_input(AppInputContext* ctx, int mods)
 {
 	if ((unsigned int)mods & (unsigned int)GLFW_MOD_SHIFT) {
 		ctx->scene->config.show_probe_grid =
-		    !ctx->scene->config.show_probe_grid;
+		    ((!ctx->scene->config.show_probe_grid) != 0);
 		LOG_INFO("suckless-ogl.app", "Probe Grid Debug: %s",
 		         ctx->scene->config.show_probe_grid ? "ON" : "OFF");
 		action_notifier_push(ctx->notifier,
-		                     ctx->scene->config.show_probe_grid
+		                     (int)ctx->scene->config.show_probe_grid
 		                         ? "Probes: ON"
 		                         : "Probes: OFF",
 		                     NOTIF_DUR_NORMAL);
@@ -721,11 +721,11 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 			break;
 		case GLFW_KEY_K:
 			ctx->scene->config.show_envmap =
-			    !ctx->scene->config.show_envmap;
+			    ((!ctx->scene->config.show_envmap) != 0);
 			LOG_INFO("suckless-ogl.app", "Envmap: %s",
 			         ctx->scene->config.show_envmap ? "ON" : "OFF");
 			action_notifier_push(ctx->notifier,
-			                     ctx->scene->config.show_envmap
+			                     (int)ctx->scene->config.show_envmap
 			                         ? "Skybox: ON"
 			                         : "Skybox: OFF",
 			                     NOTIF_DUR_NORMAL);

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -214,7 +214,7 @@ static void handle_subdiv_input(AppInputContext* ctx, int key)
 
 static void handle_camera_toggle(AppInputContext* ctx)
 {
-	*ctx->camera_enabled = !*ctx->camera_enabled;
+	*ctx->camera_enabled = ((!*ctx->camera_enabled) != 0);
 	if (*ctx->camera_enabled) {
 		glfwSetInputMode(ctx->window, GLFW_CURSOR,
 		                 GLFW_CURSOR_DISABLED);
@@ -223,9 +223,10 @@ static void handle_camera_toggle(AppInputContext* ctx)
 		glfwSetInputMode(ctx->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 	}
 	LOG_INFO("suckless-ogl.app", "Camera control: %s",
-	         *ctx->camera_enabled ? "ENABLED" : "DISABLED");
+	         (int)*ctx->camera_enabled ? "ENABLED" : "DISABLED");
 	action_notifier_push(
-	    ctx->notifier, *ctx->camera_enabled ? "Camera: ON" : "Camera: OFF",
+	    ctx->notifier,
+	    (int)*ctx->camera_enabled ? "Camera: ON" : "Camera: OFF",
 	    NOTIF_DUR_NORMAL);
 }
 
@@ -258,14 +259,14 @@ static void handle_f3_input(AppInputContext* ctx, int mods)
 static void handle_f9_input(AppInputContext* ctx)
 {
 	PROFILE_ZONE(f9_zone, "Input: F9 (Performance Mode)");
-	if (*ctx->perf_mode_active != 0) {
+	if (*ctx->perf_mode_active) {
 		perf_mode_request_end(ctx->perf_context);
-		*ctx->perf_mode_active = 0;
+		*ctx->perf_mode_active = false;
 		action_notifier_push(ctx->notifier, "Perf Mode: OFF",
 		                     NOTIF_DUR_LONG);
 	} else {
 		*ctx->perf_mode_active =
-		    (perf_mode_request_start(ctx->perf_context) == 0) ? 1 : 0;
+		    (perf_mode_request_start(ctx->perf_context) == 0);
 		char buf[NOTIF_BUF_SIZE];
 		(void)safe_snprintf(
 		    buf, sizeof(buf), "Perf Mode: ON (%s)",
@@ -273,7 +274,7 @@ static void handle_f9_input(AppInputContext* ctx)
 		action_notifier_push(ctx->notifier, buf, NOTIF_DUR_LONG);
 	}
 	LOG_INFO("suckless-ogl.app", "Performance Mode: %s (%s)",
-	         (*ctx->perf_mode_active != 0) ? "ON" : "OFF",
+	         *ctx->perf_mode_active ? "ON" : "OFF",
 	         perf_mode_get_state_string(ctx->perf_context));
 	PROFILE_ZONE_END(f9_zone);
 }
@@ -299,15 +300,15 @@ static void app_toggle_help(AppInputContext* ctx)
 		/* Opening overlay: if camera is active, disable it. */
 		if (*ctx->camera_enabled) {
 			handle_camera_toggle(ctx);
-			ctx->overlay->help_captured_camera = 1;
+			ctx->overlay->help_captured_camera = true;
 		} else {
-			ctx->overlay->help_captured_camera = 0;
+			ctx->overlay->help_captured_camera = false;
 		}
 	} else if (next == HELP_MODE_OFF && prev != HELP_MODE_OFF) {
 		/* Closing overlay: re-enable camera if we disabled it. */
 		if (ctx->overlay->help_captured_camera) {
 			handle_camera_toggle(ctx);
-			ctx->overlay->help_captured_camera = 0;
+			ctx->overlay->help_captured_camera = false;
 		}
 	}
 	action_notifier_push(ctx->notifier, HELP_MODE_NAMES[(int)next],
@@ -322,7 +323,7 @@ static void app_close_help(AppInputContext* ctx)
 	ctx->overlay->show_help = HELP_MODE_OFF;
 	if (ctx->overlay->help_captured_camera) {
 		handle_camera_toggle(ctx);
-		ctx->overlay->help_captured_camera = 0;
+		ctx->overlay->help_captured_camera = false;
 	}
 	action_notifier_push(ctx->notifier, HELP_MODE_NAMES[0],
 	                     NOTIF_DUR_NORMAL);
@@ -341,12 +342,11 @@ static bool handle_f_key_input(AppInputContext* ctx, int key, int mods)
 			handle_f3_input(ctx, mods);
 			return true;
 		case GLFW_KEY_F4:
-			*ctx->log_gpu_metrics =
-			    (*ctx->log_gpu_metrics != 0) ? 0 : 1;
+			*ctx->log_gpu_metrics = ((!*ctx->log_gpu_metrics) != 0);
 			LOG_INFO("suckless-ogl.app", "Log GPU Metrics: %s",
-			         (*ctx->log_gpu_metrics != 0) ? "ON" : "OFF");
+			         (int)*ctx->log_gpu_metrics ? "ON" : "OFF");
 			action_notifier_push(ctx->notifier,
-			                     (*ctx->log_gpu_metrics != 0)
+			                     (int)*ctx->log_gpu_metrics
 			                         ? "Log Metrics: ON"
 			                         : "Log Metrics: OFF",
 			                     NOTIF_DUR_NORMAL);
@@ -419,9 +419,9 @@ static void handle_system_key_input(AppInputContext* ctx, int key, int mods)
 			break;
 		case GLFW_KEY_Z:
 			ctx->scene->config.wireframe =
-			    !ctx->scene->config.wireframe;
+			    ((!ctx->scene->config.wireframe) != 0);
 			action_notifier_push(ctx->notifier,
-			                     ctx->scene->config.wireframe
+			                     (int)ctx->scene->config.wireframe
 			                         ? "Wireframe: ON"
 			                         : "Wireframe: OFF",
 			                     NOTIF_DUR_NORMAL);
@@ -477,9 +477,9 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 	}
 	scene_toggle_nbody(ctx->scene);
 	LOG_INFO("suckless-ogl.app", "N-Body mode: %s",
-	         ctx->scene->simulation->nbody_mode ? "ON" : "OFF");
+	         (int)ctx->scene->simulation->nbody_mode ? "ON" : "OFF");
 	action_notifier_push(ctx->notifier,
-	                     ctx->scene->simulation->nbody_mode
+	                     (int)ctx->scene->simulation->nbody_mode
 	                         ? "N-Body Gravity: ON"
 	                         : "N-Body Gravity: OFF",
 	                     NOTIF_DUR_LONG);
@@ -670,17 +670,18 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 			break;
 		case GLFW_KEY_L:
 			ctx->scene->config.billboard_mode =
-			    !ctx->scene->config.billboard_mode;
+			    ((!ctx->scene->config.billboard_mode) != 0);
 			// app_update_instancing_mode(app) was empty and
 			// removed.
 			LOG_INFO(
 			    "suckless-ogl.app", "Billboard Mode: %s",
 			    ctx->scene->config.billboard_mode ? "ON" : "OFF");
-			action_notifier_push(ctx->notifier,
-			                     ctx->scene->config.billboard_mode
-			                         ? "Billboards: ON"
-			                         : "Billboards: OFF",
-			                     NOTIF_DUR_NORMAL);
+			action_notifier_push(
+			    ctx->notifier,
+			    (int)ctx->scene->config.billboard_mode
+			        ? "Billboards: ON"
+			        : "Billboards: OFF",
+			    NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_O:
 			handle_o_key_input(ctx);
@@ -710,10 +711,11 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 				handle_aa_mode_input(ctx);
 			} else {
 				ctx->scene->config.specular_aa_enabled =
-				    !ctx->scene->config.specular_aa_enabled;
+				    ((!ctx->scene->config
+				           .specular_aa_enabled) != 0);
 				action_notifier_push(
 				    ctx->notifier,
-				    ctx->scene->config.specular_aa_enabled
+				    (int)ctx->scene->config.specular_aa_enabled
 				        ? "Specular AA: ON"
 				        : "Specular AA: OFF",
 				    NOTIF_DUR_SHORT);

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -1,6 +1,7 @@
 #include "app_input.h"
 
 #include "app_ui.h"
+#include "bool_utils.h"
 #include "camera.h"
 #include "camera_input.h"
 #include "env_manager.h"
@@ -214,7 +215,7 @@ static void handle_subdiv_input(AppInputContext* ctx, int key)
 
 static void handle_camera_toggle(AppInputContext* ctx)
 {
-	*ctx->camera_enabled = ((!*ctx->camera_enabled) != 0);
+	BOOL_TOGGLE(*ctx->camera_enabled);
 	if (*ctx->camera_enabled) {
 		glfwSetInputMode(ctx->window, GLFW_CURSOR,
 		                 GLFW_CURSOR_DISABLED);
@@ -223,10 +224,10 @@ static void handle_camera_toggle(AppInputContext* ctx)
 		glfwSetInputMode(ctx->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 	}
 	LOG_INFO("suckless-ogl.app", "Camera control: %s",
-	         (int)*ctx->camera_enabled ? "ENABLED" : "DISABLED");
+	         BOOL_TO_INT(*ctx->camera_enabled) ? "ENABLED" : "DISABLED");
 	action_notifier_push(
 	    ctx->notifier,
-	    (int)*ctx->camera_enabled ? "Camera: ON" : "Camera: OFF",
+	    BOOL_TO_INT(*ctx->camera_enabled) ? "Camera: ON" : "Camera: OFF",
 	    NOTIF_DUR_NORMAL);
 }
 
@@ -342,11 +343,12 @@ static bool handle_f_key_input(AppInputContext* ctx, int key, int mods)
 			handle_f3_input(ctx, mods);
 			return true;
 		case GLFW_KEY_F4:
-			*ctx->log_gpu_metrics = ((!*ctx->log_gpu_metrics) != 0);
-			LOG_INFO("suckless-ogl.app", "Log GPU Metrics: %s",
-			         (int)*ctx->log_gpu_metrics ? "ON" : "OFF");
+			BOOL_TOGGLE(*ctx->log_gpu_metrics);
+			LOG_INFO(
+			    "suckless-ogl.app", "Log GPU Metrics: %s",
+			    BOOL_TO_INT(*ctx->log_gpu_metrics) ? "ON" : "OFF");
 			action_notifier_push(ctx->notifier,
-			                     (int)*ctx->log_gpu_metrics
+			                     BOOL_TO_INT(*ctx->log_gpu_metrics)
 			                         ? "Log Metrics: ON"
 			                         : "Log Metrics: OFF",
 			                     NOTIF_DUR_NORMAL);
@@ -386,15 +388,15 @@ static bool handle_f_key_input(AppInputContext* ctx, int key, int mods)
 static void handle_y_key_input(AppInputContext* ctx, int mods)
 {
 	if ((unsigned int)mods & (unsigned int)GLFW_MOD_SHIFT) {
-		ctx->scene->config.show_probe_grid =
-		    ((!ctx->scene->config.show_probe_grid) != 0);
+		BOOL_TOGGLE(ctx->scene->config.show_probe_grid);
 		LOG_INFO("suckless-ogl.app", "Probe Grid Debug: %s",
 		         ctx->scene->config.show_probe_grid ? "ON" : "OFF");
-		action_notifier_push(ctx->notifier,
-		                     (int)ctx->scene->config.show_probe_grid
-		                         ? "Probes: ON"
-		                         : "Probes: OFF",
-		                     NOTIF_DUR_NORMAL);
+		action_notifier_push(
+		    ctx->notifier,
+		    BOOL_TO_INT(ctx->scene->config.show_probe_grid)
+		        ? "Probes: ON"
+		        : "Probes: OFF",
+		    NOTIF_DUR_NORMAL);
 	} else {
 		ctx->scene->config.gi_mode =
 		    (ctx->scene->config.gi_mode + 1) % GI_MODE_COUNT;
@@ -418,13 +420,13 @@ static void handle_system_key_input(AppInputContext* ctx, int key, int mods)
 			                     NOTIF_DUR_LONG);
 			break;
 		case GLFW_KEY_Z:
-			ctx->scene->config.wireframe =
-			    ((!ctx->scene->config.wireframe) != 0);
-			action_notifier_push(ctx->notifier,
-			                     (int)ctx->scene->config.wireframe
-			                         ? "Wireframe: ON"
-			                         : "Wireframe: OFF",
-			                     NOTIF_DUR_NORMAL);
+			BOOL_TOGGLE(ctx->scene->config.wireframe);
+			action_notifier_push(
+			    ctx->notifier,
+			    BOOL_TO_INT(ctx->scene->config.wireframe)
+			        ? "Wireframe: ON"
+			        : "Wireframe: OFF",
+			    NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_UP:
 		case GLFW_KEY_DOWN:
@@ -476,10 +478,11 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 		return false;
 	}
 	scene_toggle_nbody(ctx->scene);
-	LOG_INFO("suckless-ogl.app", "N-Body mode: %s",
-	         (int)ctx->scene->simulation->nbody_mode ? "ON" : "OFF");
+	LOG_INFO(
+	    "suckless-ogl.app", "N-Body mode: %s",
+	    BOOL_TO_INT(ctx->scene->simulation->nbody_mode) ? "ON" : "OFF");
 	action_notifier_push(ctx->notifier,
-	                     (int)ctx->scene->simulation->nbody_mode
+	                     BOOL_TO_INT(ctx->scene->simulation->nbody_mode)
 	                         ? "N-Body Gravity: ON"
 	                         : "N-Body Gravity: OFF",
 	                     NOTIF_DUR_LONG);
@@ -669,8 +672,7 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 			handle_y_key_input(ctx, mods);
 			break;
 		case GLFW_KEY_L:
-			ctx->scene->config.billboard_mode =
-			    ((!ctx->scene->config.billboard_mode) != 0);
+			BOOL_TOGGLE(ctx->scene->config.billboard_mode);
 			// app_update_instancing_mode(app) was empty and
 			// removed.
 			LOG_INFO(
@@ -678,7 +680,7 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 			    ctx->scene->config.billboard_mode ? "ON" : "OFF");
 			action_notifier_push(
 			    ctx->notifier,
-			    (int)ctx->scene->config.billboard_mode
+			    BOOL_TO_INT(ctx->scene->config.billboard_mode)
 			        ? "Billboards: ON"
 			        : "Billboards: OFF",
 			    NOTIF_DUR_NORMAL);
@@ -710,27 +712,27 @@ void handle_app_input(AppInputContext* ctx, int key, int mods)
 			if (check_flag(mods, GLFW_MOD_SHIFT)) {
 				handle_aa_mode_input(ctx);
 			} else {
-				ctx->scene->config.specular_aa_enabled =
-				    ((!ctx->scene->config
-				           .specular_aa_enabled) != 0);
+				BOOL_TOGGLE(
+				    ctx->scene->config.specular_aa_enabled);
 				action_notifier_push(
 				    ctx->notifier,
-				    (int)ctx->scene->config.specular_aa_enabled
+				    BOOL_TO_INT(
+				        ctx->scene->config.specular_aa_enabled)
 				        ? "Specular AA: ON"
 				        : "Specular AA: OFF",
 				    NOTIF_DUR_SHORT);
 			}
 			break;
 		case GLFW_KEY_K:
-			ctx->scene->config.show_envmap =
-			    ((!ctx->scene->config.show_envmap) != 0);
+			BOOL_TOGGLE(ctx->scene->config.show_envmap);
 			LOG_INFO("suckless-ogl.app", "Envmap: %s",
 			         ctx->scene->config.show_envmap ? "ON" : "OFF");
-			action_notifier_push(ctx->notifier,
-			                     (int)ctx->scene->config.show_envmap
-			                         ? "Skybox: ON"
-			                         : "Skybox: OFF",
-			                     NOTIF_DUR_NORMAL);
+			action_notifier_push(
+			    ctx->notifier,
+			    BOOL_TO_INT(ctx->scene->config.show_envmap)
+			        ? "Skybox: ON"
+			        : "Skybox: OFF",
+			    NOTIF_DUR_NORMAL);
 			break;
 		case GLFW_KEY_G:
 			if (handle_g_key_input(ctx, mods)) {

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -478,11 +478,10 @@ static bool handle_g_key_input(AppInputContext* ctx, int mods)
 		return false;
 	}
 	scene_toggle_nbody(ctx->scene);
-	LOG_INFO(
-	    "suckless-ogl.app", "N-Body mode: %s",
-	    BOOL_TO_INT(ctx->scene->simulation->nbody_mode) ? "ON" : "OFF");
+	LOG_INFO("suckless-ogl.app", "N-Body mode: %s",
+	         ctx->scene->simulation->nbody_mode ? "ON" : "OFF");
 	action_notifier_push(ctx->notifier,
-	                     BOOL_TO_INT(ctx->scene->simulation->nbody_mode)
+	                     ctx->scene->simulation->nbody_mode
 	                         ? "N-Body Gravity: ON"
 	                         : "N-Body Gravity: OFF",
 	                     NOTIF_DUR_LONG);

--- a/src/app_input.c
+++ b/src/app_input.c
@@ -52,7 +52,7 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 	 * mid-mode-switch. */
 	*ctx->pending_width = width;
 	*ctx->pending_height = height;
-	*ctx->resize_pending = 1;
+	*ctx->resize_pending = true;
 }
 
 static void handle_pbr_debug_mode(AppInputContext* ctx)
@@ -218,7 +218,7 @@ static void handle_camera_toggle(AppInputContext* ctx)
 	if (*ctx->camera_enabled) {
 		glfwSetInputMode(ctx->window, GLFW_CURSOR,
 		                 GLFW_CURSOR_DISABLED);
-		ctx->camera->first_mouse = 1;
+		ctx->camera->first_mouse = true;
 	} else {
 		glfwSetInputMode(ctx->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 	}
@@ -831,21 +831,21 @@ void app_toggle_fullscreen(AppInputContext* ctx, GLFWwindow* window)
 	 * pending fences/swaps, the NVIDIA driver can deadlock. */
 	glFinish();
 
-	if (*ctx->is_fullscreen == 0) {
+	if (!*ctx->is_fullscreen) {
 		GLFWmonitor* monitor = glfwGetPrimaryMonitor();
 		const GLFWvidmode* mode = glfwGetVideoMode(monitor);
 		glfwGetWindowPos(window, ctx->saved_x, ctx->saved_y);
 		glfwGetWindowSize(window, ctx->saved_width, ctx->saved_height);
 		glfwSetWindowMonitor(window, monitor, 0, 0, mode->width,
 		                     mode->height, mode->refreshRate);
-		*ctx->is_fullscreen = 1;
+		*ctx->is_fullscreen = true;
 		LOG_INFO("suckless-ogl.app", "Switched to fullscreen (%dx%d)",
 		         mode->width, mode->height);
 	} else {
 		glfwSetWindowMonitor(window, NULL, *ctx->saved_x, *ctx->saved_y,
 		                     *ctx->saved_width, *ctx->saved_height,
 		                     REFRESH_RATE_WINDOWED);
-		*ctx->is_fullscreen = 0;
+		*ctx->is_fullscreen = false;
 		LOG_INFO("suckless-ogl.app", "Switched to windowed");
 	}
 	glfwFocusWindow(window);
@@ -861,7 +861,7 @@ void app_toggle_fullscreen(AppInputContext* ctx, GLFWwindow* window)
 		                 (double)(height / 2));
 
 		glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-		ctx->camera->first_mouse = 1;
+		ctx->camera->first_mouse = true;
 	}
 }
 

--- a/src/app_profiling.c
+++ b/src/app_profiling.c
@@ -14,8 +14,8 @@ void app_profiling_init(AppProfiling* prof, int width, int height)
 	gpu_profiler_init(&prof->gpu_profiler);
 	gpu_profiler_ui_init(&prof->timeline_ui);
 	gpu_usage_init(&prof->gpu_usage);
-	prof->perf_mode_active = 0;
-	prof->log_gpu_metrics = 0;
+	prof->perf_mode_active = false;
+	prof->log_gpu_metrics = false;
 }
 
 void app_profiling_cleanup(AppProfiling* prof)

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -4,6 +4,7 @@
 #include "app_input_state.h"
 #include "app_profiling.h"
 #include "app_ui_layout.h" /* Private: layout constants, keyboard/gamepad data */
+#include "bool_utils.h"
 #include "env_manager.h"
 #include "glad/glad.h"
 #include "nbody.h"
@@ -1242,7 +1243,7 @@ static void draw_loading_indicator(const App* app)
 	}
 
 	char loading_text[UI_LOADING_TEXT_SIZE];
-	const char* status = (int)app->env_mgr->env_map_loading
+	const char* status = BOOL_TO_INT(app->env_mgr->env_map_loading)
 	                         ? "Loading HDR"
 	                         : "Generating IBL";
 	(void)safe_snprintf(loading_text, sizeof(loading_text), "%s", status);

--- a/src/app_ui.c
+++ b/src/app_ui.c
@@ -82,7 +82,7 @@ void app_ui_init(AppUIOverlay* overlay)
 	    texture_load_rgba_png("assets/textures/ui/kbd_panel_frame.png");
 	overlay->kbd_tex_key_base =
 	    texture_load_rgba_png("assets/textures/ui/kbd_key_base.png");
-	overlay->help_captured_camera = 0;
+	overlay->help_captured_camera = false;
 }
 
 void app_ui_cleanup(AppUIOverlay* overlay)
@@ -1242,7 +1242,7 @@ static void draw_loading_indicator(const App* app)
 	}
 
 	char loading_text[UI_LOADING_TEXT_SIZE];
-	const char* status = (app->env_mgr->env_map_loading != 0)
+	const char* status = (int)app->env_mgr->env_map_loading
 	                         ? "Loading HDR"
 	                         : "Generating IBL";
 	(void)safe_snprintf(loading_text, sizeof(loading_text), "%s", status);

--- a/src/app_window.c
+++ b/src/app_window.c
@@ -6,7 +6,7 @@
 int app_window_subsys_init(App* app)
 {
 	app->win.is_fullscreen = false;
-	app->win.resize_pending = 0;
+	app->win.resize_pending = false;
 
 	app->win.handle =
 	    window_create(app->width, app->height, app->title, DEFAULT_SAMPLES);

--- a/src/camera.c
+++ b/src/camera.c
@@ -17,9 +17,9 @@ void camera_init(Camera* cam, float distance, float yaw, float pitch)
 	cam->sensitivity = DEFAULT_CAMERA_SENSITIVITY;
 	cam->zoom = DEFAULT_CAMERA_ZOOM;
 
-	cam->move_forward = cam->move_backward = 0;
-	cam->move_left = cam->move_right = 0;
-	cam->move_up = cam->move_down = 0;
+	cam->move_forward = cam->move_backward = false;
+	cam->move_left = cam->move_right = false;
+	cam->move_up = cam->move_down = false;
 	glm_vec3_zero(cam->move_input);
 
 	// Physique
@@ -38,7 +38,7 @@ void camera_init(Camera* cam, float distance, float yaw, float pitch)
 	cam->bobbing_time = 0.0F;
 	cam->bobbing_frequency = DEFAULT_BOBBING_FREQUENCY;
 	cam->bobbing_amplitude = DEFAULT_BOBBING_AMPLITUDE;
-	cam->bobbing_enabled = 1;
+	cam->bobbing_enabled = true;
 
 	// Fixed timestep
 	cam->physics_accumulator = 0.0F;
@@ -72,12 +72,12 @@ void camera_update_vectors(Camera* cam)
 
 void camera_build_keyboard_input(Camera* cam)
 {
-	cam->move_input[0] =
-	    (float)(cam->move_right - cam->move_left); /* right/left */
+	cam->move_input[0] = (float)((int)cam->move_right -
+	                             (int)cam->move_left); /* right/left */
 	cam->move_input[1] =
-	    (float)(cam->move_up - cam->move_down); /* up/down */
-	cam->move_input[2] =
-	    (float)(cam->move_forward - cam->move_backward); /* fwd/back */
+	    (float)((int)cam->move_up - (int)cam->move_down); /* up/down */
+	cam->move_input[2] = (float)((int)cam->move_forward -
+	                             (int)cam->move_backward); /* fwd/back */
 }
 
 void camera_fixed_update(Camera* cam)

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,5 +1,6 @@
 #include "camera.h"
 
+#include "bool_utils.h"
 #include <cglm/cam.h>
 #include <cglm/types.h>
 #include <cglm/util.h>
@@ -72,12 +73,14 @@ void camera_update_vectors(Camera* cam)
 
 void camera_build_keyboard_input(Camera* cam)
 {
-	cam->move_input[0] = (float)((int)cam->move_right -
-	                             (int)cam->move_left); /* right/left */
-	cam->move_input[1] =
-	    (float)((int)cam->move_up - (int)cam->move_down); /* up/down */
-	cam->move_input[2] = (float)((int)cam->move_forward -
-	                             (int)cam->move_backward); /* fwd/back */
+	cam->move_input[0] =
+	    (float)(BOOL_TO_INT(cam->move_right) -
+	            BOOL_TO_INT(cam->move_left)); /* right/left */
+	cam->move_input[1] = (float)(BOOL_TO_INT(cam->move_up) -
+	                             BOOL_TO_INT(cam->move_down)); /* up/down */
+	cam->move_input[2] =
+	    (float)(BOOL_TO_INT(cam->move_forward) -
+	            BOOL_TO_INT(cam->move_backward)); /* fwd/back */
 }
 
 void camera_fixed_update(Camera* cam)

--- a/src/camera.c
+++ b/src/camera.c
@@ -50,7 +50,7 @@ void camera_init(Camera* cam, float distance, float yaw, float pitch)
 	// Input State
 	cam->last_mouse_x = 0.0;
 	cam->last_mouse_y = 0.0;
-	cam->first_mouse = 1;
+	cam->first_mouse = true;
 
 	camera_update_vectors(cam);
 }

--- a/src/camera_input.c
+++ b/src/camera_input.c
@@ -9,7 +9,7 @@
 
 void camera_input_handle_key(Camera* cam, int key, int action)
 {
-	int pressed = (action != GLFW_RELEASE);
+	bool pressed = (action != GLFW_RELEASE);
 
 	if (key == GLFW_KEY_W) {
 		cam->move_forward = pressed;

--- a/src/camera_input.c
+++ b/src/camera_input.c
@@ -36,7 +36,7 @@ void camera_input_handle_mouse(Camera* cam, double xpos, double ypos)
 	if (cam->first_mouse) {
 		cam->last_mouse_x = xpos;
 		cam->last_mouse_y = ypos;
-		cam->first_mouse = 0;
+		cam->first_mouse = false;
 		return;
 	}
 

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -36,7 +36,7 @@ int env_manager_load(EnvManager* mgr, AsyncLoader* loader, const char* filename)
 
 	LOG_INFO("suckless-ogl.env", "Queuing async load for: %s", path);
 	if (async_loader_request(loader, path)) {
-		mgr->env_map_loading = 1;
+		mgr->env_map_loading = true;
 		return 1;
 	}
 	LOG_WARNING("suckless-ogl.env",
@@ -58,7 +58,7 @@ void env_manager_process_loading_step(EnvManager* mgr, GLuint* recycled_hdr_tex,
 		if (!req->half_data && !req->pbo_mapped_ptr) {
 			LOG_ERROR("suckless-ogl.env",
 			          "Async request data is NULL!");
-			mgr->env_map_loading = 0;
+			mgr->env_map_loading = false;
 			mgr->env_map_loading_step = 0;
 			return;
 		}
@@ -96,7 +96,7 @@ void env_manager_process_loading_step(EnvManager* mgr, GLuint* recycled_hdr_tex,
 		} else {
 			LOG_ERROR("suckless-ogl.env",
 			          "Failed to create texture from HDR data!");
-			mgr->env_map_loading = 0;
+			mgr->env_map_loading = false;
 			mgr->env_map_loading_step = 0;
 		}
 
@@ -110,7 +110,7 @@ void env_manager_process_loading_step(EnvManager* mgr, GLuint* recycled_hdr_tex,
 			                      req->width, req->height);
 			mgr->pending_env_tex = 0;
 		}
-		mgr->env_map_loading = 0;
+		mgr->env_map_loading = false;
 		mgr->env_map_loading_step = 0;
 	}
 }
@@ -331,7 +331,7 @@ int env_mgr_subsys_init(App* app)
 	if (!app->env_mgr) {
 		return 0;
 	}
-	*app->env_mgr = (EnvManager){0};
+	*app->env_mgr = (EnvManager){.env_map_loading = false};
 	app->env_mgr->is_first_load = true;
 	app->env_mgr->transition_state = TRANSITION_WAIT_IBL;
 	app->env_mgr->transition_alpha = 1.0F;

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -332,7 +332,7 @@ int env_mgr_subsys_init(App* app)
 		return 0;
 	}
 	*app->env_mgr = (EnvManager){0};
-	app->env_mgr->is_first_load = 1;
+	app->env_mgr->is_first_load = true;
 	app->env_mgr->transition_state = TRANSITION_WAIT_IBL;
 	app->env_mgr->transition_alpha = 1.0F;
 	app->env_mgr->transition_duration = DEFAULT_ENV_TRANSITION_DURATION;

--- a/src/gamepad_input.c
+++ b/src/gamepad_input.c
@@ -12,7 +12,7 @@
 
 void gamepad_input_init(GamepadState* state)
 {
-	state->connected = 0;
+	state->connected = false;
 	state->joystick_id = GLFW_JOYSTICK_1;
 	state->deadzone = GAMEPAD_DEFAULT_DEADZONE;
 	state->look_sensitivity = GAMEPAD_DEFAULT_LOOK_SENSITIVITY;
@@ -54,10 +54,10 @@ static void gamepad_poll_buttons(GamepadState* state,
 		    state->prev_buttons[GLFW_GAMEPAD_BUTTON_LEFT_BUMPER];
 
 		if (r1_now && !r1_prev) {
-			actions->env_next = 1;
+			actions->env_next = true;
 		}
 		if (l1_now && !l1_prev) {
-			actions->env_prev = 1;
+			actions->env_prev = true;
 		}
 
 		unsigned char share_now =
@@ -65,7 +65,7 @@ static void gamepad_poll_buttons(GamepadState* state,
 		unsigned char share_prev =
 		    state->prev_buttons[GLFW_GAMEPAD_BUTTON_BACK];
 		if (share_now && !share_prev) {
-			actions->camera_reset = 1;
+			actions->camera_reset = true;
 		}
 	}
 	/* Save button state for next-frame edge detection. */
@@ -77,13 +77,13 @@ static void gamepad_poll_buttons(GamepadState* state,
 void gamepad_input_poll(GamepadState* state, GamepadActions* actions)
 {
 	/* Detect connection. */
-	int was_connected = state->connected;
-	state->connected = glfwJoystickIsGamepad(state->joystick_id);
+	bool was_connected = state->connected;
+	state->connected = (glfwJoystickIsGamepad(state->joystick_id) != 0);
 
 	if (actions) {
-		actions->env_next = 0;
-		actions->env_prev = 0;
-		actions->camera_reset = 0;
+		actions->env_next = false;
+		actions->env_prev = false;
+		actions->camera_reset = false;
 	}
 
 	if (state->connected && !was_connected) {
@@ -103,7 +103,7 @@ void gamepad_input_poll(GamepadState* state, GamepadActions* actions)
 
 	GLFWgamepadstate pad;
 	if (!glfwGetGamepadState(state->joystick_id, &pad)) {
-		state->connected = 0;
+		state->connected = false;
 		for (int idx = 0; idx < GAMEPAD_AXIS_COUNT; idx++) {
 			state->axes[idx] = 0.0F;
 		}

--- a/src/gamepad_input.c
+++ b/src/gamepad_input.c
@@ -1,5 +1,6 @@
 #include "gamepad_input.h"
 
+#include "bool_utils.h"
 #include "log.h"
 #ifndef GLFW_INCLUDE_NONE
 #define GLFW_INCLUDE_NONE
@@ -78,7 +79,8 @@ void gamepad_input_poll(GamepadState* state, GamepadActions* actions)
 {
 	/* Detect connection. */
 	bool was_connected = state->connected;
-	state->connected = (glfwJoystickIsGamepad(state->joystick_id) != 0);
+	state->connected =
+	    INT_TO_BOOL(glfwJoystickIsGamepad(state->joystick_id));
 
 	if (actions) {
 		actions->env_next = false;

--- a/src/light_probes.c
+++ b/src/light_probes.c
@@ -155,9 +155,9 @@ void light_probe_grid_init_cpu(LightProbeGrid* grid, int dim_x, int dim_y,
 
 	pthread_mutex_init(&grid->mutex, NULL);
 	pthread_cond_init(&grid->cond, NULL);
-	grid->running = 0;
-	grid->update_pending = 0;
-	grid->results_ready = 0;
+	grid->running = false;
+	grid->update_pending = false;
+	grid->results_ready = false;
 }
 
 void light_probe_grid_free_cpu(LightProbeGrid* grid)
@@ -352,7 +352,7 @@ static void* light_probe_worker(void* arg)
 			break;
 		}
 
-		grid->update_pending = 0;
+		grid->update_pending = false;
 
 		/* Snapshot scene data under lock to avoid race with
 		 * set_scene() */
@@ -415,7 +415,7 @@ static void* light_probe_worker(void* arg)
 		PROFILE_ZONE_END(gi_compute_ctx);
 
 		pthread_mutex_lock(&grid->mutex);
-		grid->results_ready = 1;
+		grid->results_ready = true;
 		pthread_mutex_unlock(&grid->mutex);
 	}
 	return NULL;
@@ -466,7 +466,7 @@ void light_probe_grid_init(LightProbeGrid* grid, int dim_x, int dim_y,
 	}
 	glBindTexture(GL_TEXTURE_3D, 0);
 
-	grid->running = 1;
+	grid->running = true;
 	pthread_create(&grid->worker_thread, NULL, light_probe_worker, grid);
 }
 
@@ -528,7 +528,7 @@ void light_probe_grid_update_async(LightProbeGrid* grid)
 	}
 	pthread_mutex_lock(&grid->mutex);
 	if (!grid->update_pending) {
-		grid->update_pending = 1;
+		grid->update_pending = true;
 		pthread_cond_signal(&grid->cond);
 	}
 	pthread_mutex_unlock(&grid->mutex);
@@ -613,7 +613,7 @@ void light_probe_grid_sync(LightProbeGrid* grid)
 	LOG_DEBUG("perf.gi", "GI Sync: %d probes updated (SSBO + 7x 3D Tex)",
 	          grid->total_probes);
 
-	grid->results_ready = 0;
+	grid->results_ready = false;
 	pthread_mutex_unlock(&grid->mutex);
 }
 
@@ -624,7 +624,7 @@ void light_probe_grid_cleanup(LightProbeGrid* grid)
 	}
 
 	pthread_mutex_lock(&grid->mutex);
-	grid->running = 0;
+	grid->running = false;
 	pthread_cond_signal(&grid->cond);
 	pthread_mutex_unlock(&grid->mutex);
 

--- a/src/perf_mode.c
+++ b/src/perf_mode.c
@@ -126,7 +126,7 @@ int perf_mode_init(PerfModeContext* ctx)
 		         "No performance optimization backend available");
 	}
 
-	ctx->initialized = 1;
+	ctx->initialized = true;
 	LOG_INFO("suckless-ogl.perf",
 	         "Performance mode initialized (backend: %s)",
 	         ctx->backend == PERF_BACKEND_GAMEMODE ? "GameMode"
@@ -358,7 +358,7 @@ void perf_mode_cleanup(PerfModeContext* ctx)
 		perf_mode_request_end(ctx);
 	}
 
-	ctx->initialized = 0;
+	ctx->initialized = false;
 	LOG_INFO("suckless-ogl.perf", "Performance mode cleaned up");
 }
 

--- a/src/perf_timer.c
+++ b/src/perf_timer.c
@@ -104,7 +104,7 @@ void gpu_timer_start(GPUTimer* timer)
 	// Forcer l'envoi de la commande de début pour éviter le batching
 	glFlush();
 
-	timer->active = 1;
+	timer->active = true;
 }
 
 double gpu_timer_elapsed_ms(GPUTimer* timer, int wait_for_result)
@@ -120,7 +120,7 @@ double gpu_timer_elapsed_ms(GPUTimer* timer, int wait_for_result)
 
 	// Enregistrer le timestamp final sur le GPU
 	glQueryCounter(timer->query_end, GL_TIMESTAMP);
-	timer->active = 0;
+	timer->active = false;
 
 	GLuint64 start_time = 0;
 	GLuint64 end_time = 0;
@@ -175,7 +175,7 @@ void gpu_timer_cleanup(GPUTimer* timer)
 		glDeleteQueries(1, &timer->query_end);
 		timer->query_end = 0;
 	}
-	timer->active = 0;
+	timer->active = false;
 }
 
 // ============================================================================

--- a/src/postprocess_readback.c
+++ b/src/postprocess_readback.c
@@ -178,7 +178,7 @@ int postprocess_compute_luminance_histogram(PostProcess* post_processing,
 				post_processing->readback.last_max_lum =
 				    *max_lum;
 				post_processing->readback
-				    .last_histogram_updated = 1;
+				    .last_histogram_updated = true;
 				glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
 			}
 			glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,6 +1,7 @@
 #include "renderer.h"
 
 #include "action_notifier.h"
+#include "bool_utils.h"
 #include "camera.h"
 #include "effect_benchmark.h"
 #include "env_manager.h"
@@ -17,8 +18,8 @@
 void renderer_draw_frame(const RenderContext* ctx)
 {
 	bool profiling_enabled =
-	    (ctx->profiler_ui->visible || ctx->log_gpu_metrics ||
-	     effect_benchmark_is_running(ctx->effect_bench)) != 0;
+	    INT_TO_BOOL(ctx->profiler_ui->visible || ctx->log_gpu_metrics ||
+	                effect_benchmark_is_running(ctx->effect_bench));
 	postprocess_update_readbacks(ctx->postprocess, ctx->frame_count);
 
 	PROFILE_FRAME_MARK;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -17,7 +17,7 @@
 void renderer_draw_frame(const RenderContext* ctx)
 {
 	bool profiling_enabled =
-	    (ctx->profiler_ui->visible || ctx->log_gpu_metrics != 0 ||
+	    (ctx->profiler_ui->visible || ctx->log_gpu_metrics ||
 	     effect_benchmark_is_running(ctx->effect_bench)) != 0;
 	postprocess_update_readbacks(ctx->postprocess, ctx->frame_count);
 
@@ -95,5 +95,5 @@ void renderer_draw_frame(const RenderContext* ctx)
 	// 4. Logique d'affichage et animations
 	double current_time = glfwGetTime();
 	gpu_profiler_ui_update(ctx->profiler_ui, ctx->profiler, ctx->delta_time,
-	                       current_time, (bool)ctx->log_gpu_metrics);
+	                       current_time, ctx->log_gpu_metrics);
 }

--- a/src/scene_init.c
+++ b/src/scene_init.c
@@ -228,13 +228,13 @@ static void scene_init_state(Scene* scene)
 	scene->config.wireframe = 0;
 	scene->config.env_lod = DEFAULT_ENV_LOD;
 	scene->config.pbr_debug_mode = 0;
-	scene->config.show_envmap = 1;
+	scene->config.show_envmap = true;
 	scene->config.billboard_mode = 1;
 	scene->config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
 	scene->config.aa_mode = AA_MODE_CURVATURE;
 	scene->config.sorting_mode = SORTING_MODE_GPU_BITONIC;
 	scene->config.gi_mode = GI_MODE_OFF;
-	scene->config.show_probe_grid = 0;
+	scene->config.show_probe_grid = false;
 	scene->gpu->billboard_ubo_ptr = NULL;
 
 	scene->billboard_sorter = (BillboardSorter){0};

--- a/src/scene_init.c
+++ b/src/scene_init.c
@@ -225,11 +225,11 @@ static void scene_init_ssbo(Scene* scene)
 static void scene_init_state(Scene* scene)
 {
 	scene->config.subdivisions = INITIAL_SUBDIVISIONS;
-	scene->config.wireframe = 0;
+	scene->config.wireframe = false;
 	scene->config.env_lod = DEFAULT_ENV_LOD;
 	scene->config.pbr_debug_mode = 0;
 	scene->config.show_envmap = true;
-	scene->config.billboard_mode = 1;
+	scene->config.billboard_mode = true;
 	scene->config.specular_aa_enabled = DEFAULT_SPECULAR_AA_ENABLED;
 	scene->config.aa_mode = AA_MODE_CURVATURE;
 	scene->config.sorting_mode = SORTING_MODE_GPU_BITONIC;

--- a/src/scene_nbody.c
+++ b/src/scene_nbody.c
@@ -1,6 +1,7 @@
 #include "app_settings.h"
 #include "billboard_rendering.h"
 #include "billboard_sorting.h"
+#include "bool_utils.h"
 #include "instanced_rendering.h"
 #include "nbody.h"
 #include "platform/platform_utils.h"
@@ -15,7 +16,7 @@
 
 void scene_toggle_nbody(Scene* scene)
 {
-	scene->simulation->nbody_mode = ((!scene->simulation->nbody_mode) != 0);
+	BOOL_TOGGLE(scene->simulation->nbody_mode);
 
 	if (scene->simulation->nbody_mode) {
 		/* Initialize simulation and trails */

--- a/src/scene_nbody.c
+++ b/src/scene_nbody.c
@@ -15,7 +15,7 @@
 
 void scene_toggle_nbody(Scene* scene)
 {
-	scene->simulation->nbody_mode = !scene->simulation->nbody_mode;
+	scene->simulation->nbody_mode = ((!scene->simulation->nbody_mode) != 0);
 
 	if (scene->simulation->nbody_mode) {
 		/* Initialize simulation and trails */
@@ -24,14 +24,14 @@ void scene_toggle_nbody(Scene* scene)
 		int count = nbody_get_count(&scene->simulation->nbody_sim);
 		if (!trail_renderer_init(&scene->visuals->trail_renderer,
 		                         count)) {
-			scene->simulation->nbody_mode = 0;
+			scene->simulation->nbody_mode = false;
 			return;
 		}
 
 		if (!shockwave_renderer_init(
 		        &scene->visuals->shockwave_renderer)) {
 			trail_renderer_cleanup(&scene->visuals->trail_renderer);
-			scene->simulation->nbody_mode = 0;
+			scene->simulation->nbody_mode = false;
 			return;
 		}
 

--- a/src/scene_nbody.c
+++ b/src/scene_nbody.c
@@ -1,7 +1,6 @@
 #include "app_settings.h"
 #include "billboard_rendering.h"
 #include "billboard_sorting.h"
-#include "bool_utils.h"
 #include "instanced_rendering.h"
 #include "nbody.h"
 #include "platform/platform_utils.h"
@@ -16,7 +15,7 @@
 
 void scene_toggle_nbody(Scene* scene)
 {
-	BOOL_TOGGLE(scene->simulation->nbody_mode);
+	scene->simulation->nbody_mode = !scene->simulation->nbody_mode;
 
 	if (scene->simulation->nbody_mode) {
 		/* Initialize simulation and trails */

--- a/src/scene_render.c
+++ b/src/scene_render.c
@@ -1,6 +1,7 @@
 #include "app_settings.h"
 #include "billboard_rendering.h"
 #include "billboard_sorting.h"
+#include "bool_utils.h"
 #include "gl_debug.h"
 #include "glad/glad.h"
 #include "gpu_profiler.h"
@@ -127,7 +128,7 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		glm_vec3_copy(scene->lighting.probe_grid.aabb_max,
 		              ubo.probe_grid_max);
 		ubo.specular_aa_enabled =
-		    (int32_t)scene->config.specular_aa_enabled;
+		    BOOL_TO_INT(scene->config.specular_aa_enabled);
 		ubo.probe_grid_dim[0] = scene->lighting.probe_grid.grid_dim[0];
 		ubo.probe_grid_dim[1] = scene->lighting.probe_grid.grid_dim[1];
 		ubo.probe_grid_dim[2] = scene->lighting.probe_grid.grid_dim[2];
@@ -250,7 +251,7 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 	if (scene->shaders->instanced_uniforms.u_specular_aa_enabled != -1) {
 		glUniform1i(
 		    scene->shaders->instanced_uniforms.u_specular_aa_enabled,
-		    (GLint)scene->config.specular_aa_enabled);
+		    BOOL_TO_INT(scene->config.specular_aa_enabled));
 	}
 	if (scene->shaders->instanced_uniforms.u_aa_mode != -1) {
 		glUniform1i(scene->shaders->instanced_uniforms.u_aa_mode,
@@ -417,9 +418,10 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			GPU_STAGE_PROFILER(profiler, "Instanced Render",
 			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
-			glPolygonMode(
-			    GL_FRONT_AND_BACK,
-			    (int)scene->config.wireframe ? GL_LINE : GL_FILL);
+			glPolygonMode(GL_FRONT_AND_BACK,
+			              BOOL_TO_INT(scene->config.wireframe)
+			                  ? GL_LINE
+			                  : GL_FILL);
 
 			scene_render_instanced(scene, view, proj, camera_pos,
 			                       previous_view_proj);
@@ -462,9 +464,10 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			GPU_STAGE_PROFILER(profiler, "Instanced Render",
 			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
-			glPolygonMode(
-			    GL_FRONT_AND_BACK,
-			    (int)scene->config.wireframe ? GL_LINE : GL_FILL);
+			glPolygonMode(GL_FRONT_AND_BACK,
+			              BOOL_TO_INT(scene->config.wireframe)
+			                  ? GL_LINE
+			                  : GL_FILL);
 			scene_render_instanced(scene, view, proj, camera_pos,
 			                       previous_view_proj);
 

--- a/src/scene_render.c
+++ b/src/scene_render.c
@@ -126,7 +126,8 @@ static void scene_render_billboards(Scene* scene, mat4 view, mat4 proj,
 		ubo.gi_mode = (int32_t)scene->config.gi_mode;
 		glm_vec3_copy(scene->lighting.probe_grid.aabb_max,
 		              ubo.probe_grid_max);
-		ubo.specular_aa_enabled = scene->config.specular_aa_enabled;
+		ubo.specular_aa_enabled =
+		    (int32_t)scene->config.specular_aa_enabled;
 		ubo.probe_grid_dim[0] = scene->lighting.probe_grid.grid_dim[0];
 		ubo.probe_grid_dim[1] = scene->lighting.probe_grid.grid_dim[1];
 		ubo.probe_grid_dim[2] = scene->lighting.probe_grid.grid_dim[2];
@@ -249,7 +250,7 @@ static void scene_render_instanced(Scene* scene, mat4 view, mat4 proj,
 	if (scene->shaders->instanced_uniforms.u_specular_aa_enabled != -1) {
 		glUniform1i(
 		    scene->shaders->instanced_uniforms.u_specular_aa_enabled,
-		    scene->config.specular_aa_enabled);
+		    (GLint)scene->config.specular_aa_enabled);
 	}
 	if (scene->shaders->instanced_uniforms.u_aa_mode != -1) {
 		glUniform1i(scene->shaders->instanced_uniforms.u_aa_mode,
@@ -416,9 +417,9 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			GPU_STAGE_PROFILER(profiler, "Instanced Render",
 			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
-			glPolygonMode(GL_FRONT_AND_BACK, scene->config.wireframe
-			                                     ? GL_LINE
-			                                     : GL_FILL);
+			glPolygonMode(
+			    GL_FRONT_AND_BACK,
+			    (int)scene->config.wireframe ? GL_LINE : GL_FILL);
 
 			scene_render_instanced(scene, view, proj, camera_pos,
 			                       previous_view_proj);
@@ -461,9 +462,9 @@ void scene_render(Scene* scene, GPUProfiler* profiler, mat4 view, mat4 proj,
 			GPU_STAGE_PROFILER(profiler, "Instanced Render",
 			                   GPU_PROFILER_SCENE_COLOR);
 			gl_debug_push_group("Instanced_Geometry_Render");
-			glPolygonMode(GL_FRONT_AND_BACK, scene->config.wireframe
-			                                     ? GL_LINE
-			                                     : GL_FILL);
+			glPolygonMode(
+			    GL_FRONT_AND_BACK,
+			    (int)scene->config.wireframe ? GL_LINE : GL_FILL);
 			scene_render_instanced(scene, view, proj, camera_pos,
 			                       previous_view_proj);
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -248,7 +248,7 @@ int ui_init(UIContext* ui_context, const char* font_path, float font_size)
 	ui_context->vbo = 0;
 	ui_context->font_size = font_size;
 	ui_context->batch_count = 0;
-	ui_context->batch_active = 0;
+	ui_context->batch_active = false;
 	ui_context->current_texture = 0;
 	for (int i = 0; i < FONT_CHAR_COUNT; i++) {
 		ui_context->cdata[i] = (GlyphInfo){0};
@@ -318,7 +318,7 @@ void ui_begin(UIContext* ui_context, int screen_width, int screen_height)
 	ui_context->current_screen_width = screen_width;
 	ui_context->current_screen_height = screen_height;
 	ui_context->batch_count = 0;
-	ui_context->batch_active = 1;
+	ui_context->batch_active = true;
 	ui_context->current_texture =
 	    ui_context->texture; /* Default to font atlas */
 }
@@ -365,7 +365,7 @@ void ui_end(UIContext* ui_context)
 
 	ui_flush(ui_context);
 	render_utils_restore_state(&g_ui_saved_state);
-	ui_context->batch_active = 0;
+	ui_context->batch_active = false;
 }
 
 void ui_draw_text(UIContext* ui_context, const char* text, float pos_x,

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -509,7 +509,7 @@ static void apply_subtle_auto_exposure(const ViewPoint* vpoint, void* data)
 	postprocess_enable(g_test_app.postprocess, POSTFX_AUTO_EXPOSURE);
 	postprocess_disable(g_test_app.postprocess, POSTFX_VIGNETTE);
 	postprocess_disable(g_test_app.postprocess, POSTFX_GRAIN);
-	g_test_app.profiling->log_gpu_metrics = 1;
+	g_test_app.profiling->log_gpu_metrics = true;
 
 	// Note: warmup frames are handled inside the app_update cycles in the
 	// main loop. We might need a special case for this if 16 frames is not

--- a/tests/test_app_input.c
+++ b/tests/test_app_input.c
@@ -286,7 +286,7 @@ void test_camera_movement_keys(void)
 void test_mouse_and_scroll_exhaustive(void)
 {
 	test_app->input->camera_enabled = true;
-	test_app->input->camera.first_mouse = 1;
+	test_app->input->camera.first_mouse = true;
 	mouse_callback(test_app->win.handle, 100.0, 100.0);
 	mouse_callback(test_app->win.handle, 110.0, 120.0);
 	TEST_ASSERT_EQUAL_FLOAT(110.0F,

--- a/tests/test_app_subsystem.c
+++ b/tests/test_app_subsystem.c
@@ -399,8 +399,7 @@ void test_scene_subsys_init_sets_defaults(void)
 
 	TEST_ASSERT_EQUAL(1, scene_subsys_init(&app));
 	TEST_ASSERT_NOT_NULL(app.scene);
-	TEST_ASSERT_EQUAL(DEFAULT_SPECULAR_AA_ENABLED,
-	                  app.scene->config.specular_aa_enabled);
+	TEST_ASSERT_TRUE(app.scene->config.specular_aa_enabled);
 
 	scene_subsys_cleanup(&app);
 	TEST_ASSERT_NULL(app.scene);

--- a/tests/test_app_subsystem.c
+++ b/tests/test_app_subsystem.c
@@ -414,7 +414,7 @@ void test_env_mgr_subsys_init_sets_defaults(void)
 
 	TEST_ASSERT_EQUAL(1, env_mgr_subsys_init(&app));
 	TEST_ASSERT_NOT_NULL(app.env_mgr);
-	TEST_ASSERT_EQUAL(1, app.env_mgr->is_first_load);
+	TEST_ASSERT_TRUE(app.env_mgr->is_first_load);
 	TEST_ASSERT_EQUAL(TRANSITION_WAIT_IBL, app.env_mgr->transition_state);
 	TEST_ASSERT_FLOAT_WITHIN(0.001F, 1.0F, app.env_mgr->transition_alpha);
 

--- a/tests/test_app_subsystem.c
+++ b/tests/test_app_subsystem.c
@@ -335,7 +335,7 @@ void test_input_subsys_roundtrip(void)
 	TEST_ASSERT_NOT_NULL(app.input);
 
 	app_input_state_init(app.input);
-	TEST_ASSERT_EQUAL(1, app.input->camera_enabled);
+	TEST_ASSERT_TRUE(app.input->camera_enabled);
 
 	app_input_state_cleanup(app.input);
 	free(app.input);

--- a/tests/test_camera.c
+++ b/tests/test_camera.c
@@ -98,7 +98,7 @@ void test_camera_fixed_update_no_input(void)
 void test_camera_fixed_update_with_forward_input(void)
 {
 	// Active le mouvement avant
-	cam.move_forward = 1;
+	cam.move_forward = true;
 	vec3 initial_pos;
 	glm_vec3_copy(cam.position, initial_pos);
 

--- a/tests/test_camera_input.c
+++ b/tests/test_camera_input.c
@@ -43,7 +43,7 @@ void test_camera_input_handle_mouse_should_handle_first_mouse(void)
 	camera_init(&cam, 10.0F, 90.0F, 0.0F);
 
 	/* Ensure initialized state */
-	TEST_ASSERT_EQUAL(1, cam.first_mouse);
+	TEST_ASSERT_TRUE(cam.first_mouse);
 	TEST_ASSERT_EQUAL_FLOAT(0.0F, cam.last_mouse_x);
 	TEST_ASSERT_EQUAL_FLOAT(0.0F, cam.last_mouse_y);
 
@@ -52,7 +52,7 @@ void test_camera_input_handle_mouse_should_handle_first_mouse(void)
 
 	/* Verify state updated but no movement applied (as deltas are 0
 	 * effectively) */
-	TEST_ASSERT_EQUAL(0, cam.first_mouse);
+	TEST_ASSERT_FALSE(cam.first_mouse);
 	TEST_ASSERT_EQUAL_FLOAT(100.0F, cam.last_mouse_x);
 	TEST_ASSERT_EQUAL_FLOAT(200.0F, cam.last_mouse_y);
 
@@ -68,7 +68,7 @@ void test_camera_input_handle_mouse_should_update_orientation(void)
 {
 	Camera cam;
 	camera_init(&cam, 10.0F, 90.0F, 0.0F);
-	cam.first_mouse = 0;
+	cam.first_mouse = false;
 	cam.last_mouse_x = 100.0;
 	cam.last_mouse_y = 100.0;
 

--- a/tests/test_gamepad_input.c
+++ b/tests/test_gamepad_input.c
@@ -90,7 +90,7 @@ void test_gamepad_init_sets_defaults(void)
 	GamepadState state;
 	gamepad_input_init(&state);
 
-	TEST_ASSERT_EQUAL(0, state.connected);
+	TEST_ASSERT_FALSE(state.connected);
 	TEST_ASSERT_EQUAL(0, state.joystick_id);
 	TEST_ASSERT_FLOAT_WITHIN(0.001F, GAMEPAD_DEFAULT_DEADZONE,
 	                         state.deadzone);
@@ -170,7 +170,7 @@ void test_poll_without_gamepad_does_nothing(void)
 	gamepad_write_input(&state, &gctx);
 	gamepad_ctx_to_camera(&gctx, &cam);
 
-	TEST_ASSERT_EQUAL(0, state.connected);
+	TEST_ASSERT_FALSE(state.connected);
 	/* move_input should stay zero. */
 	TEST_ASSERT_FLOAT_WITHIN(0.0001F, 0.0F, cam.move_input[0]);
 	TEST_ASSERT_FLOAT_WITHIN(0.0001F, 0.0F, cam.move_input[1]);
@@ -199,7 +199,7 @@ void test_poll_left_stick_forward_adds_velocity(void)
 	gamepad_write_input(&state, &gctx);
 	gamepad_ctx_to_camera(&gctx, &cam);
 
-	TEST_ASSERT_EQUAL(1, state.connected);
+	TEST_ASSERT_TRUE(state.connected);
 	/* move_input[2] should be positive (forward). */
 	TEST_ASSERT_TRUE(cam.move_input[2] > 0.0F);
 
@@ -287,31 +287,31 @@ void test_share_button_triggers_camera_reset(void)
 	g_mock_gamepad_connected = 1;
 
 	/* First poll: Share not pressed → no action. */
-	GamepadActions act1 = {0, 0, 0};
+	GamepadActions act1 = {false, false, false};
 	gamepad_input_poll(&state, &act1);
-	TEST_ASSERT_EQUAL(0, act1.camera_reset);
+	TEST_ASSERT_FALSE(act1.camera_reset);
 
 	/* Second poll: Share pressed (edge) → action fires. */
 	g_mock_gamepad_state.buttons[GLFW_GAMEPAD_BUTTON_BACK] = GLFW_PRESS;
-	GamepadActions act2 = {0, 0, 0};
+	GamepadActions act2 = {false, false, false};
 	gamepad_input_poll(&state, &act2);
-	TEST_ASSERT_EQUAL(1, act2.camera_reset);
+	TEST_ASSERT_TRUE(act2.camera_reset);
 
 	/* Third poll: Share held → no repeat. */
-	GamepadActions act3 = {0, 0, 0};
+	GamepadActions act3 = {false, false, false};
 	gamepad_input_poll(&state, &act3);
-	TEST_ASSERT_EQUAL(0, act3.camera_reset);
+	TEST_ASSERT_FALSE(act3.camera_reset);
 
 	/* Fourth poll: Share released then pressed → fires again. */
 	g_mock_gamepad_state.buttons[GLFW_GAMEPAD_BUTTON_BACK] = GLFW_RELEASE;
-	GamepadActions act4 = {0, 0, 0};
+	GamepadActions act4 = {false, false, false};
 	gamepad_input_poll(&state, &act4);
-	TEST_ASSERT_EQUAL(0, act4.camera_reset);
+	TEST_ASSERT_FALSE(act4.camera_reset);
 
 	g_mock_gamepad_state.buttons[GLFW_GAMEPAD_BUTTON_BACK] = GLFW_PRESS;
-	GamepadActions act5 = {0, 0, 0};
+	GamepadActions act5 = {false, false, false};
 	gamepad_input_poll(&state, &act5);
-	TEST_ASSERT_EQUAL(1, act5.camera_reset);
+	TEST_ASSERT_TRUE(act5.camera_reset);
 }
 
 void test_poll_sticks_in_deadzone_no_effect(void)

--- a/tests/test_scene_nbody.c
+++ b/tests/test_scene_nbody.c
@@ -192,7 +192,7 @@ void tearDown(void)
 void test_toggle_nbody_enables_mode(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation->nbody_mode = 0;
+	scene.simulation->nbody_mode = false;
 
 	scene_toggle_nbody(&scene);
 
@@ -207,7 +207,7 @@ void test_toggle_nbody_disables_mode(void)
 {
 	Scene scene = make_test_scene();
 	/* Enable first */
-	scene.simulation->nbody_mode = 0;
+	scene.simulation->nbody_mode = false;
 	scene_toggle_nbody(&scene);
 	reset_mocks();
 
@@ -225,7 +225,7 @@ void test_toggle_nbody_disables_mode(void)
 void test_toggle_nbody_trail_init_failure_aborts(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation->nbody_mode = 0;
+	scene.simulation->nbody_mode = false;
 	mock_trail_init_fail = true;
 
 	scene_toggle_nbody(&scene);
@@ -239,7 +239,7 @@ void test_toggle_nbody_trail_init_failure_aborts(void)
 void test_toggle_nbody_shockwave_init_failure_cleans_trails(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation->nbody_mode = 0;
+	scene.simulation->nbody_mode = false;
 	mock_shockwave_init_fail = true;
 
 	scene_toggle_nbody(&scene);
@@ -276,7 +276,7 @@ void test_toggle_nbody_roundtrip(void)
 void test_nbody_update_noop_when_disabled(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation->nbody_mode = 0;
+	scene.simulation->nbody_mode = false;
 
 	scene_nbody_update(&scene, 1.0F / 60.0F);
 
@@ -289,7 +289,7 @@ void test_nbody_update_noop_when_disabled(void)
 void test_nbody_update_calls_subsystems(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation->nbody_mode = 0;
+	scene.simulation->nbody_mode = false;
 	scene_toggle_nbody(&scene);
 	reset_mocks();
 
@@ -303,7 +303,7 @@ void test_nbody_update_calls_subsystems(void)
 void test_nbody_update_multiple_steps(void)
 {
 	Scene scene = make_test_scene();
-	scene.simulation->nbody_mode = 0;
+	scene.simulation->nbody_mode = false;
 	scene_toggle_nbody(&scene);
 	reset_mocks();
 

--- a/tests/test_scene_render.c
+++ b/tests/test_scene_render.c
@@ -432,12 +432,12 @@ void test_render_instanced_no_envmap_no_nbody(void)
 	glm_mat4_identity(prev_vp);
 
 	/* Instanced path (billboard_mode=0), no envmap, no nbody */
-	s.config.billboard_mode = 0;
+	s.config.billboard_mode = false;
 	s.config.show_envmap = false;
-	s.config.wireframe = 0;
+	s.config.wireframe = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -462,12 +462,12 @@ void test_render_instanced_wireframe(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 0;
-	s.config.wireframe = 1;
+	s.config.billboard_mode = false;
+	s.config.wireframe = true;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -486,12 +486,12 @@ void test_render_billboard_mode(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 1;
-	s.config.wireframe = 0;
+	s.config.billboard_mode = true;
+	s.config.wireframe = false;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -511,12 +511,12 @@ void test_render_nbody_draws_trails_and_shockwave(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 0;
-	s.config.wireframe = 0;
+	s.config.billboard_mode = false;
+	s.config.wireframe = false;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 1;
+	s.simulation->nbody_mode = true;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -536,12 +536,12 @@ void test_render_nbody_wireframe_shockwave(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 0;
-	s.config.wireframe = 1;
+	s.config.billboard_mode = false;
+	s.config.wireframe = true;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 1;
+	s.simulation->nbody_mode = true;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -561,12 +561,12 @@ void test_render_gi_mode_triggers_probe_sync(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 0;
-	s.config.wireframe = 0;
+	s.config.billboard_mode = false;
+	s.config.wireframe = false;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_3D_TEX;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -589,12 +589,12 @@ void test_render_show_probe_grid_triggers_sync_and_debug(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 0;
-	s.config.wireframe = 0;
+	s.config.billboard_mode = false;
+	s.config.wireframe = false;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = true;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -615,12 +615,12 @@ void test_render_envmap_draws_skybox(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 0;
-	s.config.wireframe = 0;
+	s.config.billboard_mode = false;
+	s.config.wireframe = false;
 	s.config.show_envmap = true;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -639,13 +639,13 @@ void test_render_billboard_wireframe_draws_debug(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 1;
-	s.config.wireframe = 1;
+	s.config.billboard_mode = true;
+	s.config.wireframe = true;
 	s.config.pbr_debug_mode = 0;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -667,13 +667,13 @@ void test_render_billboard_sort_cpu(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 1;
+	s.config.billboard_mode = true;
 	s.config.sorting_mode = SORTING_MODE_CPU_QSORT;
-	s.config.wireframe = 0;
+	s.config.wireframe = false;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -692,13 +692,13 @@ void test_render_billboard_sort_radix(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 1;
+	s.config.billboard_mode = true;
 	s.config.sorting_mode = SORTING_MODE_CPU_RADIX;
-	s.config.wireframe = 0;
+	s.config.wireframe = false;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -717,13 +717,13 @@ void test_render_billboard_sort_gpu(void)
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
 
-	s.config.billboard_mode = 1;
+	s.config.billboard_mode = true;
 	s.config.sorting_mode = SORTING_MODE_GPU_BITONIC;
-	s.config.wireframe = 0;
+	s.config.wireframe = false;
 	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
 	s.config.show_probe_grid = false;
-	s.simulation->nbody_mode = 0;
+	s.simulation->nbody_mode = false;
 
 	reset_counters();
 	scene_render(&s, &profiler, view, proj, cam, prev_vp, 800, 600);
@@ -744,7 +744,7 @@ void test_render_billboards_no_wireframe(void)
 	glm_mat4_identity(view);
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
-	s.config.wireframe = 0;
+	s.config.wireframe = false;
 	s.config.pbr_debug_mode = 0;
 
 	reset_counters();
@@ -762,7 +762,7 @@ void test_render_billboards_wireframe_debug(void)
 	glm_mat4_identity(view);
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
-	s.config.wireframe = 1;
+	s.config.wireframe = true;
 	s.config.pbr_debug_mode = 0;
 
 	reset_counters();
@@ -782,7 +782,7 @@ void test_render_billboards_wireframe_skips_when_debug_nonzero(void)
 	glm_mat4_identity(view);
 	glm_mat4_identity(proj);
 	glm_mat4_identity(prev_vp);
-	s.config.wireframe = 1;
+	s.config.wireframe = true;
 	s.config.pbr_debug_mode = 1; /* non-zero => skip wireframe overlay */
 
 	reset_counters();

--- a/tests/test_scene_render.c
+++ b/tests/test_scene_render.c
@@ -433,10 +433,10 @@ void test_render_instanced_no_envmap_no_nbody(void)
 
 	/* Instanced path (billboard_mode=0), no envmap, no nbody */
 	s.config.billboard_mode = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.wireframe = 0;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -464,9 +464,9 @@ void test_render_instanced_wireframe(void)
 
 	s.config.billboard_mode = 0;
 	s.config.wireframe = 1;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -488,9 +488,9 @@ void test_render_billboard_mode(void)
 
 	s.config.billboard_mode = 1;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -513,9 +513,9 @@ void test_render_nbody_draws_trails_and_shockwave(void)
 
 	s.config.billboard_mode = 0;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 1;
 
 	reset_counters();
@@ -538,9 +538,9 @@ void test_render_nbody_wireframe_shockwave(void)
 
 	s.config.billboard_mode = 0;
 	s.config.wireframe = 1;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 1;
 
 	reset_counters();
@@ -563,9 +563,9 @@ void test_render_gi_mode_triggers_probe_sync(void)
 
 	s.config.billboard_mode = 0;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_3D_TEX;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -591,9 +591,9 @@ void test_render_show_probe_grid_triggers_sync_and_debug(void)
 
 	s.config.billboard_mode = 0;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 1;
+	s.config.show_probe_grid = true;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -617,9 +617,9 @@ void test_render_envmap_draws_skybox(void)
 
 	s.config.billboard_mode = 0;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 1;
+	s.config.show_envmap = true;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -642,9 +642,9 @@ void test_render_billboard_wireframe_draws_debug(void)
 	s.config.billboard_mode = 1;
 	s.config.wireframe = 1;
 	s.config.pbr_debug_mode = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -670,9 +670,9 @@ void test_render_billboard_sort_cpu(void)
 	s.config.billboard_mode = 1;
 	s.config.sorting_mode = SORTING_MODE_CPU_QSORT;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -695,9 +695,9 @@ void test_render_billboard_sort_radix(void)
 	s.config.billboard_mode = 1;
 	s.config.sorting_mode = SORTING_MODE_CPU_RADIX;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();
@@ -720,9 +720,9 @@ void test_render_billboard_sort_gpu(void)
 	s.config.billboard_mode = 1;
 	s.config.sorting_mode = SORTING_MODE_GPU_BITONIC;
 	s.config.wireframe = 0;
-	s.config.show_envmap = 0;
+	s.config.show_envmap = false;
 	s.config.gi_mode = GI_MODE_OFF;
-	s.config.show_probe_grid = 0;
+	s.config.show_probe_grid = false;
 	s.simulation->nbody_mode = 0;
 
 	reset_counters();


### PR DESCRIPTION
## Summary

Normalize `int`-as-boolean struct fields to C99 `bool`/`true`/`false` across the codebase (first pass).

Closes #293

## Changes

### Commit 1 — `style(ui)`: UI structs
- `AppUI`: `show_info_overlay`, `show_exposure_debug` → `bool`
- `SceneConfig`: `show_envmap`, `show_probe_grid` → `bool`
- Explicit `int`↔`bool` casts for clang-tidy `readability-implicit-bool-conversion`
- `test_scene_render.c`: ~26 literal updates

### Commit 2 — `style(core)`: Core structs
- `AppWindow`: `is_fullscreen`, `resize_pending` → `bool`
- `AppInputContext`: matching `bool*` pointer types
- `Camera`: `first_mouse` → `bool`
- `EnvManager`: `is_first_load` → `bool`
- Idiomatic `!*ctx->is_fullscreen` instead of `== 0`

### Commit 3 — `style(perf)`: Profiling/notifier structs
- `GPUTimer`: `active` → `bool`
- `PerfModeContext`: `initialized` → `bool`
- `ActionNotification`: `active` → `bool`
- `GamepadControlPos`: `is_bound` → `bool`

### Commit 4 — `style(threading)`: Thread sync flags
- `LightProbeGrid`: `running`, `update_pending`, `results_ready` → `volatile bool`
- All mutex-guarded assignments updated
- `volatile bool` is well-defined in C99/C11

## Quality Gate
- `just format` ✅
- `just lint` ✅ (0 failures)
- `just test-all` ✅ (69/69 passed)
- Pre-push hooks ✅ (format-check + lint + iwyu)

## Not in scope (second pass planned)
23 additional `int`-as-boolean fields identified across 12 headers (camera movement flags, SceneConfig toggles, gamepad actions, etc.) — will be added in follow-up commits on this same branch.