### PR TITLE
docs(arch): add static traceability annotations for subsystem descriptor pattern

### DIFF
--- a/.github/instructions/c-coding-style.instructions.md
+++ b/.github/instructions/c-coding-style.instructions.md
@@ -158,3 +158,28 @@ volatile bool results_ready;
 ```
 
 This is well-defined in C99/C11 for simple flag signaling (not for synchronization — use mutexes for that).
+
+## Subsystem Function Naming Convention
+
+### Rule: `*_subsys_init` / `*_subsys_cleanup` for descriptor-driven lifecycle
+
+Any function registered in `APP_SUBSYSTEM_TABLE` (the subsystem descriptor pattern) **MUST** follow this naming:
+
+```c
+int  <module>_subsys_init(App* app);    // returns 1 on success, 0 on failure
+void <module>_subsys_cleanup(App* app);
+```
+
+### Rule: Traceability comment above every definition
+
+Because function pointers break static call-graph tools, add this comment immediately before the function body:
+
+```c
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
+int my_module_subsys_init(App* app)
+{
+    ...
+}
+```
+
+This enables `grep -rn "_subsys_init\|_subsys_cleanup" src/` for reliable discovery.

--- a/Justfile
+++ b/Justfile
@@ -375,6 +375,11 @@ test-python:
     @echo "Running Python script tests..."
     @{{py_run}} .github/workflows/scripts/test_trace_analyze.py
 
+# Show subsystem descriptor init/cleanup call order
+subsystem-order:
+    @chmod +x scripts/show_subsystem_order.sh
+    @./scripts/show_subsystem_order.sh
+
 # Build the Docker image
 docker-build:
     @{{container_engine}} build -t {{image_name}} .

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -157,6 +157,40 @@ graph LR
 
 **Légende** : 🟡 doit être premier (crée le contexte GL), 🔵 nécessite GL, 🟢 pas de dépendance GL.
 
+#### Table d'ordre d'appel des descripteurs
+
+Le tableau ci-dessous liste chaque sous-système dans l'ordre d'initialisation (le cleanup s'exécute en ordre inverse) :
+
+| # | Macro descripteur | Fonction init | Fonction cleanup | Fichier source |
+|--:|-------------------|---------------|------------------|----------------|
+| 0 | `APP_WINDOW_DESCRIPTOR` | `app_window_subsys_init` | `app_window_subsys_cleanup` | `src/app_window.c` |
+| 1 | `APP_INPUT_DESCRIPTOR` | `app_input_subsys_init` | `app_input_subsys_cleanup` | `src/app_input_state.c` |
+| 2 | `APP_PROFILING_DESCRIPTOR` | `app_profiling_subsys_init` | `app_profiling_subsys_cleanup` | `src/app_profiling.c` |
+| 3 | `APP_ASYNC_COORD_DESCRIPTOR` | `async_coord_subsys_init` | `async_coord_subsys_cleanup` | `src/async_coordinator.c` |
+| 4 | `APP_LUM_HISTOGRAM_DESCRIPTOR` | `lum_histogram_subsys_init` | `lum_histogram_subsys_cleanup` | `src/lum_histogram.c` |
+| 5 | `APP_ASYNC_LOADER_DESCRIPTOR` | `async_loader_subsys_init` | `async_loader_subsys_cleanup` | `src/async_loader.c` |
+| 6 | `APP_SCENE_DESCRIPTOR` | `scene_subsys_init` | `scene_subsys_cleanup` | `src/scene_init.c` |
+| 7 | `APP_ENV_MGR_DESCRIPTOR` | `env_mgr_subsys_init` | `env_mgr_subsys_cleanup` | `src/env_manager.c` |
+| 8 | `APP_POSTPROCESS_DESCRIPTOR` | `postprocess_subsys_init` | `postprocess_subsys_cleanup` | `src/postprocess_init.c` |
+
+#### Annotations statiques de traçabilité
+
+Les pointeurs de fonctions cassent l'analyse statique du graphe d'appels (clangd « Call Hierarchy », « Find All References »). Pour compenser, chaque définition `*_subsys_init` / `*_subsys_cleanup` porte un commentaire de traçabilité :
+
+```c
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
+int my_module_subsys_init(App* app)
+{
+    ...
+}
+```
+
+**Convention de nommage** : toutes les fonctions de cycle de vie utilisent le suffixe `*_subsys_init` / `*_subsys_cleanup`. Cela garantit une découverte fiable par grep :
+
+```bash
+grep -rn "_subsys_init\|_subsys_cleanup" src/ --include="*.c"
+```
+
 #### Comment ajouter un nouveau sous-système
 
 1. **Créer la paire init/cleanup** dans le fichier `.c` du module :

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,6 +197,40 @@ graph LR
 
 **Legend**: 🟡 must be first (creates GL context), 🔵 needs GL, 🟢 no GL dependency.
 
+#### Descriptor Call-Order Table
+
+The table below lists each subsystem in init order (cleanup runs in reverse):
+
+| # | Descriptor Macro | Init Function | Cleanup Function | Source File |
+|--:|------------------|---------------|------------------|-------------|
+| 0 | `APP_WINDOW_DESCRIPTOR` | `app_window_subsys_init` | `app_window_subsys_cleanup` | `src/app_window.c` |
+| 1 | `APP_INPUT_DESCRIPTOR` | `app_input_subsys_init` | `app_input_subsys_cleanup` | `src/app_input_state.c` |
+| 2 | `APP_PROFILING_DESCRIPTOR` | `app_profiling_subsys_init` | `app_profiling_subsys_cleanup` | `src/app_profiling.c` |
+| 3 | `APP_ASYNC_COORD_DESCRIPTOR` | `async_coord_subsys_init` | `async_coord_subsys_cleanup` | `src/async_coordinator.c` |
+| 4 | `APP_LUM_HISTOGRAM_DESCRIPTOR` | `lum_histogram_subsys_init` | `lum_histogram_subsys_cleanup` | `src/lum_histogram.c` |
+| 5 | `APP_ASYNC_LOADER_DESCRIPTOR` | `async_loader_subsys_init` | `async_loader_subsys_cleanup` | `src/async_loader.c` |
+| 6 | `APP_SCENE_DESCRIPTOR` | `scene_subsys_init` | `scene_subsys_cleanup` | `src/scene_init.c` |
+| 7 | `APP_ENV_MGR_DESCRIPTOR` | `env_mgr_subsys_init` | `env_mgr_subsys_cleanup` | `src/env_manager.c` |
+| 8 | `APP_POSTPROCESS_DESCRIPTOR` | `postprocess_subsys_init` | `postprocess_subsys_cleanup` | `src/postprocess_init.c` |
+
+#### Static Traceability Annotations
+
+Because function pointers break static call-graph analysis (clangd "Call Hierarchy", "Find All References"), each `*_subsys_init` / `*_subsys_cleanup` definition carries a traceability comment:
+
+```c
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
+int my_module_subsys_init(App* app)
+{
+    ...
+}
+```
+
+**Naming convention**: All subsystem lifecycle functions use the `*_subsys_init` / `*_subsys_cleanup` suffix. This guarantees reliable grep-based discovery:
+
+```bash
+grep -rn "_subsys_init\|_subsys_cleanup" src/ --include="*.c"
+```
+
 #### How to Add a New Subsystem
 
 1. **Create the init/cleanup pair** in your module's `.c` file:

--- a/scripts/show_subsystem_order.sh
+++ b/scripts/show_subsystem_order.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Show the subsystem descriptor init/cleanup call order.
+# Parses APP_SUBSYSTEM_TABLE in src/app.c and resolves each descriptor macro
+# to its {name, init_fn, cleanup_fn} triple from the include/ headers.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+APP_C="$ROOT_DIR/src/app.c"
+
+# Extract descriptor macro names from APP_SUBSYSTEM_TABLE (skip {0} sentinel)
+mapfile -t MACROS < <(
+    sed -n '/^static const SubsystemDescriptor APP_SUBSYSTEM_TABLE/,/^};/p' "$APP_C" \
+        | grep -oP 'APP_\w+_DESCRIPTOR' \
+        | grep -v '^$'
+)
+
+if [[ ${#MACROS[@]} -eq 0 ]]; then
+    echo "ERROR: No descriptor macros found in $APP_C" >&2
+    exit 1
+fi
+
+# Resolve each macro to its {name, init, cleanup} triple from headers
+declare -a NAMES=()
+declare -a INITS=()
+declare -a CLEANUPS=()
+declare -a SOURCES=()
+
+for macro in "${MACROS[@]}"; do
+    # Find the header defining this macro
+    header=$(grep -rl "#define $macro" "$ROOT_DIR/include/" 2>/dev/null | head -1)
+    if [[ -z "$header" ]]; then
+        NAMES+=("???")
+        INITS+=("???")
+        CLEANUPS+=("???")
+        SOURCES+=("???")
+        continue
+    fi
+
+    # Extract the triple: {"name", init_fn, cleanup_fn}
+    # Remove line-continuation backslashes before joining lines
+    triple=$(sed -n "/#define $macro/,/}/p" "$header" \
+        | sed 's/\\$//' | tr '\n' ' ' | sed 's/.*{//;s/}.*//' | tr -s ' ')
+
+    name=$(echo "$triple" | cut -d',' -f1 | tr -d ' "')
+    init_fn=$(echo "$triple" | cut -d',' -f2 | xargs)
+    cleanup_fn=$(echo "$triple" | cut -d',' -f3 | xargs)
+
+    # Find the source file containing the init function
+    src=$(grep -rl "^int ${init_fn}(" "$ROOT_DIR/src/" 2>/dev/null | head -1 \
+        || grep -rl "${init_fn}" "$ROOT_DIR/src/" 2>/dev/null | head -1)
+    src="${src#"$ROOT_DIR/"}"
+
+    NAMES+=("$name")
+    INITS+=("$init_fn")
+    CLEANUPS+=("$cleanup_fn")
+    SOURCES+=("${src:-unknown}")
+done
+
+COUNT=${#MACROS[@]}
+
+# --- Output ---
+echo "Subsystem Descriptor Order (from APP_SUBSYSTEM_TABLE in src/app.c)"
+echo "==================================================================="
+echo ""
+echo "Init order (forward) — app_subsystems_init():"
+for ((i = 0; i < COUNT; i++)); do
+    printf "  %d: %-12s → %-35s (%s)\n" "$i" "${NAMES[$i]}" "${INITS[$i]}" "${SOURCES[$i]}"
+done
+
+echo ""
+echo "Cleanup order (reverse) — app_subsystems_cleanup():"
+for ((i = COUNT - 1; i >= 0; i--)); do
+    printf "  %d: %-12s → %-35s (%s)\n" "$i" "${NAMES[$i]}" "${CLEANUPS[$i]}" "${SOURCES[$i]}"
+done
+
+echo ""
+echo "Total: $COUNT subsystems"

--- a/src/app_input_state.c
+++ b/src/app_input_state.c
@@ -22,6 +22,7 @@ void app_input_state_cleanup(AppInput* input)
 	adaptive_sampler_cleanup(&input->fps_sampler);
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int app_input_subsys_init(App* app)
 {
 	app->input =
@@ -34,6 +35,7 @@ int app_input_subsys_init(App* app)
 	return 1;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void app_input_subsys_cleanup(App* app)
 {
 	if (app->input) {

--- a/src/app_profiling.c
+++ b/src/app_profiling.c
@@ -27,6 +27,7 @@ void app_profiling_cleanup(AppProfiling* prof)
 	tracy_manager_cleanup(&prof->tracy_mgr);
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int app_profiling_subsys_init(App* app)
 {
 	app->profiling =
@@ -39,6 +40,7 @@ int app_profiling_subsys_init(App* app)
 	return 1;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void app_profiling_subsys_cleanup(App* app)
 {
 	if (app->profiling) {

--- a/src/app_window.c
+++ b/src/app_window.c
@@ -3,6 +3,7 @@
 #include "app_settings.h"
 #include "window.h"
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int app_window_subsys_init(App* app)
 {
 	app->win.is_fullscreen = false;
@@ -25,6 +26,7 @@ int app_window_subsys_init(App* app)
 	return 1;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void app_window_subsys_cleanup(App* app)
 {
 	if (app->win.handle) {

--- a/src/async_coordinator.c
+++ b/src/async_coordinator.c
@@ -88,6 +88,7 @@ bool async_coordinator_update(AsyncCoordinator* coord, AsyncLoader* loader,
 
 /* --- Subsystem descriptor (Phase 1 alloc + Phase 3 GL init) --- */
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int async_coord_subsys_init(App* app)
 {
 	app->async_coord =
@@ -100,6 +101,7 @@ int async_coord_subsys_init(App* app)
 	return 1;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void async_coord_subsys_cleanup(App* app)
 {
 	if (app->async_coord) {

--- a/src/async_loader.c
+++ b/src/async_loader.c
@@ -427,12 +427,14 @@ void async_loader_cancel(AsyncLoader* loader)
 #include "app.h"
 #include "app_profiling.h"
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int async_loader_subsys_init(App* app)
 {
 	app->async_loader = async_loader_create(&app->profiling->tracy_mgr);
 	return app->async_loader != NULL;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void async_loader_subsys_cleanup(App* app)
 {
 	async_loader_destroy(app->async_loader);

--- a/src/env_manager.c
+++ b/src/env_manager.c
@@ -324,6 +324,7 @@ void env_manager_render_overlay(const EnvManager* mgr, const Scene* scene)
 
 /* --- Subsystem descriptor (Phase 1: alloc + defaults) --- */
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int env_mgr_subsys_init(App* app)
 {
 	app->env_mgr =
@@ -340,6 +341,7 @@ int env_mgr_subsys_init(App* app)
 	return 1;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void env_mgr_subsys_cleanup(App* app)
 {
 	if (app->env_mgr) {

--- a/src/lum_histogram.c
+++ b/src/lum_histogram.c
@@ -4,6 +4,7 @@
 #include "app_settings.h"
 #include <stdlib.h>
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int lum_histogram_subsys_init(App* app)
 {
 	app->lum_histogram_buffer =
@@ -12,6 +13,7 @@ int lum_histogram_subsys_init(App* app)
 	return app->lum_histogram_buffer != NULL;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void lum_histogram_subsys_cleanup(App* app)
 {
 	free(app->lum_histogram_buffer);

--- a/src/postprocess_init.c
+++ b/src/postprocess_init.c
@@ -377,6 +377,7 @@ void postprocess_resize(PostProcess* post_processing, int width, int height)
 
 /* --- Subsystem descriptor (Phase 1 alloc + Phase 3 GL init) --- */
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int postprocess_subsys_init(App* app)
 {
 	app->postprocess =
@@ -395,6 +396,7 @@ int postprocess_subsys_init(App* app)
 	return 1;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void postprocess_subsys_cleanup(App* app)
 {
 	if (app->postprocess) {

--- a/src/scene_init.c
+++ b/src/scene_init.c
@@ -495,6 +495,7 @@ int scene_init(Scene* scene)
 
 /* --- Subsystem descriptor (Phase 1 alloc + Phase 3 GL init) --- */
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 int scene_subsys_init(App* app)
 {
 	app->scene =
@@ -513,6 +514,7 @@ int scene_subsys_init(App* app)
 	return 1;
 }
 
+/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */
 void scene_subsys_cleanup(App* app)
 {
 	if (app->scene) {


### PR DESCRIPTION
## Summary

Implements issue #299: static traceability annotations for the subsystem descriptor pattern.

### Changes

1. **refactor(core)**: Added `/* Called via APP_SUBSYSTEM_TABLE in app.c (subsystem descriptor pattern) */` comment above every `*_subsys_init` / `*_subsys_cleanup` definition (9 source files, 18 annotations)
2. **docs(arch)**: Added Descriptor Call-Order Table and Static Traceability Annotations sections to `docs/architecture.md` (EN + FR)
3. **docs(style)**: Documented the `*_subsys_init/_cleanup` naming convention in `.github/instructions/c-coding-style.instructions.md`
4. **feat(tooling)**: New `scripts/show_subsystem_order.sh` + `just subsystem-order` recipe that extracts and prints the init/cleanup call order from source

### Acceptance Criteria

- [x] Every `*_subsys_init` / `*_subsys_cleanup` has a traceability comment
- [x] `docs/architecture.md` (EN+FR) includes a descriptor call-order diagram
- [x] Naming convention documented in contributing guidelines
- [x] `scripts/` helper that extracts and prints call order (`just subsystem-order`)

### Testing

- `just format` ✅
- `just build` ✅ (0 warnings)
- `just lint` ✅ (77/77 C sources + 31 shaders)
- `just test-all` ✅ (69/69 tests passed)
- `shellcheck scripts/show_subsystem_order.sh` ✅

Closes #299